### PR TITLE
feat: resizable, sticky editor preview that scales to fit

### DIFF
--- a/src/app/platform/editor/[id]/layout.tsx
+++ b/src/app/platform/editor/[id]/layout.tsx
@@ -1,0 +1,27 @@
+import { EditorSidebar } from "@/components/editor/editor-sidebar";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@/components/ui/resizable";
+import { ScrollArea } from "@/components/ui/scroll-area";
+
+export default function EditorLayoutPage(
+  props: LayoutProps<"/platform/editor/[id]">,
+) {
+  return (
+    <div className="h-[calc(100vh-4rem)] flex-1 overflow-hidden">
+      <ResizablePanelGroup>
+        <ResizablePanel defaultSize="68%" minSize="40%" maxSize="72%">
+          <ScrollArea className="h-[calc(100vh-3.5rem)]">
+            <div className="bg-muted px-6 py-10">{props.children}</div>
+          </ScrollArea>
+        </ResizablePanel>
+
+        <ResizableHandle withHandle />
+
+        <EditorSidebar />
+      </ResizablePanelGroup>
+    </div>
+  );
+}

--- a/src/app/platform/editor/[id]/page.tsx
+++ b/src/app/platform/editor/[id]/page.tsx
@@ -1,3 +1,6 @@
+import { ResumeDocument } from "@/components/editor/resume-document";
+import { RESUME_PREVIEW_FIXTURE } from "@/components/editor/resume-preview-data";
+
 export default function EditorPage() {
-  return <h1>Hey editor</h1>;
+  return <ResumeDocument resume={RESUME_PREVIEW_FIXTURE} />;
 }

--- a/src/app/platform/layout.tsx
+++ b/src/app/platform/layout.tsx
@@ -16,7 +16,7 @@ export default function PlatformLayout({ children }: PropsWithChildren) {
 
       <SidebarInset>
         <PlatformNavbar />
-        <div className="flex flex-1 flex-col gap-4 p-4">{children}</div>
+        {children}
       </SidebarInset>
     </SidebarProvider>
   );

--- a/src/app/platform/page.tsx
+++ b/src/app/platform/page.tsx
@@ -4,10 +4,10 @@ import { PlatformResumeToolbar } from "@/components/platform/platform-resume-too
 
 export default function PlatformPage() {
   return (
-    <>
+    <div className="flex flex-col gap-4 p-4">
       <PlatformResumeToolbar />
       <PlatformResumeGrid />
       <PlatformEmptyState />
-    </>
+    </div>
   );
 }

--- a/src/components/editor/editor-sidebar.tsx
+++ b/src/components/editor/editor-sidebar.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { ResizablePanel } from "../ui/resizable";
+import { useSidebar } from "../ui/sidebar";
+
+export function EditorSidebar() {
+  const { open } = useSidebar();
+  return (
+    <ResizablePanel
+      defaultSize={open ? "32%" : "36%"}
+      minSize={open ? "28%" : "30%"}
+      maxSize="40%"
+    >
+      <div className="h-full overflow-y-auto p-4">
+        <div className="inline-flex items-center gap-2">
+          <h3 className="text-lg font-medium">Editor</h3>
+        </div>
+      </div>
+    </ResizablePanel>
+  );
+}

--- a/src/components/editor/resume-block-view.tsx
+++ b/src/components/editor/resume-block-view.tsx
@@ -1,0 +1,35 @@
+import type { ResumeBlock } from "./resume-blocks";
+import { ResumeCertificateItem } from "./resume-certificate-item";
+import { ResumeEducationItem } from "./resume-education-item";
+import { ResumeExperienceItem } from "./resume-experience-item";
+import { ResumeHeader } from "./resume-header";
+import { ResumeLanguagesList } from "./resume-languages-list";
+import { ResumeSectionHeading } from "./resume-section-heading";
+import { ResumeSkillsList } from "./resume-skills-list";
+import { ResumeSummaryBody } from "./resume-summary-body";
+
+interface ResumeBlockViewProps {
+  block: ResumeBlock;
+}
+
+export function ResumeBlockView(props: ResumeBlockViewProps) {
+  const { block } = props;
+  switch (block.kind) {
+    case "header":
+      return <ResumeHeader {...block.header} />;
+    case "heading":
+      return <ResumeSectionHeading title={block.title} />;
+    case "summary":
+      return <ResumeSummaryBody body={block.body} />;
+    case "experience":
+      return <ResumeExperienceItem {...block.item} />;
+    case "education":
+      return <ResumeEducationItem {...block.item} />;
+    case "certificate":
+      return <ResumeCertificateItem {...block.item} />;
+    case "skills":
+      return <ResumeSkillsList items={block.items} />;
+    case "languages":
+      return <ResumeLanguagesList items={block.items} />;
+  }
+}

