### PR TITLE
chore: standardize license on AGPL-3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ See `AGENTS.md` for architecture rules and code conventions before submitting a 
 
 ## License
 
-GPL-3.0.
+[AGPL-3.0-only](LICENSE). Copyright © 2026 Rizki Citra.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "lanjut",
   "version": "0.1.0",
   "private": true,
+  "license": "AGPL-3.0-only",
+  "author": "Rizki Citra",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
The three license references disagreed:

- `LICENSE` = **AGPL-3.0** (GNU Affero)
- `README` said **GPL-3.0**
- `package.json` had **no `license` field**

Standardized on **AGPL-3.0** (your call):
- `README` → `AGPL-3.0-only` with copyright © 2026 Rizki Citra
- `package.json` → `"license": "AGPL-3.0-only"` + `"author": "Rizki Citra"`
- `LICENSE` file unchanged (verbatim FSF AGPL-3.0 text — its body must not be edited)