### PR TITLE
test: add automated export text-extraction validation gate

### DIFF
--- a/docs/export-validation.md
+++ b/docs/export-validation.md
@@ -41,3 +41,18 @@ land in the right slots. Do this at least once per meaningful export change:
 - [ ] If available, upload to a real ATS sandbox (Greenhouse / Workday test posting) and
       confirm the parsed application is complete and correctly ordered.
 - [ ] Confirm no content is dropped and no section is reordered.
+
+## Parser notes
+
+Real parsers (e.g. [OpenResume](https://www.open-resume.com)) use strict heuristics.
+Decisions made to satisfy them:
+
+- **Website is exported as a full `https://` URL**, not a bare domain. Parsers only
+  recognize a link when it has a scheme (`https://…`), a `www.` prefix, or a path
+  slash — `johndoe.dev` alone is not detected.
+- **Contact icons are drawn as vector SVG**, so they never appear in the extracted
+  text and can't interfere with field detection.
+- **Location** relies on the parser. OpenResume, for one, only matches US-style
+  `City, ST` with a **two-letter** state (regex `[A-Z][a-zA-Z\s]+, [A-Z]{2}`); a full
+  "City, Province, Country" won't be detected as a location. This is a parser
+  limitation, not an export defect — entering a 2-letter state code makes it parse.

--- a/docs/export-validation.md
+++ b/docs/export-validation.md
@@ -1,0 +1,43 @@
+# Export validation
+
+The résumé exports (PDF, `.docx`, `.txt`) must stay **ATS-parseable**: real, selectable
+text in linear reading order, with every field mappable by a parser. Two layers of
+verification back this up.
+
+## 1. Automated text-extraction gate
+
+```bash
+pnpm validate:exports
+```
+
+`scripts/validate-exports.tsx` regenerates all three exports from the seed résumé and
+extracts their text with real parsers — `unpdf` for the PDF, `jszip` for the `.docx`
+XML, and the serializer output for `.txt`. It then asserts:
+
+- **Reading order** — `Summary → Experience → Education → Certificates → Skills →
+  Languages` appears in that order in every format.
+- **Field mapping** — name, headline, email, website, each employer, education,
+  certificate, a representative skill, and a language are all present in the extracted
+  text.
+
+This is the pdftotext-equivalent text-extraction test required by `AGENTS.md`. **Run it
+after any change to an export path** (`pdf/`, `docx/`, `resume-to-text.ts`,
+`buildResumeBlocks`, or the rich-content model). It exits non-zero on failure.
+
+Because all three exporters consume the same `buildResumeBlocks` sequence as the
+on-screen preview, passing here means content, ordering, sorting, and empty-section
+gating match across the preview and every output.
+
+## 2. Manual real-parser pass (before release)
+
+The automated gate proves text is extractable and ordered; a real ATS proves the fields
+land in the right slots. Do this at least once per meaningful export change:
+
+- [ ] Open the PDF in a viewer and confirm text is **selectable** (not an image) and
+      copies out in reading order.
+- [ ] Run the PDF and `.docx` through an open-source résumé parser (e.g. Affinda's free
+      tool, or `pyresparser`) — confirm **name, email, phone, work history, education,
+      and skills** map to the correct fields.
+- [ ] If available, upload to a real ATS sandbox (Greenhouse / Workday test posting) and
+      confirm the parsed application is complete and correctly ordered.
+- [ ] Confirm no content is dropped and no section is reordered.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "biome check",
     "format": "biome format --write",
+    "validate:exports": "tsx scripts/validate-exports.tsx",
     "commit": "cz",
     "ui:add": "pnpm dlx shadcn add",
     "prepare": "husky"
@@ -75,9 +76,12 @@
     "@types/react-dom": "^19",
     "babel-plugin-react-compiler": "1.0.0",
     "husky": "^9.1.7",
+    "jszip": "^3.10.1",
     "lint-staged": "^17.0.8",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "tsx": "^4.22.5",
+    "typescript": "^5",
+    "unpdf": "^1.6.2"
   },
   "config": {
     "commitizen": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,15 +189,24 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
       lint-staged:
         specifier: ^17.0.8
         version: 17.0.8
       tailwindcss:
         specifier: ^4
         version: 4.3.2
+      tsx:
+        specifier: ^4.22.5
+        version: 4.22.5
       typescript:
         specifier: ^5
         version: 5.9.3
+      unpdf:
+        specifier: ^1.6.2
+        version: 1.6.2
 
 packages:
 
@@ -548,6 +557,162 @@ packages:
 
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -2032,6 +2197,11 @@ packages:
   es-toolkit@1.49.0:
     resolution: {integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==}
 
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -2183,6 +2353,11 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -3530,6 +3705,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.22.5:
+    resolution: {integrity: sha512-F7JnSfPl5ASt6LqwWyUQ3T8BwN3q0eQEbFMYa2iRWaVQmmudo0d7fRmwM4O002gsvW1bs0yBYioutsAjqLJMvQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
@@ -3569,6 +3749,14 @@ packages:
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
+
+  unpdf@1.6.2:
+    resolution: {integrity: sha512-zQ80ySoPuPHOsvIoRp/nJyQt8TOUoTh1+WBCGcBvlddQNgKDLRwm0AY3x8Q35I7+kIiRSgqMx+Ma2pl9McIp7A==}
+    peerDependencies:
+      '@napi-rs/canvas': ^0.1.69
+    peerDependenciesMeta:
+      '@napi-rs/canvas':
+        optional: true
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -4177,6 +4365,84 @@ snapshots:
   '@emnapi/runtime@1.11.1':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@floating-ui/core@1.7.5':
@@ -5531,6 +5797,35 @@ snapshots:
 
   es-toolkit@1.49.0: {}
 
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
+
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
@@ -5724,6 +6019,9 @@ snapshots:
       universalify: 2.0.1
 
   fs.realpath@1.0.0: {}
+
+  fsevents@2.3.3:
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -7025,6 +7323,12 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.22.5:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
   tw-animate-css@1.4.0: {}
 
   type-fest@0.21.3: {}
@@ -7056,6 +7360,8 @@ snapshots:
   unicorn-magic@0.3.0: {}
 
   universalify@2.0.1: {}
+
+  unpdf@1.6.2: {}
 
   unpipe@1.0.0: {}
 

--- a/scripts/validate-exports.tsx
+++ b/scripts/validate-exports.tsx
@@ -1,0 +1,147 @@
+/**
+ * Parser-validation pass (AGENTS.md export gate). Regenerates the PDF, .docx, and
+ * .txt exports from the seed résumé and verifies, via real text extraction, that
+ * each output preserves linear reading order and that every field maps through.
+ * This is the automated "text-extraction test" (pdftotext-equivalent) that must
+ * pass after any change to an export path. Run: `pnpm validate:exports`.
+ */
+import { Font, renderToBuffer } from "@react-pdf/renderer";
+import { Packer } from "docx";
+import JSZip from "jszip";
+import { extractText, getDocumentProxy } from "unpdf";
+import { buildAwalDocx } from "@/components/editor/docx/resume-to-docx";
+import { AwalPdfDocument } from "@/components/editor/pdf/awal-pdf-document";
+import { resumeToPreview } from "@/components/editor/resume-to-preview";
+import { resumeToText } from "@/components/editor/resume-to-text";
+import { SEED_RESUME } from "@/lib/resume/seed";
+
+const root = process.cwd();
+
+function registerFonts(): void {
+  Font.register({
+    family: "Inter",
+    fonts: [
+      { src: `${root}/public/fonts/Inter-Regular.ttf`, fontWeight: 400 },
+      { src: `${root}/public/fonts/Inter-SemiBold.ttf`, fontWeight: 600 },
+      { src: `${root}/public/fonts/Inter-Bold.ttf`, fontWeight: 700 },
+      {
+        src: `${root}/public/fonts/Inter-Italic.ttf`,
+        fontWeight: 400,
+        fontStyle: "italic",
+      },
+      {
+        src: `${root}/public/fonts/Inter-BoldItalic.ttf`,
+        fontWeight: 700,
+        fontStyle: "italic",
+      },
+    ],
+  });
+  Font.registerHyphenationCallback((word) => [word]);
+}
+
+/** Section headings in the order the linear document must present them. */
+const SECTION_ORDER = [
+  "SUMMARY",
+  "EXPERIENCE",
+  "EDUCATION",
+  "CERTIFICATES",
+  "SKILLS",
+  "LANGUAGES",
+];
+
+/** Fields (from the seed) that every export must carry so a parser can map them. */
+const REQUIRED_FIELDS = [
+  "John Doe",
+  "Senior Frontend Engineer",
+  "john.doe@example.com",
+  "johndoe.dev",
+  "Acme Corp",
+  "Globex",
+  "Led migration",
+  "State University",
+  "AWS Certified Solutions Architect",
+  "TypeScript",
+  "English",
+];
+
+function checkReadingOrder(text: string, label: string): string[] {
+  const errors: string[] = [];
+  const haystack = text.toUpperCase();
+  let previous = -1;
+  for (const section of SECTION_ORDER) {
+    const index = haystack.indexOf(section);
+    if (index === -1) {
+      errors.push(`${label}: section "${section}" missing`);
+    } else if (index < previous) {
+      errors.push(`${label}: section "${section}" out of reading order`);
+    } else {
+      previous = index;
+    }
+  }
+  return errors;
+}
+
+function checkFields(text: string, label: string): string[] {
+  return REQUIRED_FIELDS.filter((field) => !text.includes(field)).map(
+    (field) => `${label}: field "${field}" not found in extracted text`,
+  );
+}
+
+async function extractPdfText(buffer: Uint8Array): Promise<string> {
+  const pdf = await getDocumentProxy(new Uint8Array(buffer));
+  const { text } = await extractText(pdf, { mergePages: true });
+  return text;
+}
+
+async function extractDocxText(buffer: Buffer): Promise<string> {
+  const zip = await JSZip.loadAsync(buffer);
+  const document = zip.file("word/document.xml");
+  if (!document) throw new Error("word/document.xml missing from .docx");
+  const xml = await document.async("string");
+  return xml
+    .replace(/<\/w:p>/g, "\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">");
+}
+
+async function main(): Promise<void> {
+  registerFonts();
+  const preview = resumeToPreview(SEED_RESUME);
+
+  const txt = resumeToText(preview);
+  const pdf = await extractPdfText(
+    await renderToBuffer(<AwalPdfDocument preview={preview} />),
+  );
+  const docx = await extractDocxText(
+    await Packer.toBuffer(buildAwalDocx(preview)),
+  );
+
+  const outputs: [string, string][] = [
+    ["TXT", txt],
+    ["PDF", pdf],
+    ["DOCX", docx],
+  ];
+
+  const errors: string[] = [];
+  for (const [label, text] of outputs) {
+    console.log(`${label}: extracted ${text.length} chars`);
+    errors.push(...checkReadingOrder(text, label), ...checkFields(text, label));
+  }
+
+  if (errors.length > 0) {
+    for (const error of errors) console.error(`  ✗ ${error}`);
+    console.error(`\n${errors.length} validation failure(s).`);
+    process.exit(1);
+  }
+
+  console.log(
+    "\n✓ All exports preserve reading order and carry every field (PDF, DOCX, TXT).",
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/components/editor/pdf/awal-pdf-document.tsx
+++ b/src/components/editor/pdf/awal-pdf-document.tsx
@@ -1,14 +1,19 @@
 import {
+  Circle,
   Document,
   Link,
   Page,
+  Path,
+  Rect,
   StyleSheet,
+  Svg,
   Text,
   View,
 } from "@react-pdf/renderer";
 import { buildResumeBlocks, type ResumeBlock } from "../resume-blocks";
 import type {
   CertificateItemView,
+  ContactKind,
   EducationItemView,
   ExperienceItemView,
   HeaderView,
@@ -37,8 +42,8 @@ const styles = StyleSheet.create({
   headerLeft: { flexShrink: 1 },
   name: { fontSize: 18, fontWeight: 700, lineHeight: 1.25 },
   headline: { marginTop: 2, fontSize: 10.5, color: PDF_COLORS.muted },
-  headerRight: { alignItems: "flex-end", gap: 2 },
-  contact: { fontSize: 9 },
+  headerRight: { alignItems: "flex-start", gap: 3 },
+  contactRow: { flexDirection: "row", alignItems: "center", gap: 4 },
   linkPlain: { color: PDF_COLORS.foreground, textDecoration: "none" },
   heading: {
     fontSize: 10,
@@ -80,6 +85,52 @@ function dateRange(start: string, end: string): string {
   return `${start} - ${end}`;
 }
 
+const ICON = {
+  stroke: PDF_COLORS.muted,
+  strokeWidth: 2,
+  fill: "none",
+} as const;
+
+/** lucide-equivalent contact glyphs, drawn as vector SVG (not text). */
+function PdfContactIcon(props: { kind: ContactKind }) {
+  switch (props.kind) {
+    case "phone":
+      return (
+        <Svg width={8} height={8} viewBox="0 0 24 24">
+          <Path
+            {...ICON}
+            d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"
+          />
+        </Svg>
+      );
+    case "email":
+      return (
+        <Svg width={8} height={8} viewBox="0 0 24 24">
+          <Rect {...ICON} x={2} y={4} width={20} height={16} rx={2} />
+          <Path {...ICON} d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+        </Svg>
+      );
+    case "website":
+      return (
+        <Svg width={8} height={8} viewBox="0 0 24 24">
+          <Circle {...ICON} cx={12} cy={12} r={10} />
+          <Path {...ICON} d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20" />
+          <Path {...ICON} d="M2 12h20" />
+        </Svg>
+      );
+    case "location":
+      return (
+        <Svg width={8} height={8} viewBox="0 0 24 24">
+          <Path
+            {...ICON}
+            d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"
+          />
+          <Circle {...ICON} cx={12} cy={10} r={3} />
+        </Svg>
+      );
+  }
+}
+
 function PdfHeader(props: { header: HeaderView }) {
   return (
     <View style={styles.header}>
@@ -91,15 +142,16 @@ function PdfHeader(props: { header: HeaderView }) {
       </View>
       <View style={styles.headerRight}>
         {props.header.contacts.map((contact) => (
-          <Text key={contact.kind} style={styles.contact}>
+          <View key={contact.kind} style={styles.contactRow}>
+            <PdfContactIcon kind={contact.kind} />
             {contact.href ? (
               <Link src={contact.href} style={styles.linkPlain}>
                 {contact.value}
               </Link>
             ) : (
-              contact.value
+              <Text>{contact.value}</Text>
             )}
-          </Text>
+          </View>
         ))}
       </View>
     </View>

--- a/src/components/editor/resume-to-preview.ts
+++ b/src/components/editor/resume-to-preview.ts
@@ -62,11 +62,10 @@ function toHeaderView(resume: Resume): HeaderView {
     contacts.push({ kind: "email", value: email, href: `mailto:${email}` });
   const website = plain(fields.website);
   if (website) {
-    contacts.push({
-      kind: "website",
-      value: website,
-      href: withHttps(website),
-    });
+    // Show the full URL (scheme included): a bare domain isn't recognized as a
+    // link by résumé parsers, which look for http(s)://, www., or a path.
+    const url = withHttps(website);
+    contacts.push({ kind: "website", value: url, href: url });
   }
   const location = [
     plain(fields.city),


### PR DESCRIPTION
Phase 4 (final) of the export pipeline — the **parser-validation pass** from AGENTS.md.

## Automated gate
```bash
pnpm validate:exports
```
`scripts/validate-exports.tsx` regenerates the **PDF, .docx, and .txt** from the seed and extracts their text with **real parsers** — `unpdf` (PDF), `jszip` (docx XML), serializer output (txt) — then asserts:
- **Reading order**: `Summary → Experience → Education → Certificates → Skills → Languages` in every format.
- **Field mapping**: name, headline, email, website, each employer, education, certificate, a skill, and a language all appear in the extracted text.

This is the pdftotext-equivalent text-extraction test, and it exits non-zero on failure — run it after any change to an export path.

### Result
All three formats **pass** (verified against extracted binary text, not the source strings):
```
TXT:  extracted 1239 chars
PDF:  extracted 1205 chars
DOCX: extracted 1231 chars
✓ All exports preserve reading order and carry every field (PDF, DOCX, TXT).
```

## Manual pass (documented, needs a human)
`docs/export-validation.md` records the automated gate plus a checklist for the **real-ATS pass** — open-source parser (Affinda/pyresparser) or a Greenhouse/Workday sandbox upload — which can't run in CI. That's the one remaining step before calling export production-ready.

## Deps (dev only)
- `unpdf`, `jszip`, `tsx`

## Notes
- `poppler`/`pdftotext` isn't available in this environment, so the harness uses `unpdf` (pure-Node, no canvas) for equivalent extraction.