### PR TITLE
docs: domain model, ADRs, and phased build plan

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,91 @@
+# Lanjut
+
+A local-first, ATS-safe résumé builder. The domain splits into a **structural layer** (the parseable content: header + sections) and a **presentation layer** (typography, spacing, color — never alters the linear text structure).
+
+## Language
+
+**Resume**:
+A single résumé document owned by the user. Has a versioned schema, a privileged Header, an ordered list of Sections, and Presentation settings.
+_Avoid_: CV, document, file
+
+**Header**:
+The privileged, non-reorderable, single-instance top of a Resume holding identity and contact information. Always first in reading order. Not a Section.
+_Avoid_: contact block, top section
+
+**Section**:
+A typed, reorderable unit of the structural layer below the Header (summary, experience, education, skills, custom). Contains an ordered list of Entries. Participates in drag-and-drop ordering.
+_Avoid_: block, panel
+
+**Entry**:
+A repeatable item within a Section (e.g. one job in Experience, one school in Education). Reorderable within its Section. Holds a map of typed Fields. Single-blob sections (e.g. Summary) have exactly one Entry.
+_Avoid_: item, record, row
+
+**Field**:
+A typed value slot within an Entry, identified by a stable key. Either `plain` (string, no formatting) or `richtext` (restricted TipTap document). The smallest unit of structural content.
+_Avoid_: input, attribute
+
+**Custom section**:
+A user-added Section beyond the core four. In v1, the only custom type is the free-form escape hatch: a section with a user-set title and repeatable Entries of (title + restricted richtext body). "Custom" means optional/user-added and relabelable — never a user-defined field structure. A future curated catalog (projects, certifications, etc.) will add more known schemas.
+_Avoid_: free section, arbitrary section
+
+**Section title**:
+The user-visible label of a Section (e.g. renaming "Experience" → "Work History"). Presentation/label data only. Changing it never changes the Section's parse shape or Field schema.
+_Avoid_: section name, heading
+
+**Section schema registry**:
+Code-side (not persisted) definition of each Section type: which Field keys it has, each Field's kind, and the allowed TipTap extensions per richtext Field. Saved Resume data holds only values, never the schema.
+_Avoid_: section config, template
+
+**Restricted schema**:
+The explicit per-Field TipTap extension allowlist (bold, italic, bullet/ordered list, link, plus base document/paragraph/text). Both typing and paste are filtered through it, so disallowed structure (tables, headings, images) cannot be represented or pasted in. The runtime enforcement point of the closed structural registry.
+_Avoid_: editor config, formatting options
+
+**Library**:
+The surface (route `/`) listing all Resumes with create / duplicate / rename / delete, and the app's landing/empty state. Backed by the Resume index.
+_Avoid_: dashboard, home, gallery
+
+**Seed fixture**:
+The single code-defined sample Resume ("John Doe" persona — full content across all core sections) that every newly created Resume is initialized from. Also reused as the Parser gate's test fixture. Export warns if the identity fields are still byte-identical to the seed.
+_Avoid_: sample, template, default doc
+
+**Resume index**:
+The lightweight list of all Resumes (id, title, updatedAt) held in memory to drive the library/list UI, separate from the single fully-hydrated open Resume. The full body of a non-open Resume is not kept in memory.
+_Avoid_: resume list (as a data concept), catalog
+
+**Schema version**:
+An integer stored inside each Resume document recording the field-shape version it was written against. Drives read-time migration. Distinct from the IndexedDB DB version (which governs object-store/index structure only).
+_Avoid_: doc version, db version (for this concept)
+
+**Migration ladder**:
+The ordered set of pure functions `migrate N → N+1` over plain document JSON. On read, a Resume below the current schema version is stepped up through the ladder before reaching the store. Forward-only.
+_Avoid_: upgrade, transform
+
+**Structural layer**:
+The parseable content of a Resume — Header and Sections and their text. Export and ATS parsing depend on it. Constrained on purpose.
+
+**Presentation layer**:
+Typography, spacing, color, accent, and visual ordering. Fully customizable. Must never change the linear text structure used for parsing or export.
+
+**Presentation tokens**:
+The serializable set of presentation values (font family/scale, spacing, color/accent, etc.) attached to a Resume. Consumed identically by the editing preview and every exporter. The only thing presentation is allowed to vary.
+_Avoid_: theme config, styles
+
+**Theme**:
+A named, code-defined preset that sets all Presentation tokens at once. Selecting one populates the Resume's tokens; the user may then tweak individual tokens. User-saved custom themes are deferred — customization lives as the Resume's token values, not as a saved theme.
+_Avoid_: template, skin, preset (loosely)
+
+**Exporter**:
+A pure function from the structural document model + Presentation tokens to an output format (PDF, DOCX, TXT). Never scrapes the DOM. Iterates the model so reading order is guaranteed.
+_Avoid_: renderer (for export), generator
+
+**Parser gate**:
+The CI test that runs each Exporter on a fixture Resume and asserts the output parses in the expected linear order (`pdftotext` for PDF, string-order for DOCX/TXT, optionally an open-source parser). Engineering verification that keeps the export promise. Ships no UI.
+_Avoid_: ATS test (for this), validation
+
+**ATS check**:
+The deferred user-facing feature that lints the user's own content (missing contact info, empty sections, unparseable dates, overlong bullets). A later phase, distinct from the Parser gate.
+_Avoid_: linter, validation (loosely)
+
+**Export preview**:
+The user-facing "what you'll get" surface, rendered through the actual PDF exporter (not the editing canvas), so preview equals output. Distinct from the editing canvas, which is HTML/DOM because TipTap requires real DOM.
+_Avoid_: print view

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,0 +1,47 @@
+# Lanjut — Build Plan
+
+Phases are demoable milestones; increments are vertical slices within them. Ordering honors the AGENTS.md build order (schema → store → editor → dnd → presentation → export → parser gate). Design decisions behind this plan are recorded as ADRs in [docs/adr/](./adr/); domain vocabulary lives in [CONTEXT.md](../CONTEXT.md).
+
+## Phase 0 — Foundations
+_Verifiable in isolation; not yet user-visible._
+
+- **0.1** Domain types (`Resume`, `Header`, `Section`, `Entry`, `Field`) + Section schema registry (core four: summary, experience, education, skills; plus the free-form custom type) + the Seed fixture ("John Doe"). See ADR-0001.
+- **0.2** Migration ladder harness: in-document `schemaVersion`, read-time `runMigrations`, fixture test. Exists from v1 even with a single version. See ADR-0002.
+- **0.3** IndexedDB layer via `idb`: `resumes` store (keyed by id) + `app` store (`lastOpenedResumeId`), CRUD, flush primitives. DB version governs store structure only. See ADR-0002.
+
+## Phase 1 — Editable resume, persisted
+_The walking skeleton: create → fill → reload restores. First usable product._
+
+- **1.1** zustand store: single open Resume + Resume index; hydrate/flush; `subscribe`→debounced whole-document persist; flush on `visibilitychange`/`pagehide`. See ADR-0003.
+- **1.2** Library (`/`): create (seeds the Seed fixture), open, rename, duplicate, delete.
+- **1.3** Editor shell (`/r/[id]`): resolve id → hydrate (unknown id → Library), render Header + Sections, plain-input Fields editable, reload restores.
+- **1.4** TipTap richtext Fields: per-field instance, Restricted schema allowlist, paste filtering, debounced commit to store. v1 mounts a live editor per visible richtext field. See ADR-0004.
+
+## Phase 1.5 — Export de-risking spike
+_Thin proof, not the full pipeline._
+
+- Minimal `@react-pdf` PDF of the seeded Resume (no presentation, no preview UI, no DOCX). Assert `pdftotext` yields clean linear text from the document model. Validates the load-bearing assumption (ADR-0005) before presentation is built on top of it.
+
+## Phase 2 — Structure control
+- **2.1** Section reordering via dnd-kit (sortable over `sections[]`; array-position ordering).
+- **2.2** Entry reordering within a Section (sortable over `entries[]`).
+- **2.3** Add/remove Sections (incl. free-form custom), add/remove Entries, Section title rename.
+
+## Phase 3 — Presentation
+- **3.1** Presentation token model + `presentation` block + migration step + default Theme. See ADR-0006.
+- **3.2** Code-defined Theme presets + picker; tokens applied to the editing canvas.
+- **3.3** Constrained customization panel (fontFamily, fontScale, density, accentColor, headingStyle, page size/margins). No custom CSS, no per-element overrides.
+
+## Phase 4 — Export pipeline
+- **4.1** TXT Exporter — establishes the pure-function model-walk pattern.
+- **4.2** PDF Exporter via `@react-pdf` (font registration, token mapping, reading order); Export preview panel renders the real Exporter; download.
+- **4.3** DOCX Exporter via `docx`.
+- **4.4** Parser gate (CI: all Exporters on the Seed fixture, `pdftotext` + string-order assertions) + export-time sample guard. See ADR-0005.
+
+## Phase 5 — Hardening & deferred
+Curated custom-section catalog (tier 2); user-facing ATS check; service worker / installable PWA; open-next on Cloudflare deploy config; document-level undo/redo; blank-resume creation option; user-saved custom themes.
+
+## Deferred decisions (not yet designed)
+- Resume import / parsing an existing file.
+- Document-level undo/redo mechanism.
+- Multi-page break behavior in PDF beyond `@react-pdf` defaults.

