### PR TITLE
feat: add editor sidebar section list

### DIFF
--- a/src/components/editor/editor-section-list-item.tsx
+++ b/src/components/editor/editor-section-list-item.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { EditorSectionVisibilityToggle } from "./editor-section-visibility-toggle";
+import type {
+  EditorSectionDescriptor,
+  EditorSectionId,
+} from "./editor-sections";
+
+interface EditorSectionListItemProps {
+  section: EditorSectionDescriptor;
+  active: boolean;
+  hidden: boolean;
+  onSelect: (id: EditorSectionId) => void;
+  onToggleHidden: (id: EditorSectionId) => void;
+}
+
+export function EditorSectionListItem(props: EditorSectionListItemProps) {
+  const Icon = props.section.icon;
+
+  return (
+    <li className="relative">
+      <button
+        type="button"
+        onClick={() => props.onSelect(props.section.id)}
+        className={cn(
+          "flex w-full items-center gap-3 py-5 pr-16 text-left transition-colors",
+          props.active
+            ? "text-foreground"
+            : "text-muted-foreground hover:text-foreground",
+        )}
+      >
+        <Icon className="size-5 shrink-0 text-foreground" />
+        <span className="flex-1 truncate text-lg">{props.section.label}</span>
+      </button>
+
+      {/* Overlays the row button; only the toggle re-enables pointer events, so
+          taps on the chevron fall through to select the row. */}
+      <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center gap-2">
+        {!props.section.required && (
+          <span className="pointer-events-auto">
+            <EditorSectionVisibilityToggle
+              hidden={props.hidden}
+              onToggle={() => props.onToggleHidden(props.section.id)}
+            />
+          </span>
+        )}
+        <ChevronRight
+          className={cn(
+            "size-5 shrink-0",
+            props.active ? "text-foreground" : "text-muted-foreground/50",
+          )}
+        />
+      </div>
+    </li>
+  );
+}