--- a/src/components/editor/resume-blocks.ts
+++ b/src/components/editor/resume-blocks.ts
@@ -1,0 +1,130 @@
+import type {
+  CertificateItemView,
+  EducationItemView,
+  ExperienceItemView,
+  HeaderView,
+  LanguageItemView,
+  ResumePreview,
+} from "./resume-preview";
+
+/**
+ * Pagination metadata shared by every block. `keepWithNext` glues a block to the
+ * one after it (a section heading to its first entry) so a heading can never be
+ * orphaned at the foot of a page. `gapBefore` is the vertical space (px) that
+ * precedes the block when it is *not* the first on its page.
+ */
+interface BlockMeta {
+  id: string;
+  gapBefore: number;
+  keepWithNext: boolean;
+}
+
+/**
+ * The atomic units of the document, in linear reading order. Pagination groups
+ * this sequence into pages without ever reordering it, so parse/export order is
+ * preserved (see AGENTS.md two-layer rule).
+ */
+export type ResumeBlock = BlockMeta &
+  (
+    | { kind: "header"; header: HeaderView }
+    | { kind: "heading"; title: string }
+    | { kind: "summary"; body: string }
+    | { kind: "experience"; item: ExperienceItemView }
+    | { kind: "education"; item: EducationItemView }
+    | { kind: "certificate"; item: CertificateItemView }
+    | { kind: "skills"; items: string[] }
+    | { kind: "languages"; items: LanguageItemView[] }
+  );
+
+const GAP = {
+  /** Space above a section heading. */
+  section: 24,
+  /** Space above a singleton section's body (summary, skills, languages). */
+  body: 8,
+  /** Space between repeated entries within a section. */
+  entry: 16,
+  /** Space above the first entry, directly under its heading. */
+  firstEntry: 8,
+} as const;
+
+function heading(id: string, title: string): ResumeBlock {
+  return {
+    id,
+    kind: "heading",
+    title,
+    gapBefore: GAP.section,
+    keepWithNext: true,
+  };
+}
+
+function entryGap(index: number): number {
+  return index === 0 ? GAP.firstEntry : GAP.entry;
+}
+
+export function buildResumeBlocks(resume: ResumePreview): ResumeBlock[] {
+  const blocks: ResumeBlock[] = [
+    {
+      id: "header",
+      kind: "header",
+      header: resume.header,
+      gapBefore: 0,
+      keepWithNext: false,
+    },
+    heading("summary-heading", "Summary"),
+    {
+      id: "summary-body",
+      kind: "summary",
+      body: resume.summary,
+      gapBefore: GAP.body,
+      keepWithNext: false,
+    },
+    heading("experience-heading", "Experience"),
+    ...resume.experience.map(
+      (item, index): ResumeBlock => ({
+        id: item.id,
+        kind: "experience",
+        item,
+        gapBefore: entryGap(index),
+        keepWithNext: false,
+      }),
+    ),
+    heading("education-heading", "Education"),
+    ...resume.education.map(
+      (item, index): ResumeBlock => ({
+        id: item.id,
+        kind: "education",
+        item,
+        gapBefore: entryGap(index),
+        keepWithNext: false,
+      }),
+    ),
+    heading("certificates-heading", "Certificates"),
+    ...resume.certificates.map(
+      (item, index): ResumeBlock => ({
+        id: item.id,
+        kind: "certificate",
+        item,
+        gapBefore: entryGap(index),
+        keepWithNext: false,
+      }),
+    ),
+    heading("skills-heading", "Skills"),
+    {
+      id: "skills-body",
+      kind: "skills",
+      items: resume.skills,
+      gapBefore: GAP.body,
+      keepWithNext: false,
+    },
+    heading("languages-heading", "Languages"),
+    {
+      id: "languages-body",
+      kind: "languages",
+      items: resume.languages,
+      gapBefore: GAP.body,
+      keepWithNext: false,
+    },
+  ];
+
+  return blocks;
+}