--- a/docs/adr/0001-closed-structural-registry.md
+++ b/docs/adr/0001-closed-structural-registry.md
@@ -1,0 +1,13 @@
+# Structural layer is a closed, code-defined registry
+
+The set of Section types and the Field structure of each is defined in code (the Section schema registry), not by users. Users can add Sections, reorder them, relabel their titles, and fill in values — but they can never define new Field structures. The v1 catalog is the core four (summary, experience, education, skills) plus a single free-form escape-hatch type (title + repeatable title/richtext entries).
+
+## Why
+
+The product's entire value proposition is ATS-parseable export. Arbitrary user-defined structures (tables, custom field shapes, free layout) cannot carry an export guarantee. Closing the structural layer is what lets the export pipeline make a hard promise about reading order and field mapping. The presentation layer absorbs the user's desire for customization instead.
+
+## Consequences
+
+- Adding a new Section type is a code change (new registry entry + export mapping), deliberately — it forces the parseability question to be answered before the type ships.
+- Section title is presentation/label data, decoupled from parse shape. Relabeling is always safe.
+- The curated catalog (projects, certifications, languages, …) is additive future work; it does not change this boundary.

--- a/docs/adr/0002-persistence-and-versioning.md
+++ b/docs/adr/0002-persistence-and-versioning.md
@@ -1,0 +1,14 @@
+# Multi-resume persistence with two-tier versioning
+
+Resumes persist in IndexedDB (via `idb`) as multiple documents from day one: a `resumes` object store keyed by `id`, plus a small `app`/`meta` store for pointers like `lastOpenedResumeId`. Document field-shape changes are versioned by an in-document integer `schemaVersion` and migrated by a forward-only ladder of pure functions run at **read time**, per document. The IndexedDB DB version is reserved for object-store/index structure only.
+
+## Why
+
+- **Multi from day one**: tailoring a résumé per job posting is core to the ATS use case; retrofitting multi-document storage later is a painful migration. Designing the store for many costs nothing now.
+- **Two separate version numbers**: document shape changes far more often than store structure. Conflating them (migrating in `idb`'s `onupgradeneeded`) forces a DB-version bump for every field tweak, runs against raw cursors, and resists unit testing. Keeping `schemaVersion` inside the document lets migrations be pure JSON→JSON functions, tested with fixtures, run lazily on read.
+
+## Consequences
+
+- Every field-shape change requires a new ladder step + a fixture test. Enforced by review, not the compiler.
+- Migrated documents are written back on the next debounced save (or eagerly post-migration).
+- No resume content ever leaves the browser; this is the only persistence tier.

--- a/docs/adr/0003-store-persistence-sync.md
+++ b/docs/adr/0003-store-persistence-sync.md
@@ -1,0 +1,14 @@
+# zustand holds one open resume; persist via subscription with two debounce layers
+
+The zustand store holds only the currently-open Resume (full document tree) plus a lightweight Resume index for the list UI — not all resume bodies. Persistence is a single `store.subscribe` that debounces (~500ms) a whole-document write to that resume's IndexedDB record. TipTap fields debounce their own serialize-to-store commit (on delay/blur) rather than dispatching per keystroke. Pending writes flush on `visibilitychange`/`pagehide` and on resume-switch.
+
+## Why
+
+- A subscription that syncs to IndexedDB is the one legitimate external-system effect AGENTS.md allows; a per-action middleware write would thrash IndexedDB and re-render on every keystroke.
+- Whole-document writes (resumes are KB-scale) avoid field-level diffing complexity.
+- Two debounce layers (TipTap→store, store→IndexedDB) keep keystrokes from re-rendering the world, at the cost of up to ~1s of in-flight unsaved edits — bounded by the flush-on-hide safety net.
+
+## Consequences
+
+- Switching resumes must flush-then-hydrate to avoid cross-document writes.
+- Worst-case data loss on a hard crash is one debounce window; acceptable for a local single-user tool.

--- a/docs/adr/0004-richtext-as-prosemirror-json.md
+++ b/docs/adr/0004-richtext-as-prosemirror-json.md
@@ -1,0 +1,14 @@
+# Richtext fields persist as ProseMirror JSON, not HTML
+
+Richtext Field values are stored as TipTap's native ProseMirror JSON. Plain Fields (name, contact, dates, titles) skip TipTap entirely and render as ordinary inputs. Each richtext Field configures TipTap with exactly its allowed extensions; typing and paste are both filtered through that Restricted schema. Export converts JSON → PDF/text/docx at export time. We never store HTML.
+
+## Why
+
+- JSON is schema-validated: invalid nodes can't be represented, so the closed structural registry (ADR-0001) is enforced at the data layer, not just the UI. Pasting a Word table yields plain text.
+- HTML would require re-parse and re-sanitize on every load and invites smuggled structure.
+- Plain inputs for non-formatted fields avoid spinning up dozens of editor instances per resume.
+
+## Consequences
+
+- Export and static display both derive from the same JSON; there is one source of truth.
+- v1 mounts a live editor per visible richtext field (simple). Mount-on-focus is a deferred performance optimization, not a v1 requirement.

--- a/docs/adr/0005-model-driven-exporters.md
+++ b/docs/adr/0005-model-driven-exporters.md
@@ -1,0 +1,18 @@
+# All exports are pure functions over the document model, not DOM scrapes
+
+PDF, DOCX, and TXT are each produced by an Exporter that takes the structural document model + Presentation tokens and emits the format directly. PDF uses a client-side React→PDF renderer (`@react-pdf/renderer`); DOCX uses a model→docx mapper (the `docx` library); TXT is trivial model serialization. The editing canvas (HTML/DOM, required by TipTap) is a separate renderer; the user's "Export preview" is rendered through the real PDF exporter so preview equals output.
+
+## Considered Options
+
+- **Rejected — print-CSS (`window.print`):** single-source layout and real text, but only covers PDF, has fragile page-break/margin control, and hands the file to the browser dialog. DOCX/TXT must iterate the model regardless, so PDF-via-print would be a one-off that unifies nothing.
+- **Rejected — html2canvas / rasterized PDF:** produces an image with no extractable text. Fatal for ATS.
+- **Rejected — server-side headless Chrome:** would send resume content to a server, violating the no-server-storage rule.
+
+## Why
+
+Reading order is the ATS guarantee. A model-driven exporter makes reading order a property of a pure function — testable with `pdftotext`/parser assertions in CI without a browser. One pipeline shape serves all three formats.
+
+## Consequences
+
+- Two render paths (editing canvas vs exporters); they share document model + Presentation tokens but are not pixel-identical. Mitigated by making the Export preview the real exporter.
+- `@react-pdf/renderer` and `docx` are new dependencies, added when the export phase begins.

--- a/docs/adr/0006-presentation-as-enumerated-tokens.md
+++ b/docs/adr/0006-presentation-as-enumerated-tokens.md
@@ -1,0 +1,14 @@
+# Presentation is an enumerated token set in the renderer intersection
+
+Presentation is a fixed, enumerated set of Presentation tokens (fontFamily from a curated embeddable-TTF list, discrete fontScale, density presets, a single constrained accentColor, a small headingStyle enum, discrete page size/margins) — not free-form CSS. Every token must be expressible in both the HTML editing canvas and `@react-pdf`. Themes are code-defined presets that populate tokens; the user tweaks token values from there. No per-element style overrides, no custom CSS, no user-saved themes in v1.
+
+## Why
+
+- `@react-pdf` supports only a flexbox subset and embedded TTF fonts. A token that the PDF exporter can't honor would break preview-equals-output. Constraining tokens to the renderer intersection keeps the dual-render guarantee (ADR-0005) true.
+- Per-element overrides and custom CSS are structural freedom in disguise — they would let users build layouts that defeat ATS parsing. The constraint is the product.
+
+## Consequences
+
+- Tokens live in the Resume `presentation` block and migrate via the same schemaVersion ladder as structural content.
+- Users expecting Canva-style freedom are intentionally not served; this is an ATS builder.
+- Curated fonts must be shipped as TTFs and registered with both `@react-pdf` and `@font-face`.


### PR DESCRIPTION
Captures the design produced in the grilling/domain-modeling session. **Docs only — no implementation.**

## What's here

- **`CONTEXT.md`** — domain glossary (Resume, Header, Section, Entry, Field, Exporter, Presentation tokens, …).
- **`docs/adr/0001-0006`** — the architectural decisions:
  - 0001 — closed, code-defined structural registry (users fill values, never define field structures)
  - 0002 — multi-resume IndexedDB; in-document `schemaVersion` ladder separate from the `idb` DB version
  - 0003 — one open resume in zustand; subscription-based debounced persist; flush-on-hide
  - 0004 — richtext stored as ProseMirror JSON; plain inputs for non-formatted fields
  - 0005 — model-driven exporters (PDF/`@react-pdf`, DOCX/`docx`, TXT); export preview *is* the real exporter
  - 0006 — presentation as an enumerated token set in the renderer intersection (no custom CSS)
- **`docs/PLAN.md`** — phased build plan (Phases 0–5) with a Phase 1.5 export de-risking spike.

## Deliberately left open

Resume import, document-level undo/redo, and multi-page PDF break behavior — noted as undesigned in `PLAN.md`.

## Next step (separate PR)

Phase 0.1 — domain types + Section schema registry + Seed fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)