--- a/src/components/editor/editor-section-list.tsx
+++ b/src/components/editor/editor-section-list.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useState } from "react";
+import { EditorSectionListItem } from "./editor-section-list-item";
+import { EDITOR_SECTIONS, type EditorSectionId } from "./editor-sections";
+
+export function EditorSectionList() {
+  const [activeId, setActiveId] = useState<EditorSectionId>("personal-details");
+  const [hidden, setHidden] = useState<ReadonlySet<EditorSectionId>>(
+    () => new Set(),
+  );
+
+  const toggleHidden = (id: EditorSectionId) => {
+    setHidden((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  return (
+    <ul className="divide-y">
+      {EDITOR_SECTIONS.map((section) => (
+        <EditorSectionListItem
+          key={section.id}
+          section={section}
+          active={section.id === activeId}
+          hidden={hidden.has(section.id)}
+          onSelect={setActiveId}
+          onToggleHidden={toggleHidden}
+        />
+      ))}
+    </ul>
+  );
+}

--- a/src/components/editor/editor-section-visibility-toggle.tsx
+++ b/src/components/editor/editor-section-visibility-toggle.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Eye, EyeOff } from "lucide-react";
+
+interface EditorSectionVisibilityToggleProps {
+  hidden: boolean;
+  onToggle: () => void;
+}
+
+export function EditorSectionVisibilityToggle({
+  hidden,
+  onToggle,
+}: EditorSectionVisibilityToggleProps) {
+  const Icon = hidden ? EyeOff : Eye;
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-pressed={hidden}
+      aria-label={hidden ? "Show section" : "Hide section"}
+      className="rounded p-1 text-muted-foreground/70 transition-colors hover:text-foreground"
+    >
+      <Icon className="size-5" />
+    </button>
+  );
+}

--- a/src/components/editor/editor-sections.ts
+++ b/src/components/editor/editor-sections.ts
@@ -1,0 +1,48 @@
+import {
+  AlignLeft,
+  Award,
+  Briefcase,
+  CircleUserRound,
+  GraduationCap,
+  Languages,
+  type LucideIcon,
+  Zap,
+} from "lucide-react";
+
+export type EditorSectionId =
+  | "personal-details"
+  | "experience"
+  | "education"
+  | "skills"
+  | "languages"
+  | "certificates"
+  | "summary";
+
+export interface EditorSectionDescriptor {
+  id: EditorSectionId;
+  label: string;
+  icon: LucideIcon;
+  /** Required sections are always present and cannot be hidden (no visibility toggle). */
+  required: boolean;
+}
+
+/**
+ * The editor's section navigation, in reading order. Personal Details maps to the
+ * privileged `Header` (always first, never hidden); the rest map to reorderable
+ * sections. This is the sidebar's view contract, decoupled from the persisted
+ * `Resume` model — an adapter will project real sections onto these descriptors.
+ */
+export const EDITOR_SECTIONS: EditorSectionDescriptor[] = [
+  {
+    id: "personal-details",
+    label: "Personal Details",
+    icon: CircleUserRound,
+    required: true,
+  },
+  { id: "experience", label: "Experience", icon: Briefcase, required: false },
+  { id: "education", label: "Education", icon: GraduationCap, required: false },
+  { id: "skills", label: "Skills", icon: Zap, required: false },
+  { id: "languages", label: "Languages", icon: Languages, required: false },
+  { id: "certificates", label: "Certificates", icon: Award, required: false },
+  { id: "summary", label: "Summary", icon: AlignLeft, required: false },
+];

--- a/src/components/editor/editor-sidebar.tsx
+++ b/src/components/editor/editor-sidebar.tsx
@@ -2,6 +2,7 @@
 
 import { ResizablePanel } from "../ui/resizable";
 import { useSidebar } from "../ui/sidebar";
+import { EditorSectionList } from "./editor-section-list";
 
 export function EditorSidebar() {
   const { open } = useSidebar();
@@ -11,10 +12,9 @@ export function EditorSidebar() {
       minSize={open ? "28%" : "30%"}
       maxSize="40%"
     >
-      <div className="h-full overflow-y-auto p-4">
-        <div className="inline-flex items-center gap-2">
-          <h3 className="text-lg font-medium">Editor</h3>
-        </div>
+      <div className="h-full overflow-y-auto px-6 py-5">
+        <h2 className="mb-2 text-2xl font-bold tracking-tight">Resume</h2>
+        <EditorSectionList />
       </div>
     </ResizablePanel>
   );


### PR DESCRIPTION
## What

Adds the Wozber-style section navigation to the editor sidebar, replacing the placeholder "Editor" heading.

![sections](https://user-images.githubusercontent.com/placeholder)

## Sections

Personal Details · Experience · Education · Skills · Languages · Certificates · Summary

- Each row shows an icon + label + chevron.
- Non-required sections get an eye visibility toggle. **Personal Details** maps to the always-present `Header` and has no toggle (can't be hidden).
- Active selection highlights the row (foreground text + darker chevron).

## Structure

Split per the CLAUDE.md component conventions:
- `editor-sections.ts` — section descriptors (view contract, decoupled from the persisted `Resume` model).
- `editor-section-list.tsx` — list container + state.
- `editor-section-list-item.tsx` — a single row.
- `editor-section-visibility-toggle.tsx` — the eye toggle.

The visibility toggle overlays the row button with `pointer-events` gating so there are no nested `<button>`s and chevron taps still select the row.

## Notes / follow-ups

- Active selection and hidden state are **local** for now — nothing is persisted and toggling visibility does not yet hide sections in the preview. An adapter projecting the real `Resume` sections onto these descriptors (and store-backed visibility/reordering) is the next step.

## Verification

- `tsc --noEmit` and `biome check` clean.
- Editor route renders HTTP 200 with all 7 sections and 6 visibility toggles (Personal Details excluded).