### PR TITLE
feat: render rich-text formatting in the résumé preview

### DIFF
--- a/src/components/editor/editor-resume-preview.tsx
+++ b/src/components/editor/editor-resume-preview.tsx
@@ -37,13 +37,13 @@ export function EditorResumePreview() {
 
 function PreviewSkeleton() {
   return (
-    <div className="mx-auto aspect-[210/297] w-full max-w-[794px] animate-pulse rounded border bg-white shadow-sm" />
+    <div className="mx-auto aspect-210/297 w-full max-w-[794px] animate-pulse rounded border bg-white shadow-sm" />
   );
 }
 
 function PreviewMessage(props: { children: string }) {
   return (
-    <div className="mx-auto flex aspect-[210/297] w-full max-w-[794px] items-center justify-center rounded border bg-white text-sm text-muted-foreground shadow-sm">
+    <div className="mx-auto flex aspect-210/297 w-full max-w-[794px] items-center justify-center rounded border bg-white text-sm text-muted-foreground shadow-sm">
       {props.children}
     </div>
   );

--- a/src/components/editor/resume-blocks.ts
+++ b/src/components/editor/resume-blocks.ts
@@ -7,6 +7,7 @@ import type {
   ResumePreview,
   SkillItemView,
 } from "./resume-preview";
+import { isRichEmpty, type RichBlock } from "./rich-content";
 
 /**
  * Pagination metadata shared by every block. `keepWithNext` glues a block to the
@@ -29,7 +30,7 @@ export type ResumeBlock = BlockMeta &
   (
     | { kind: "header"; header: HeaderView }
     | { kind: "heading"; title: string }
-    | { kind: "summary"; body: string }
+    | { kind: "summary"; body: RichBlock[] }
     | { kind: "experience"; item: ExperienceItemView }
     | { kind: "education"; item: EducationItemView }
     | { kind: "certificate"; item: CertificateItemView }
@@ -63,7 +64,7 @@ function entryGap(index: number): number {
 }
 
 function hasExperience(item: ExperienceItemView): boolean {
-  return Boolean(item.role || item.company || item.highlights.length > 0);
+  return Boolean(item.role || item.company) || !isRichEmpty(item.description);
 }
 
 function hasEducation(item: EducationItemView): boolean {
@@ -98,12 +99,11 @@ export function buildResumeBlocks(resume: ResumePreview): ResumeBlock[] {
     },
   ];
 
-  const summary = resume.summary.trim();
-  if (summary) {
+  if (!isRichEmpty(resume.summary)) {
     blocks.push(heading("summary-heading", "Summary"), {
       id: "summary-body",
       kind: "summary",
-      body: summary,
+      body: resume.summary,
       gapBefore: GAP.body,
       keepWithNext: false,
     });

--- a/src/components/editor/resume-education-item.tsx
+++ b/src/components/editor/resume-education-item.tsx
@@ -1,4 +1,5 @@
 import type { EducationItemView } from "./resume-preview";
+import { ResumeRichText } from "./resume-rich-text";
 
 export function ResumeEducationItem(props: EducationItemView) {
   return (
@@ -10,6 +11,7 @@ export function ResumeEducationItem(props: EducationItemView) {
         </span>
       </div>
       <p className="text-xs text-muted-foreground">{props.institution}</p>
+      <ResumeRichText blocks={props.details} className="mt-1" />
     </article>
   );
 }

--- a/src/components/editor/resume-experience-item.tsx
+++ b/src/components/editor/resume-experience-item.tsx
@@ -1,4 +1,5 @@
 import type { ExperienceItemView } from "./resume-preview";
+import { ResumeRichText } from "./resume-rich-text";
 
 export function ResumeExperienceItem(props: ExperienceItemView) {
   return (
@@ -20,11 +21,7 @@ export function ResumeExperienceItem(props: ExperienceItemView) {
         )}
       </p>
 
-      <ul className="mt-2 list-disc space-y-1 pl-5 text-xs leading-relaxed text-muted-foreground">
-        {props.highlights.map((highlight) => (
-          <li key={highlight}>{highlight}</li>
-        ))}
-      </ul>
+      <ResumeRichText blocks={props.description} className="mt-2" />
     </article>
   );
 }

--- a/src/components/editor/resume-preview.ts
+++ b/src/components/editor/resume-preview.ts
@@ -7,6 +7,8 @@
  * Data → adapter → consumer: these types are the consumer contract.
  */
 
+import type { RichBlock } from "./rich-content";
+
 export type ContactKind = "phone" | "email" | "website" | "location";
 
 export interface ContactView {
@@ -30,7 +32,7 @@ export interface ExperienceItemView {
   companyHref?: string;
   startDate: string;
   endDate: string;
-  highlights: string[];
+  description: RichBlock[];
 }
 
 export interface EducationItemView {
@@ -39,6 +41,7 @@ export interface EducationItemView {
   institution: string;
   startDate: string;
   endDate: string;
+  details: RichBlock[];
 }
 
 export interface CertificateItemView {
@@ -64,7 +67,7 @@ export interface LanguageItemView {
 
 export interface ResumePreview {
   header: HeaderView;
-  summary: string;
+  summary: RichBlock[];
   experience: ExperienceItemView[];
   education: EducationItemView[];
   certificates: CertificateItemView[];

--- a/src/components/editor/resume-rich-text.tsx
+++ b/src/components/editor/resume-rich-text.tsx
@@ -1,0 +1,76 @@
+import { cn } from "@/lib/utils";
+import type { InlineRun, RichBlock } from "./rich-content";
+
+function runsText(runs: InlineRun[]): string {
+  return runs.map((run) => run.text).join("");
+}
+
+function runKey(run: InlineRun): string {
+  return `${run.href ?? ""}|${run.bold ? "b" : ""}${run.italic ? "i" : ""}|${run.text}`;
+}
+
+function RichRun(props: InlineRun) {
+  let node: React.ReactNode = props.text;
+  if (props.bold) node = <strong className="font-semibold">{node}</strong>;
+  if (props.italic) node = <em>{node}</em>;
+  if (props.href) {
+    node = (
+      <a href={props.href} className="underline">
+        {node}
+      </a>
+    );
+  }
+  return node;
+}
+
+function RichRuns(props: { runs: InlineRun[] }) {
+  return props.runs.map((run) => <RichRun key={runKey(run)} {...run} />);
+}
+
+interface ResumeRichTextProps {
+  blocks: RichBlock[];
+  className?: string;
+}
+
+/**
+ * Renders `RichBlock`s as the résumé preview's prose: paragraphs and bullet /
+ * ordered lists with bold, italic, and link marks. Shared by every rich field
+ * (summary, experience, education) so formatting is consistent.
+ */
+export function ResumeRichText(props: ResumeRichTextProps) {
+  if (props.blocks.length === 0) return null;
+  return (
+    <div
+      className={cn(
+        "space-y-1 text-xs leading-relaxed text-muted-foreground",
+        props.className,
+      )}
+    >
+      {props.blocks.map((block) => {
+        if (block.type === "list") {
+          const ListTag = block.ordered ? "ol" : "ul";
+          return (
+            <ListTag
+              key={block.items.map(runsText).join("|")}
+              className={cn(
+                "space-y-1 pl-5",
+                block.ordered ? "list-decimal" : "list-disc",
+              )}
+            >
+              {block.items.map((runs) => (
+                <li key={runsText(runs)}>
+                  <RichRuns runs={runs} />
+                </li>
+              ))}
+            </ListTag>
+          );
+        }
+        return (
+          <p key={runsText(block.runs)}>
+            <RichRuns runs={block.runs} />
+          </p>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/editor/resume-summary-body.tsx
+++ b/src/components/editor/resume-summary-body.tsx
@@ -1,11 +1,10 @@
+import { ResumeRichText } from "./resume-rich-text";
+import type { RichBlock } from "./rich-content";
+
 interface ResumeSummaryBodyProps {
-  body: string;
+  body: RichBlock[];
 }
 
 export function ResumeSummaryBody(props: ResumeSummaryBodyProps) {
-  return (
-    <p className="text-xs leading-relaxed text-muted-foreground">
-      {props.body}
-    </p>
-  );
+  return <ResumeRichText blocks={props.body} />;
 }

--- a/src/components/editor/resume-to-preview.ts
+++ b/src/components/editor/resume-to-preview.ts
@@ -1,14 +1,14 @@
-import type { JSONContent } from "@tiptap/core";
 import type { Field, Resume, Section } from "@/lib/resume/types";
 import { dateSortValue } from "./month-year-menu/month-year-menu-data";
 import type { ContactView, HeaderView, ResumePreview } from "./resume-preview";
+import { type RichBlock, tiptapToRichBlocks } from "./rich-content";
 
 function plain(field: Field | undefined): string {
   return field?.kind === "plain" ? field.value.trim() : "";
 }
 
-function rich(field: Field | undefined): JSONContent | undefined {
-  return field?.kind === "richtext" ? field.value : undefined;
+function richBlocks(field: Field | undefined): RichBlock[] {
+  return field?.kind === "richtext" ? tiptapToRichBlocks(field.value) : [];
 }
 
 function sectionOfType(
@@ -16,36 +16,6 @@ function sectionOfType(
   type: Section["type"],
 ): Section | undefined {
   return resume.sections.find((section) => section.type === type);
-}
-
-/** All text nodes under `node`, concatenated in document order. */
-function nodeText(node: JSONContent | undefined): string {
-  if (!node) return "";
-  let text = node.text ?? "";
-  for (const child of node.content ?? []) text += nodeText(child);
-  return text;
-}
-
-/**
- * Flattens a restricted TipTap doc into linear text lines: every list item and
- * every top-level paragraph becomes one line. Inline marks (bold/italic/link)
- * collapse to their text — the plain-string view-model carries structure, not
- * formatting. Rendering marks in the preview is separate follow-up work.
- */
-function richLines(doc: JSONContent | undefined): string[] {
-  const lines: string[] = [];
-  for (const block of doc?.content ?? []) {
-    if (block.type === "bulletList" || block.type === "orderedList") {
-      for (const item of block.content ?? []) {
-        const text = nodeText(item).trim();
-        if (text) lines.push(text);
-      }
-      continue;
-    }
-    const text = nodeText(block).trim();
-    if (text) lines.push(text);
-  }
-  return lines;
 }
 
 /** A stored URL is domain-only (see `UrlInput`); restore the scheme for links. */
@@ -120,7 +90,7 @@ export function resumeToPreview(resume: Resume): ResumePreview {
 
   return {
     header: toHeaderView(resume),
-    summary: richLines(rich(summaryBody)).join(" "),
+    summary: richBlocks(summaryBody),
     experience: (sectionOfType(resume, "experience")?.entries ?? [])
       .map((entry) => {
         const website = plain(entry.fields.website);
@@ -131,7 +101,7 @@ export function resumeToPreview(resume: Resume): ResumePreview {
           companyHref: website ? withHttps(website) : undefined,
           startDate: plain(entry.fields.startDate),
           endDate: plain(entry.fields.endDate),
-          highlights: richLines(rich(entry.fields.description)),
+          description: richBlocks(entry.fields.description),
         };
       })
       .sort(byRecency),
@@ -142,6 +112,7 @@ export function resumeToPreview(resume: Resume): ResumePreview {
         institution: plain(entry.fields.institution),
         startDate: plain(entry.fields.startDate),
         endDate: plain(entry.fields.endDate),
+        details: richBlocks(entry.fields.details),
       }))
       .sort(byRecency),
     certificates: (sectionOfType(resume, "certifications")?.entries ?? []).map(

--- a/src/components/editor/rich-content.ts
+++ b/src/components/editor/rich-content.ts
@@ -1,0 +1,80 @@
+import type { JSONContent } from "@tiptap/core";
+
+/**
+ * A run of inline text carrying the restricted schema's marks (bold, italic,
+ * link). This is the export-neutral shape every renderer consumes — the DOM
+ * preview, the PDF template, and the text/docx serializers — so marks survive
+ * into every output instead of collapsing to plain strings.
+ */
+export interface InlineRun {
+  text: string;
+  bold?: boolean;
+  italic?: boolean;
+  href?: string;
+}
+
+/**
+ * A block in a rich field: a paragraph, or a bullet/ordered list whose items are
+ * each a line of runs. The restricted TipTap schema has no nesting beyond this.
+ */
+export type RichBlock =
+  | { type: "paragraph"; runs: InlineRun[] }
+  | { type: "list"; ordered: boolean; items: InlineRun[][] };
+
+function runFromText(node: JSONContent): InlineRun {
+  const run: InlineRun = { text: node.text ?? "" };
+  for (const mark of node.marks ?? []) {
+    if (mark.type === "bold") run.bold = true;
+    else if (mark.type === "italic") run.italic = true;
+    else if (mark.type === "link" && mark.attrs?.href) {
+      run.href = String(mark.attrs.href);
+    }
+  }
+  return run;
+}
+
+/** Depth-first collection of every text node under `node`, in document order. */
+function collectRuns(node: JSONContent): InlineRun[] {
+  if (node.type === "text") return node.text ? [runFromText(node)] : [];
+  const runs: InlineRun[] = [];
+  for (const child of node.content ?? []) runs.push(...collectRuns(child));
+  return runs;
+}
+
+/**
+ * Projects a restricted TipTap document into linear `RichBlock`s. Empty
+ * paragraphs and empty list items are dropped so an untouched editor yields `[]`.
+ */
+export function tiptapToRichBlocks(doc: JSONContent | undefined): RichBlock[] {
+  const blocks: RichBlock[] = [];
+  for (const node of doc?.content ?? []) {
+    if (node.type === "bulletList" || node.type === "orderedList") {
+      const items: InlineRun[][] = [];
+      for (const item of node.content ?? []) {
+        const runs = collectRuns(item);
+        if (runs.length > 0) items.push(runs);
+      }
+      if (items.length > 0) {
+        blocks.push({
+          type: "list",
+          ordered: node.type === "orderedList",
+          items,
+        });
+      }
+      continue;
+    }
+    const runs = collectRuns(node);
+    if (runs.length > 0) blocks.push({ type: "paragraph", runs });
+  }
+  return blocks;
+}
+
+/** True when the blocks hold no non-whitespace text (used to gate empty fields). */
+export function isRichEmpty(blocks: RichBlock[]): boolean {
+  const hasText = (runs: InlineRun[]) => runs.some((run) => run.text.trim());
+  return !blocks.some((block) =>
+    block.type === "paragraph"
+      ? hasText(block.runs)
+      : block.items.some(hasText),
+  );
+}


### PR DESCRIPTION
Phase 1 of the export pipeline. Introduces the rich content model so **bold / italic / links** and **bullet / ordered lists** render in the preview instead of collapsing to plain text — and this same model is what the PDF / txt / docx exporters will consume next.

## Changes
- **`rich-content.ts`** — export-neutral `InlineRun` / `RichBlock` types, `tiptapToRichBlocks()` (walks the restricted TipTap JSON), `isRichEmpty()`.
- **`resume-rich-text.tsx`** — shared DOM renderer (`strong`/`em`/`a`, `ul`/`ol`); renders nothing when empty.
- **`ResumePreview`** — `summary`, experience `description`, education `details` are now `RichBlock[]`.
- **Adapter** — maps via `tiptapToRichBlocks`; dropped the old plain-text flatteners. **Education details now render** (were silently dropped before).
- **Blocks** — summary block carries `RichBlock[]`; empty-section gating uses `isRichEmpty`.

## Verification
- `tsc --noEmit` and `biome check src` clean.
- No schema/persistence change — purely the preview projection + rendering.

## Notes
- Scoped to the preview only. The @react-pdf document, Inter font embedding, and the export button are the next increments.