### PR TITLE
ci: grant contents read to the PR title check

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited, reopened, synchronize]
 
 permissions:
-  pull-requests: read
+  contents: read
 
 jobs:
   lint-title:


### PR DESCRIPTION
The PR-title workflow failed on #17 with `remote: Repository not found` during checkout.

Root cause: an explicit `permissions:` block **replaces** the default token permissions rather than extending them. The block had only `pull-requests: read`, which set `contents: none`, so `actions/checkout` had no read access to the repo — GitHub reports that as "Repository not found" rather than a permission error.

Fix: the job now requests `contents: read` (and drops `pull-requests: read`, which was unused — the title is read from the event payload, not the API).

After merging, re-run the failed `PR Title` check on #17 and it should pass; #17 remains the release/deploy trigger as before.