### PR TITLE
feat: export résumé to plain text and .docx

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.4.0",
+    "docx": "^9.7.1",
     "embla-carousel-react": "^8.6.0",
     "idb": "^8.0.3",
     "input-otp": "^1.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       date-fns:
         specifier: ^4.4.0
         version: 4.4.0
+      docx:
+        specifier: ^9.7.1
+        version: 9.7.1
       embla-carousel-react:
         specifier: ^8.6.0
         version: 8.6.0(react@19.2.4)
@@ -1450,6 +1453,9 @@ packages:
   '@types/node@20.19.43':
     resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
 
+  '@types/node@25.9.4':
+    resolution: {integrity: sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -1778,6 +1784,9 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
@@ -1940,6 +1949,10 @@ packages:
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
+
+  docx@9.7.1:
+    resolution: {integrity: sha512-ilXFf9Moz47ABjFpDiA5s1w9lpb4EFSp7+5iiJSbfyYDM+bpZdAgLlSr7fW4aXhVe/E+F6QCv0EvRVFEd5CsWg==}
+    engines: {node: '>=10'}
 
   dot-prop@6.0.1:
     resolution: {integrity: sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==}
@@ -2258,6 +2271,9 @@ packages:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
+  hash.js@1.1.7:
+    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
+
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
@@ -2309,6 +2325,9 @@ packages:
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
+
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
   immer@10.2.0:
     resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
@@ -2483,6 +2502,9 @@ packages:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -2539,6 +2561,9 @@ packages:
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
@@ -2549,6 +2574,9 @@ packages:
 
   libphonenumber-js@1.13.7:
     resolution: {integrity: sha512-rvr3HIMdOgzhz1RFGjftji+wjoAFlzhqCNqJOU/MKTZQ8d9NZxAR/tI+0weDicyoucqVR0U1GCniqHJ0f8aM2A==}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -2739,6 +2767,9 @@ packages:
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -3011,6 +3042,9 @@ packages:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -3164,6 +3198,9 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
@@ -3253,11 +3290,18 @@ packages:
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sax@1.6.0:
+    resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
+    engines: {node: '>=11.0.0'}
 
   scheduler@0.25.0-rc-603e6108-20241029:
     resolution: {integrity: sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==}
@@ -3281,6 +3325,9 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -3373,6 +3420,9 @@ packages:
   string-width@8.2.1:
     resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
     engines: {node: '>=20'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -3499,6 +3549,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
@@ -3618,6 +3671,13 @@ packages:
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
+
+  xml-js@1.6.11:
+    resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
+    hasBin: true
+
+  xml@1.0.1:
+    resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -4942,6 +5002,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@25.9.4':
+    dependencies:
+      undici-types: 7.24.6
+
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
       '@types/react': 19.2.17
@@ -5260,6 +5324,8 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  core-util-is@1.0.3: {}
+
   cors@2.8.6:
     dependencies:
       object-assign: 4.1.1
@@ -5391,6 +5457,15 @@ snapshots:
   dfa@1.2.0: {}
 
   diff@8.0.4: {}
+
+  docx@9.7.1:
+    dependencies:
+      '@types/node': 25.9.4
+      hash.js: 1.1.7
+      jszip: 3.10.1
+      nanoid: 5.1.16
+      xml: 1.0.1
+      xml-js: 1.6.11
 
   dot-prop@6.0.1:
     dependencies:
@@ -5738,6 +5813,11 @@ snapshots:
 
   has-symbols@1.1.0: {}
 
+  hash.js@1.1.7:
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
@@ -5779,6 +5859,8 @@ snapshots:
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
+
+  immediate@3.0.6: {}
 
   immer@10.2.0: {}
 
@@ -5914,6 +5996,8 @@ snapshots:
     dependencies:
       is-inside-container: 1.0.0
 
+  isarray@1.0.0: {}
+
   isexe@2.0.0: {}
 
   isexe@3.1.5: {}
@@ -5954,11 +6038,22 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   kleur@3.0.3: {}
 
   kleur@4.1.5: {}
 
   libphonenumber-js@1.13.7: {}
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -6114,6 +6209,8 @@ snapshots:
   mimic-fn@3.1.0: {}
 
   mimic-function@5.0.1: {}
+
+  minimalistic-assert@1.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -6352,6 +6449,8 @@ snapshots:
     dependencies:
       parse-ms: 4.0.0
 
+  process-nextick-args@2.0.1: {}
+
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
@@ -6536,6 +6635,16 @@ snapshots:
 
   react@19.2.4: {}
 
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
@@ -6633,9 +6742,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  safe-buffer@5.1.2: {}
+
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
+
+  sax@1.6.0: {}
 
   scheduler@0.25.0-rc-603e6108-20241029: {}
 
@@ -6669,6 +6782,8 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  setimmediate@1.0.5: {}
 
   setprototypeof@1.2.0: {}
 
@@ -6826,6 +6941,10 @@ snapshots:
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
 
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -6919,6 +7038,8 @@ snapshots:
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  undici-types@7.24.6: {}
 
   undici@7.28.0: {}
 
@@ -7045,6 +7166,12 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
+
+  xml-js@1.6.11:
+    dependencies:
+      sax: 1.6.0
+
+  xml@1.0.1: {}
 
   y18n@5.0.8: {}
 

--- a/src/components/editor/docx/download-resume-docx.ts
+++ b/src/components/editor/docx/download-resume-docx.ts
@@ -1,0 +1,17 @@
+import { Packer } from "docx";
+import { safeFileName, triggerDownload } from "../download-file";
+import type { ResumePreview } from "../resume-preview";
+import { buildAwalDocx } from "./resume-to-docx";
+
+/**
+ * Builds the .docx entirely in the browser and downloads it as `<fileName>.docx`.
+ * No résumé content leaves the device. Loaded lazily by the download button so
+ * the docx library stays out of the main bundle.
+ */
+export async function downloadResumeDocx(
+  preview: ResumePreview,
+  fileName: string,
+): Promise<void> {
+  const blob = await Packer.toBlob(buildAwalDocx(preview));
+  triggerDownload(blob, `${safeFileName(fileName)}.docx`);
+}

--- a/src/components/editor/docx/resume-to-docx.ts
+++ b/src/components/editor/docx/resume-to-docx.ts
@@ -1,0 +1,218 @@
+import {
+  BorderStyle,
+  Document,
+  ExternalHyperlink,
+  Paragraph,
+  TabStopType,
+  TextRun,
+} from "docx";
+import { buildResumeBlocks } from "../resume-blocks";
+import type { ContactView, HeaderView, ResumePreview } from "../resume-preview";
+import type { InlineRun, RichBlock } from "../rich-content";
+
+const MUTED = "525252";
+/** Right page edge in twips for A4 with default 1-inch margins (11906 − 2·1440). */
+const RIGHT_TAB = 9026;
+
+function dateRange(start: string, end: string): string {
+  if (!start && !end) return "";
+  return `${start} - ${end}`;
+}
+
+function inlineRuns(runs: InlineRun[]): (TextRun | ExternalHyperlink)[] {
+  return runs.map((run) => {
+    const child = new TextRun({
+      text: run.text,
+      bold: run.bold,
+      italics: run.italic,
+    });
+    return run.href
+      ? new ExternalHyperlink({ link: run.href, children: [child] })
+      : child;
+  });
+}
+
+function richParagraphs(blocks: RichBlock[]): Paragraph[] {
+  const paragraphs: Paragraph[] = [];
+  for (const block of blocks) {
+    if (block.type === "paragraph") {
+      paragraphs.push(
+        new Paragraph({
+          children: inlineRuns(block.runs),
+          spacing: { after: 80 },
+        }),
+      );
+      continue;
+    }
+    for (const item of block.items) {
+      paragraphs.push(
+        new Paragraph({
+          children: inlineRuns(item),
+          bullet: { level: 0 },
+          spacing: { after: 40 },
+        }),
+      );
+    }
+  }
+  return paragraphs;
+}
+
+function sectionHeading(title: string): Paragraph {
+  return new Paragraph({
+    spacing: { before: 220, after: 100 },
+    border: {
+      bottom: { style: BorderStyle.SINGLE, size: 4, space: 2, color: "A3A3A3" },
+    },
+    children: [
+      new TextRun({ text: title.toUpperCase(), bold: true, size: 20 }),
+    ],
+  });
+}
+
+/** A "Title …… Dates" row with the date right-aligned via a tab stop. */
+function titleRow(title: string, date: string): Paragraph {
+  return new Paragraph({
+    tabStops: [{ type: TabStopType.RIGHT, position: RIGHT_TAB }],
+    children: [
+      new TextRun({ text: title, bold: true, size: 19 }),
+      ...(date ? [new TextRun({ text: `\t${date}`, color: MUTED })] : []),
+    ],
+  });
+}
+
+function subtitle(text: string, href?: string): Paragraph {
+  const child = new TextRun({ text, color: MUTED });
+  return new Paragraph({
+    spacing: { after: 40 },
+    children: [
+      href ? new ExternalHyperlink({ link: href, children: [child] }) : child,
+    ],
+  });
+}
+
+function headerParagraphs(header: HeaderView): Paragraph[] {
+  const paragraphs: Paragraph[] = [
+    new Paragraph({
+      children: [new TextRun({ text: header.fullName, bold: true, size: 36 })],
+    }),
+  ];
+  if (header.headline) {
+    paragraphs.push(
+      new Paragraph({
+        spacing: { after: 80 },
+        children: [
+          new TextRun({ text: header.headline, size: 21, color: MUTED }),
+        ],
+      }),
+    );
+  }
+  if (header.contacts.length > 0) {
+    paragraphs.push(
+      new Paragraph({
+        spacing: { after: 80 },
+        children: contactRuns(header.contacts),
+      }),
+    );
+  }
+  return paragraphs;
+}
+
+function contactRuns(contacts: ContactView[]): (TextRun | ExternalHyperlink)[] {
+  const runs: (TextRun | ExternalHyperlink)[] = [];
+  contacts.forEach((contact, index) => {
+    if (index > 0) runs.push(new TextRun({ text: "   |   ", color: MUTED }));
+    const child = new TextRun({ text: contact.value });
+    runs.push(
+      contact.href
+        ? new ExternalHyperlink({ link: contact.href, children: [child] })
+        : child,
+    );
+  });
+  return runs;
+}
+
+function gridParagraphs(
+  items: { name: string; proficiency: string }[],
+): Paragraph[] {
+  return items.map(
+    (item) =>
+      new Paragraph({
+        spacing: { after: 20 },
+        children: [
+          new TextRun({ text: item.name, bold: true }),
+          ...(item.proficiency
+            ? [new TextRun({ text: ` — ${item.proficiency}`, color: MUTED })]
+            : []),
+        ],
+      }),
+  );
+}
+
+/**
+ * Builds the résumé as a .docx `Document` in linear reading order, reusing
+ * `buildResumeBlocks` so content, ordering, sorting, and empty-section gating
+ * match the preview and other exports. No tables or columns are used, so the
+ * document stays ATS-parseable; marks (bold/italic/links) and bullets are kept.
+ */
+export function buildAwalDocx(preview: ResumePreview): Document {
+  const children: Paragraph[] = [];
+
+  for (const block of buildResumeBlocks(preview)) {
+    switch (block.kind) {
+      case "header":
+        children.push(...headerParagraphs(block.header));
+        break;
+      case "heading":
+        children.push(sectionHeading(block.title));
+        break;
+      case "summary":
+        children.push(...richParagraphs(block.body));
+        break;
+      case "experience": {
+        const item = block.item;
+        children.push(
+          titleRow(item.role, dateRange(item.startDate, item.endDate)),
+        );
+        if (item.company)
+          children.push(subtitle(item.company, item.companyHref));
+        children.push(...richParagraphs(item.description));
+        break;
+      }
+      case "education": {
+        const item = block.item;
+        children.push(
+          titleRow(item.degree, dateRange(item.startDate, item.endDate)),
+        );
+        if (item.institution) children.push(subtitle(item.institution));
+        children.push(...richParagraphs(item.details));
+        break;
+      }
+      case "certificate": {
+        const item = block.item;
+        children.push(
+          titleRow(item.title, dateRange(item.startDate, item.endDate)),
+        );
+        if (item.issuer) children.push(subtitle(item.issuer));
+        break;
+      }
+      case "skills":
+      case "languages":
+        children.push(...gridParagraphs(block.items));
+        break;
+    }
+  }
+
+  return new Document({
+    styles: {
+      default: {
+        document: { run: { font: "Calibri", size: 20, color: "0A0A0A" } },
+      },
+    },
+    sections: [
+      {
+        properties: { page: { size: { width: 11906, height: 16838 } } },
+        children,
+      },
+    ],
+  });
+}

--- a/src/components/editor/download-file.ts
+++ b/src/components/editor/download-file.ts
@@ -1,0 +1,22 @@
+/**
+ * Sanitizes a user-typed file name: strips characters illegal in file names and
+ * a redundant trailing extension, preserving spaces and case. Falls back to
+ * "resume" when nothing usable remains.
+ */
+export function safeFileName(name: string): string {
+  const cleaned = name
+    .replace(/\.(pdf|docx|txt)$/i, "")
+    .replace(/[\\/:*?"<>|]+/g, "-")
+    .trim();
+  return cleaned || "resume";
+}
+
+/** Triggers a browser download of `blob` as `fileName`, revoking the object URL. */
+export function triggerDownload(blob: Blob, fileName: string): void {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = fileName;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}

--- a/src/components/editor/download-resume-text.ts
+++ b/src/components/editor/download-resume-text.ts
@@ -1,0 +1,14 @@
+import { safeFileName, triggerDownload } from "./download-file";
+import type { ResumePreview } from "./resume-preview";
+import { resumeToText } from "./resume-to-text";
+
+/** Serializes `preview` to plain text and downloads it as `<fileName>.txt`. */
+export function downloadResumeText(
+  preview: ResumePreview,
+  fileName: string,
+): void {
+  const blob = new Blob([resumeToText(preview)], {
+    type: "text/plain;charset=utf-8",
+  });
+  triggerDownload(blob, `${safeFileName(fileName)}.txt`);
+}

--- a/src/components/editor/pdf/download-resume-pdf.tsx
+++ b/src/components/editor/pdf/download-resume-pdf.tsx
@@ -1,20 +1,8 @@
 import { pdf } from "@react-pdf/renderer";
+import { safeFileName, triggerDownload } from "../download-file";
 import type { ResumePreview } from "../resume-preview";
 import { registerAwalFonts } from "./awal-fonts";
 import { AwalPdfDocument } from "./awal-pdf-document";
-
-/**
- * Sanitizes a user-typed file name: strips characters illegal in file names and
- * a redundant trailing ".pdf", preserving spaces and case. Falls back to
- * "resume" when nothing usable remains.
- */
-function safeFileName(name: string): string {
-  const cleaned = name
-    .replace(/\.pdf$/i, "")
-    .replace(/[\\/:*?"<>|]+/g, "-")
-    .trim();
-  return cleaned || "resume";
-}
 
 /**
  * Generates the Awal PDF for `preview` entirely in the browser and triggers a
@@ -28,10 +16,5 @@ export async function downloadResumePdf(
 ): Promise<void> {
   registerAwalFonts();
   const blob = await pdf(<AwalPdfDocument preview={preview} />).toBlob();
-  const url = URL.createObjectURL(blob);
-  const anchor = document.createElement("a");
-  anchor.href = url;
-  anchor.download = `${safeFileName(fileName)}.pdf`;
-  anchor.click();
-  URL.revokeObjectURL(url);
+  triggerDownload(blob, `${safeFileName(fileName)}.pdf`);
 }

--- a/src/components/editor/resume-to-text.ts
+++ b/src/components/editor/resume-to-text.ts
@@ -1,0 +1,73 @@
+import { buildResumeBlocks } from "./resume-blocks";
+import type { ResumePreview } from "./resume-preview";
+import { richBlocksToText } from "./rich-content";
+
+function dateRange(start: string, end: string): string {
+  if (!start && !end) return "";
+  return `${start} - ${end}`;
+}
+
+/** "Role — Company — Dates", dropping whichever parts are absent. */
+function metaLine(...parts: string[]): string {
+  return parts.filter(Boolean).join(" — ");
+}
+
+/**
+ * Serializes the résumé to plain text in linear reading order — the ATS-safest
+ * format. Reuses `buildResumeBlocks` so the content, ordering, sorting, and
+ * empty-section gating match the preview and the PDF exactly.
+ */
+export function resumeToText(preview: ResumePreview): string {
+  const lines: string[] = [];
+
+  for (const block of buildResumeBlocks(preview)) {
+    switch (block.kind) {
+      case "header": {
+        const { fullName, headline, contacts } = block.header;
+        if (fullName) lines.push(fullName);
+        if (headline) lines.push(headline);
+        for (const contact of contacts) lines.push(contact.value);
+        break;
+      }
+      case "heading":
+        lines.push("", block.title.toUpperCase());
+        break;
+      case "summary":
+        lines.push(...richBlocksToText(block.body));
+        break;
+      case "experience": {
+        const { role, company, startDate, endDate, description } = block.item;
+        lines.push(metaLine(role, company, dateRange(startDate, endDate)));
+        lines.push(...richBlocksToText(description));
+        lines.push("");
+        break;
+      }
+      case "education": {
+        const { degree, institution, startDate, endDate, details } = block.item;
+        lines.push(
+          metaLine(degree, institution, dateRange(startDate, endDate)),
+        );
+        lines.push(...richBlocksToText(details));
+        lines.push("");
+        break;
+      }
+      case "certificate": {
+        const { title, issuer, startDate, endDate } = block.item;
+        lines.push(metaLine(title, issuer, dateRange(startDate, endDate)));
+        break;
+      }
+      case "skills":
+      case "languages":
+        for (const item of block.items) {
+          lines.push(metaLine(item.name, item.proficiency));
+        }
+        break;
+    }
+  }
+
+  // Collapse runs of blank lines and normalize to a single trailing newline.
+  return `${lines
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim()}\n`;
+}

--- a/src/components/editor/rich-content.ts
+++ b/src/components/editor/rich-content.ts
@@ -78,3 +78,31 @@ export function isRichEmpty(blocks: RichBlock[]): boolean {
       : block.items.some(hasText),
   );
 }
+
+function runsText(runs: InlineRun[]): string {
+  return runs
+    .map((run) => run.text)
+    .join("")
+    .trim();
+}
+
+/**
+ * Flattens rich blocks to plain-text lines — one per paragraph, and each list
+ * item prefixed with "- " — for the .txt export. Marks are dropped (plain text
+ * carries no formatting); reading order is preserved.
+ */
+export function richBlocksToText(blocks: RichBlock[]): string[] {
+  const lines: string[] = [];
+  for (const block of blocks) {
+    if (block.type === "paragraph") {
+      const text = runsText(block.runs);
+      if (text) lines.push(text);
+      continue;
+    }
+    for (const item of block.items) {
+      const text = runsText(item);
+      if (text) lines.push(`- ${text}`);
+    }
+  }
+  return lines;
+}

--- a/src/components/platform/platform-navbar-download.tsx
+++ b/src/components/platform/platform-navbar-download.tsx
@@ -22,12 +22,18 @@ import {
   PopoverTrigger,
 } from "../ui/popover";
 import { Spinner } from "../ui/spinner";
+import { ToggleGroup, ToggleGroupItem } from "../ui/toggle-group";
+
+type ExportFormat = "pdf" | "docx" | "txt";
+
+const FORMATS: ExportFormat[] = ["pdf", "docx", "txt"];
 
 export function PlatformNavbarDownload() {
   const pathname = usePathname();
   const open = useResumeStore((state) => state.open);
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [fileName, setFileName] = useState("");
+  const [format, setFormat] = useState<ExportFormat>("pdf");
   const [generating, setGenerating] = useState(false);
 
   if (!pathname.includes("/editor/")) return null;
@@ -42,11 +48,24 @@ export function PlatformNavbarDownload() {
     if (!open) return;
     setGenerating(true);
     try {
-      // Lazy-loaded so @react-pdf stays out of the main bundle until needed.
-      const { downloadResumePdf } = await import(
-        "@/components/editor/pdf/download-resume-pdf"
-      );
-      await downloadResumePdf(resumeToPreview(open), fileName);
+      // Lazy-loaded so the heavy PDF/docx libraries stay out of the main bundle.
+      const preview = resumeToPreview(open);
+      if (format === "pdf") {
+        const { downloadResumePdf } = await import(
+          "@/components/editor/pdf/download-resume-pdf"
+        );
+        await downloadResumePdf(preview, fileName);
+      } else if (format === "docx") {
+        const { downloadResumeDocx } = await import(
+          "@/components/editor/docx/download-resume-docx"
+        );
+        await downloadResumeDocx(preview, fileName);
+      } else {
+        const { downloadResumeText } = await import(
+          "@/components/editor/download-resume-text"
+        );
+        downloadResumeText(preview, fileName);
+      }
       setPopoverOpen(false);
     } finally {
       setGenerating(false);
@@ -61,7 +80,9 @@ export function PlatformNavbarDownload() {
       <PopoverContent align="end">
         <PopoverHeader>
           <PopoverTitle>Download résumé</PopoverTitle>
-          <PopoverDescription>Name your PDF file.</PopoverDescription>
+          <PopoverDescription>
+            Pick a format and name your file.
+          </PopoverDescription>
         </PopoverHeader>
 
         <form
@@ -71,6 +92,26 @@ export function PlatformNavbarDownload() {
           }}
         >
           <Field>
+            <FieldLabel>Format</FieldLabel>
+            <ToggleGroup
+              variant="outline"
+              spacing={0}
+              className="w-full"
+              value={[format]}
+              onValueChange={(value) => {
+                const next = value[0] as ExportFormat | undefined;
+                if (next) setFormat(next);
+              }}
+            >
+              {FORMATS.map((value) => (
+                <ToggleGroupItem key={value} value={value} className="flex-1">
+                  {value.toUpperCase()}
+                </ToggleGroupItem>
+              ))}
+            </ToggleGroup>
+          </Field>
+
+          <Field className="mt-3">
             <FieldLabel htmlFor="download-file-name">File name</FieldLabel>
             <InputGroup>
               <InputGroupInput
@@ -80,7 +121,7 @@ export function PlatformNavbarDownload() {
                 onChange={(event) => setFileName(event.target.value)}
               />
               <InputGroupAddon align="inline-end">
-                <InputGroupText>.pdf</InputGroupText>
+                <InputGroupText>.{format}</InputGroupText>
               </InputGroupAddon>
             </InputGroup>
           </Field>


### PR DESCRIPTION
Phase 3 of the export pipeline. Adds the **ATS-safe `.txt` and `.docx`** export paths alongside PDF.

## How it works
All three exporters read the **same `buildResumeBlocks` linear model** as the preview and PDF, so content, ordering, date sorting, and empty-section gating are identical across every output.

- **`resume-to-text.ts`** — plain-text serializer in reading order (the ATS-safest format): `Role — Company — Dates`, `- ` bullets, uppercase section headings.
- **`docx/resume-to-docx.ts`** — builds a `.docx` `Document` with headings (bottom border), **bold/italic/links**, and bullet lists. **No tables or columns**, so it stays ATS-parseable; right-aligned dates use a tab stop, not a table.
- **`rich-content.ts`** — `richBlocksToText()` flattens the shared rich model to text lines.
- **`download-file.ts`** — shared `safeFileName` + `triggerDownload`; the PDF download was refactored onto these.
- **Download popover** — now has a **format picker (PDF / DOCX / TXT)** with a dynamic `.<ext>` addon. Each exporter is **lazy-loaded**, so react-pdf and docx stay out of the main bundle until used.

## Verification
- `tsc --noEmit` + `biome check` clean.
- Node smoke of the seed → correct **linear plain text** (verified reading order across all sections) and a **valid `.docx`** (`PK` zip, ~10 KB).

## Deps
- `docx`

## Next
- **Phase 4** — the parser-validation pass (pdftotext + a real résumé parser / Workday/Greenhouse test upload) across all three formats, per AGENTS.md.