--- a/src/components/editor/resume-certificate-item.tsx
+++ b/src/components/editor/resume-certificate-item.tsx
@@ -1,0 +1,23 @@
+import type { CertificateItemView } from "./resume-preview";
+
+export function ResumeCertificateItem(props: CertificateItemView) {
+  return (
+    <article>
+      <div className="flex items-baseline justify-between gap-4">
+        <h3 className="text-sm font-semibold">
+          {props.href ? (
+            <a href={props.href} className="hover:underline">
+              {props.title}
+            </a>
+          ) : (
+            props.title
+          )}
+        </h3>
+        <span className="shrink-0 text-xs text-muted-foreground">
+          {props.startDate} - {props.endDate}
+        </span>
+      </div>
+      <p className="text-sm text-muted-foreground">{props.issuer}</p>
+    </article>
+  );
+}

--- a/src/components/editor/resume-document.tsx
+++ b/src/components/editor/resume-document.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { ResumeBlockView } from "./resume-block-view";
+import { buildResumeBlocks } from "./resume-blocks";
+import { A4, CONTENT_HEIGHT_PX, CONTENT_WIDTH_PX } from "./resume-geometry";
+import { ResumePage } from "./resume-page";
+import { paginate } from "./resume-paginate";
+import type { ResumePreview } from "./resume-preview";
+
+interface ResumeDocumentProps {
+  resume: ResumePreview;
+}
+
+/** Vertical gap between stacked pages (matches the `gap-6` on the page stack). */
+const PAGE_GAP_PX = 24;
+
+/**
+ * Renders a résumé as exact A4 pages, reflowing content across pages as it grows.
+ * Pagination is presentation-only: blocks are measured off-screen at the printable
+ * width, then packed into page-height buckets without reordering (linear reading
+ * order — and therefore parse/export order — is preserved).
+ *
+ * The rendered stack is scaled to fit the available width (never upscaled past
+ * 100%) so the fixed A4 page shrinks as the surrounding panel narrows. Scaling is
+ * a CSS transform on the whole stack — it changes nothing about text order.
+ */
+export function ResumeDocument(props: ResumeDocumentProps) {
+  const blocks = useMemo(() => buildResumeBlocks(props.resume), [props.resume]);
+  const measureRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [heights, setHeights] = useState<Record<string, number>>({});
+  const [availableWidth, setAvailableWidth] = useState(0);
+
+  useEffect(() => {
+    const layer = measureRef.current;
+    if (!layer) return;
+
+    let cancelled = false;
+    const measure = () => {
+      if (cancelled) return;
+      const next: Record<string, number> = {};
+      layer.querySelectorAll<HTMLElement>("[data-block-id]").forEach((node) => {
+        const id = node.dataset.blockId;
+        if (id) next[id] = node.getBoundingClientRect().height;
+      });
+      setHeights(next);
+    };
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(layer);
+    // Web fonts change line-box heights; re-measure once they have loaded.
+    document.fonts?.ready.then(measure);
+    measure();
+
+    return () => {
+      cancelled = true;
+      observer.disconnect();
+    };
+    // Mount-once: the ResizeObserver re-measures whenever block content reflows.
+  }, []);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) setAvailableWidth(entry.contentRect.width);
+    });
+    observer.observe(el);
+
+    return () => observer.disconnect();
+  }, []);
+
+  const pages = useMemo(
+    () => paginate(blocks, heights, CONTENT_HEIGHT_PX),
+    [blocks, heights],
+  );
+
+  const scale =
+    availableWidth > 0 ? Math.min(1, availableWidth / A4.widthPx) : 1;
+  const naturalHeight =
+    pages.length * A4.heightPx + Math.max(0, pages.length - 1) * PAGE_GAP_PX;
+
+  return (
+    <div ref={containerRef} className="w-full">
+      <div
+        ref={measureRef}
+        aria-hidden
+        className="pointer-events-none invisible fixed top-0 left-0 -z-10"
+        style={{ width: CONTENT_WIDTH_PX }}
+      >
+        {blocks.map((block) => (
+          <div key={block.id} data-block-id={block.id}>
+            <ResumeBlockView block={block} />
+          </div>
+        ))}
+      </div>
+
+      <div
+        className="mx-auto"
+        style={{ width: A4.widthPx * scale, height: naturalHeight * scale }}
+      >
+        <div
+          className="flex flex-col gap-6"
+          style={{
+            width: A4.widthPx,
+            transform: `scale(${scale})`,
+            transformOrigin: "top left",
+          }}
+        >
+          {pages.map((pageBlocks) => (
+            <ResumePage key={pageBlocks[0].id}>
+              {pageBlocks.map((block, index) => (
+                <div
+                  key={block.id}
+                  style={{ marginTop: index === 0 ? 0 : block.gapBefore }}
+                >
+                  <ResumeBlockView block={block} />
+                </div>
+              ))}
+            </ResumePage>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/editor/resume-education-item.tsx
+++ b/src/components/editor/resume-education-item.tsx
@@ -1,0 +1,15 @@
+import type { EducationItemView } from "./resume-preview";
+
+export function ResumeEducationItem(props: EducationItemView) {
+  return (
+    <article>
+      <div className="flex items-baseline justify-between gap-4">
+        <h3 className="text-sm font-semibold">{props.degree}</h3>
+        <span className="shrink-0 text-xs text-muted-foreground">
+          {props.startDate} - {props.endDate}
+        </span>
+      </div>
+      <p className="text-sm text-muted-foreground">{props.institution}</p>
+    </article>
+  );
+}

--- a/src/components/editor/resume-experience-item.tsx
+++ b/src/components/editor/resume-experience-item.tsx
@@ -1,0 +1,30 @@
+import type { ExperienceItemView } from "./resume-preview";
+
+export function ResumeExperienceItem(props: ExperienceItemView) {
+  return (
+    <article>
+      <div className="flex items-baseline justify-between gap-4">
+        <h3 className="text-sm font-semibold">{props.role}</h3>
+        <span className="shrink-0 text-xs text-muted-foreground">
+          {props.startDate} - {props.endDate}
+        </span>
+      </div>
+
+      <p className="text-sm text-muted-foreground">
+        {props.companyHref ? (
+          <a href={props.companyHref} className="hover:underline">
+            {props.company}
+          </a>
+        ) : (
+          props.company
+        )}
+      </p>
+
+      <ul className="mt-2 list-disc space-y-1 pl-5 text-sm leading-relaxed text-muted-foreground">
+        {props.highlights.map((highlight) => (
+          <li key={highlight}>{highlight}</li>
+        ))}
+      </ul>
+    </article>
+  );
+}

--- a/src/components/editor/resume-geometry.ts
+++ b/src/components/editor/resume-geometry.ts
@@ -1,0 +1,26 @@
+/**
+ * A4 page geometry. The millimetre values are the source of truth (A4 is a
+ * physical paper size); pixel values are derived at the CSS reference 96dpi so
+ * on-screen measurement and the eventual print/@page export share one geometry.
+ */
+const MM_TO_PX = 96 / 25.4;
+
+function mmToPx(value: number): number {
+  return Math.round(value * MM_TO_PX);
+}
+
+export const A4 = {
+  widthMm: 210,
+  heightMm: 297,
+  /** Inner page margin. Resume-typical; a preset once the presentation layer lands. */
+  marginMm: 14,
+  widthPx: mmToPx(210),
+  heightPx: mmToPx(297),
+  marginPx: mmToPx(14),
+} as const;
+
+/** Printable width of one page — the exact width content is measured at. */
+export const CONTENT_WIDTH_PX = A4.widthPx - A4.marginPx * 2;
+
+/** Printable height of one page — the per-page height budget for pagination. */
+export const CONTENT_HEIGHT_PX = A4.heightPx - A4.marginPx * 2;

--- a/src/components/editor/resume-header-contact.tsx
+++ b/src/components/editor/resume-header-contact.tsx
@@ -1,0 +1,25 @@
+import { Globe, Mail, MapPin, Phone } from "lucide-react";
+import type { ContactKind, ContactView } from "./resume-preview";
+
+const CONTACT_ICON: Record<ContactKind, typeof Phone> = {
+  phone: Phone,
+  email: Mail,
+  website: Globe,
+  location: MapPin,
+};
+
+export function ResumeHeaderContact(props: ContactView) {
+  const Icon = CONTACT_ICON[props.kind];
+  return (
+    <li className="flex items-center gap-2">
+      <Icon className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+      {props.href ? (
+        <a href={props.href} className="hover:underline">
+          {props.value}
+        </a>
+      ) : (
+        <span>{props.value}</span>
+      )}
+    </li>
+  );
+}

--- a/src/components/editor/resume-header.tsx
+++ b/src/components/editor/resume-header.tsx
@@ -1,0 +1,19 @@
+import { ResumeHeaderContact } from "./resume-header-contact";
+import type { HeaderView } from "./resume-preview";
+
+export function ResumeHeader(props: HeaderView) {
+  return (
+    <header className="flex flex-wrap items-start justify-between gap-4">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">{props.fullName}</h1>
+        <p className="mt-1 text-muted-foreground">{props.headline}</p>
+      </div>
+
+      <ul className="space-y-1 text-sm">
+        {props.contacts.map((contact) => (
+          <ResumeHeaderContact key={contact.kind} {...contact} />
+        ))}
+      </ul>
+    </header>
+  );
+}

--- a/src/components/editor/resume-language-item.tsx
+++ b/src/components/editor/resume-language-item.tsx
@@ -1,0 +1,10 @@
+import type { LanguageItemView } from "./resume-preview";
+
+export function ResumeLanguageItem(props: LanguageItemView) {
+  return (
+    <li className="flex items-baseline gap-3">
+      <span className="text-sm font-semibold">{props.name}</span>
+      <span className="text-sm text-muted-foreground">{props.proficiency}</span>
+    </li>
+  );
+}

--- a/src/components/editor/resume-languages-list.tsx
+++ b/src/components/editor/resume-languages-list.tsx
@@ -1,0 +1,16 @@
+import { ResumeLanguageItem } from "./resume-language-item";
+import type { LanguageItemView } from "./resume-preview";
+
+interface ResumeLanguagesListProps {
+  items: LanguageItemView[];
+}
+
+export function ResumeLanguagesList(props: ResumeLanguagesListProps) {
+  return (
+    <ul className="flex flex-wrap gap-x-12 gap-y-2">
+      {props.items.map((item) => (
+        <ResumeLanguageItem key={item.id} {...item} />
+      ))}
+    </ul>
+  );
+}

--- a/src/components/editor/resume-page.tsx
+++ b/src/components/editor/resume-page.tsx
@@ -1,0 +1,35 @@
+import type { CSSProperties, ReactNode } from "react";
+import { A4 } from "./resume-geometry";
+
+interface ResumePageProps {
+  children: ReactNode;
+}
+
+/**
+ * A résumé is always dark ink on white paper, independent of the app theme, so
+ * the page pins `--foreground`/`--muted-foreground` to light-mode ink values
+ * rather than inheriting the surrounding theme tokens.
+ */
+const PAPER_STYLE: CSSProperties = {
+  width: A4.widthPx,
+  height: A4.heightPx,
+  padding: A4.marginPx,
+  ["--foreground" as string]: "var(--color-neutral-950)",
+  ["--muted-foreground" as string]: "var(--color-neutral-600)",
+};
+
+/**
+ * A single, exact A4 page frame. Fixed width and height with `overflow-hidden`
+ * so content never spills past the page bounds — the paginator is responsible
+ * for placing only what fits (see `paginate`).
+ */
+export function ResumePage(props: ResumePageProps) {
+  return (
+    <div
+      className="mx-auto overflow-hidden rounded border bg-white text-foreground shadow-sm"
+      style={PAPER_STYLE}
+    >
+      {props.children}
+    </div>
+  );
+}

--- a/src/components/editor/resume-paginate.ts
+++ b/src/components/editor/resume-paginate.ts
@@ -1,0 +1,65 @@
+/**
+ * Minimal shape the paginator needs. Decoupled from `ResumeBlock` so this stays
+ * a pure, testable packing function over ids, gaps, and grouping flags.
+ */
+export interface Paginable {
+  id: string;
+  gapBefore: number;
+  keepWithNext: boolean;
+}
+
+/**
+ * Height a group of blocks occupies. When placed first on a page the leading
+ * block contributes no top gap (a page's top edge already provides the margin).
+ */
+function measureGroup<T extends Paginable>(
+  group: T[],
+  heights: Record<string, number>,
+  isFirstOnPage: boolean,
+): number {
+  return group.reduce((total, block, index) => {
+    const leadingGap = isFirstOnPage && index === 0 ? 0 : block.gapBefore;
+    return total + leadingGap + (heights[block.id] ?? 0);
+  }, 0);
+}
+
+/**
+ * Greedily packs blocks into fixed-height pages. Blocks joined by `keepWithNext`
+ * are treated as one indivisible group. A group that does not fit on the current
+ * page starts a new one; a group taller than a whole page is placed anyway (this
+ * variant does not split a single entry across pages) and clipped by the frame.
+ */
+export function paginate<T extends Paginable>(
+  blocks: T[],
+  heights: Record<string, number>,
+  budget: number,
+): T[][] {
+  const pages: T[][] = [];
+  let current: T[] = [];
+  let used = 0;
+
+  let index = 0;
+  while (index < blocks.length) {
+    const group: T[] = [blocks[index]];
+    while (
+      group[group.length - 1].keepWithNext &&
+      index + group.length < blocks.length
+    ) {
+      group.push(blocks[index + group.length]);
+    }
+
+    const appendHeight = measureGroup(group, heights, false);
+    if (current.length > 0 && used + appendHeight > budget) {
+      pages.push(current);
+      current = [];
+      used = 0;
+    }
+
+    used += measureGroup(group, heights, current.length === 0);
+    current.push(...group);
+    index += group.length;
+  }
+
+  if (current.length > 0) pages.push(current);
+  return pages;
+}

--- a/src/components/editor/resume-preview-data.ts
+++ b/src/components/editor/resume-preview-data.ts
@@ -1,0 +1,113 @@
+import type { ResumePreview } from "./resume-preview";
+
+/**
+ * Static stand-in for the output of the (not-yet-written) `Resume → ResumePreview`
+ * adapter. Mirrors `resume-rimzzlabs.pdf` so the presentation layer can be built
+ * and reviewed against a real document before the data flow is wired up.
+ */
+export const RESUME_PREVIEW_FIXTURE: ResumePreview = {
+  header: {
+    fullName: "Rizki Citra",
+    headline: "Frontend Engineer",
+    contacts: [
+      { kind: "phone", value: "+62 89654983166", href: "tel:+6289654983166" },
+      {
+        kind: "email",
+        value: "hello@rimzzlabs.com",
+        href: "mailto:hello@rimzzlabs.com",
+      },
+      {
+        kind: "website",
+        value: "rimzzlabs.com",
+        href: "https://rimzzlabs.com",
+      },
+      { kind: "location", value: "Serang City, Indonesia" },
+    ],
+  },
+  summary:
+    "Frontend Engineer with 4 years building production applications for fintech; including cryptocurrency platforms. Specialized in React and Next.js with proven experience delivering real-time trading interfaces, WebSocket integrations, and high-performance web applications. Track record of improving application performance and collaborating across product, design, and backend teams in fast-paced environments.",
+  experience: [
+    {
+      id: "exp-bitwyre",
+      role: "Frontend Engineer",
+      company: "Bitwyre",
+      companyHref: "https://bitwyre.com",
+      startDate: "02/2024",
+      endDate: "10/2025",
+      highlights: [
+        "Architected and built the frontend for a cryptocurrency exchange platform using Next.js and TypeScript, implementing real-time price feeds via WebSocket integration for multiple trading pairs",
+        "Developed an institutional OTC trading platform with secure transaction flows, role-based access controls, and compliance features for enterprise clients",
+        "Improved application performance through code splitting, lazy loading, and React Query optimization, significantly reducing bundle size and initial load times",
+        "Built cross-platform mobile features for Bitwyre's crypto card product using React Native, extending core functionality to iOS and Android platforms",
+        "Designed and implemented comprehensive error handling for WebSocket connections, ensuring reliable real-time data delivery even during network disruptions",
+        "Collaborated with backend engineers on API design, reducing unnecessary data transfers and improving overall platform responsiveness",
+        "Managed deployment pipeline using Docker and Jenkins, working with DevOps team to containerize applications and automate CI/CD workflows for staging and production environments",
+      ],
+    },
+    {
+      id: "exp-skyshi",
+      role: "Frontend Developer",
+      company: "Skyshi Digital",
+      companyHref: "https://skyshi.com",
+      startDate: "12/2021",
+      endDate: "02/2024",
+      highlights: [
+        "Delivered client projects using Next.js and React, including e-commerce platforms, marketing sites, and corporate websites in a fast-paced agency environment",
+        "Built and maintained a scalable component library and design system used across multiple client projects, reducing development time and ensuring brand consistency",
+        "Optimized website performance across client sites by implementing code splitting, image optimization, and caching strategies, improving Core Web Vitals scores",
+        "Integrated analytics pipelines (Google Analytics, Mixpanel) and implemented A/B testing frameworks to enable data-driven design decisions for marketing campaigns",
+        "Led mobile-first development approach for all projects, ensuring responsive experiences across devices and browsers with cross-browser compatibility testing",
+        "Collaborated with designers and backend teams to translate Figma designs into production-ready components, establishing clear handoff processes and documentation",
+        "Built an internal ticketing system using Angular, implementing features for issue tracking, assignment workflows, and status management",
+        "Developed a dynamic form builder with drag-and-drop functionality, supporting multiple field types, conditional logic, and real-time preview capabilities",
+      ],
+    },
+  ],
+  education: [
+    {
+      id: "edu-amik",
+      degree: "Informatics Management",
+      institution: "AMIK Serang - Associate's Degree",
+      startDate: "12/2021",
+      endDate: "12/2024",
+    },
+  ],
+  certificates: [
+    {
+      id: "cert-efset",
+      title: "English Certificate (C1 Advanced)",
+      issuer: "EF SET",
+      href: "https://www.efset.org",
+      startDate: "11/2024",
+      endDate: "Present",
+    },
+    {
+      id: "cert-hackerrank",
+      title: "Frontend Developer (React)",
+      issuer: "Hackerrank",
+      href: "https://www.hackerrank.com",
+      startDate: "01/2024",
+      endDate: "Present",
+    },
+  ],
+  skills: [
+    "Next.js, React Router / Remix, Astro.js",
+    "React.js, React Native",
+    "Tanstack (Query, Table, Virtual)",
+    "Jotai, Zustand, Redux, Recoil",
+    "Jest, Vitest, Testing Library",
+    "Vue.js, Svelte.js",
+    "WebSocket, Socket.io, REST APIs",
+    "Node.js, Prisma, Drizzle",
+    "TypeScript, JavaScript / ES6+",
+    "CSS, CSS3, SCSS, Tailwind CSS, ShadCN",
+    "Figma, Git, GitHub, GitLab, Docker",
+    "Search Engine Optimization",
+    "Responsive Design",
+    "User Experience & Web Accessibility",
+  ],
+  languages: [
+    { id: "lang-id", name: "Indonesian", proficiency: "Native" },
+    { id: "lang-en", name: "English", proficiency: "Fluent" },
+  ],
+};

--- a/src/components/editor/resume-preview.ts
+++ b/src/components/editor/resume-preview.ts
@@ -1,0 +1,68 @@
+/**
+ * View-model contract consumed by the editor's static preview components. This is
+ * deliberately decoupled from the persisted `Resume` domain model (see
+ * `@/lib/resume/types`): an adapter will project a `Resume` into this shape, so
+ * the presentation components never read the storage schema directly.
+ *
+ * Data → adapter → consumer: these types are the consumer contract.
+ */
+
+export type ContactKind = "phone" | "email" | "website" | "location";
+
+export interface ContactView {
+  kind: ContactKind;
+  /** Human-readable text shown to the reader. */
+  value: string;
+  /** Optional link target. Absent for non-navigable contacts (e.g. location). */
+  href?: string;
+}
+
+export interface HeaderView {
+  fullName: string;
+  headline: string;
+  contacts: ContactView[];
+}
+
+export interface ExperienceItemView {
+  id: string;
+  role: string;
+  company: string;
+  companyHref?: string;
+  startDate: string;
+  endDate: string;
+  highlights: string[];
+}
+
+export interface EducationItemView {
+  id: string;
+  degree: string;
+  institution: string;
+  startDate: string;
+  endDate: string;
+}
+
+export interface CertificateItemView {
+  id: string;
+  title: string;
+  issuer: string;
+  href?: string;
+  startDate: string;
+  endDate: string;
+}
+
+export interface LanguageItemView {
+  id: string;
+  name: string;
+  proficiency: string;
+}
+
+export interface ResumePreview {
+  header: HeaderView;
+  summary: string;
+  experience: ExperienceItemView[];
+  education: EducationItemView[];
+  certificates: CertificateItemView[];
+  /** One line per skill group, laid out across two columns in reading order. */
+  skills: string[];
+  languages: LanguageItemView[];
+}

--- a/src/components/editor/resume-section-heading.tsx
+++ b/src/components/editor/resume-section-heading.tsx
@@ -1,0 +1,14 @@
+interface ResumeSectionHeadingProps {
+  title: string;
+}
+
+export function ResumeSectionHeading(props: ResumeSectionHeadingProps) {
+  return (
+    <div className="flex items-center gap-3">
+      <h2 className="text-sm font-semibold uppercase tracking-[0.2em]">
+        {props.title}
+      </h2>
+      <span className="flex-1 border-t border-dotted border-muted-foreground/40" />
+    </div>
+  );
+}

--- a/src/components/editor/resume-skills-list.tsx
+++ b/src/components/editor/resume-skills-list.tsx
@@ -1,0 +1,13 @@
+interface ResumeSkillsListProps {
+  items: string[];
+}
+
+export function ResumeSkillsList(props: ResumeSkillsListProps) {
+  return (
+    <ul className="grid grid-cols-2 gap-x-8 gap-y-1 text-sm text-muted-foreground">
+      {props.items.map((item) => (
+        <li key={item}>{item}</li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/editor/resume-summary-body.tsx
+++ b/src/components/editor/resume-summary-body.tsx
@@ -1,0 +1,11 @@
+interface ResumeSummaryBodyProps {
+  body: string;
+}
+
+export function ResumeSummaryBody(props: ResumeSummaryBodyProps) {
+  return (
+    <p className="text-sm leading-relaxed text-muted-foreground">
+      {props.body}
+    </p>
+  );
+}

--- a/src/components/landing/landing-hero.tsx
+++ b/src/components/landing/landing-hero.tsx
@@ -42,13 +42,11 @@ export function LandingHero() {
 
       <motion.h1
         variants={itemVariants}
-        className="mb-6 text-5xl font-bold tracking-tight md:text-7xl"
+        className="mb-6 text-5xl font-bold tracking-tight md:text-7xl bg-linear-to-r from-primary to-violet-800 bg-clip-text text-transparent"
       >
         Land The Interview,
         <br />
-        <span className="bg-linear-to-r from-foreground to-primary bg-clip-text text-transparent">
-          Not The Reject Pile.
-        </span>
+        Not The Reject Pile.
       </motion.h1>
 
       <motion.p
@@ -61,11 +59,21 @@ export function LandingHero() {
       </motion.p>
 
       <motion.div variants={itemVariants} className="flex gap-4">
-        <Button render={<Link href="/editor" />} size="lg" className="gap-2">
+        <Button
+          size="lg"
+          className="gap-2"
+          nativeButton={false}
+          render={<Link href="/platform" />}
+        >
           Start building
           <ArrowRight className="size-4" />
         </Button>
-        <Button render={<Link href="/samples" />} size="lg" variant="outline">
+        <Button
+          size="lg"
+          variant="outline"
+          nativeButton={false}
+          render={<Link href="/samples" />}
+        >
           See a sample
         </Button>
       </motion.div>

--- a/src/components/platform/platform-navbar-theme.tsx
+++ b/src/components/platform/platform-navbar-theme.tsx
@@ -32,7 +32,7 @@ export function PlatformNavbarTheme() {
   const onChangeTheme = (next: string) => setTheme(next);
 
   return (
-    <DropdownMenu>
+    <DropdownMenu modal={false}>
       <Tooltip>
         <TooltipTrigger
           render={<DropdownMenuTrigger render={<Button variant="outline" />} />}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -39,15 +39,17 @@ function SheetContent({
   className,
   children,
   side = "right",
+  skipOverlay = false,
   showCloseButton = true,
   ...props
 }: SheetPrimitive.Popup.Props & {
   side?: "top" | "right" | "bottom" | "left";
   showCloseButton?: boolean;
+  skipOverlay?: boolean;
 }) {
   return (
     <SheetPortal>
-      <SheetOverlay />
+      {!skipOverlay && <SheetOverlay />}
       <SheetPrimitive.Popup
         data-slot="sheet-content"
         data-side={side}


### PR DESCRIPTION
## What

Wires the résumé preview into the editor route and makes the editor a fixed-height resizable split where the CV scales to fit.

## Changes

- **Resizable works** — the panel group now has a resolved height (`calc(100svh - navbar)`), so the drag handle actually has grabbable area. Both panels get explicit `defaultSize`/`minSize`/`maxSize`.
- **Sticky right sheet** — each panel scrolls internally instead of the document, so the editor panel stays pinned while the CV column scrolls.
- **CV scales to panel** — the A4 page stack gets a CSS `transform: scale()` based on available width (never upscaled past 100%), shrinking as the panel narrows. An outer sizing box tracks the scaled dimensions so scroll height stays correct.
- Moved platform page padding out of the shared layout so the editor route is full-bleed.
- Added `skipOverlay` to `Sheet`, plus minor landing-hero and navbar-theme tweaks.

## ATS safety

Scaling is a presentation-only CSS transform on the whole stack — linear reading/parse order is untouched, per the two-layer architecture rule.

## Verification

- `tsc --noEmit` and `biome check` clean.
- Editor route renders HTTP 200 with the resizable group, handle, sidebar, and paginated content.
- ⚠️ Interactive drag not exercised headlessly — worth a manual drag-the-handle check.