### PR TITLE
feat: serve the app at lanjut.rimzzlabs.com

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,6 +4,12 @@
   "name": "lanjut",
   "compatibility_date": "2026-07-01",
   "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
+  "routes": [
+    {
+      "pattern": "lanjut.rimzzlabs.com",
+      "custom_domain": true
+    }
+  ],
   "assets": {
     "directory": ".open-next/assets",
     "binding": "ASSETS"


### PR DESCRIPTION
Adds a Workers Custom Domain route to wrangler.jsonc. On the next deploy, Cloudflare will:

- create the `lanjut.rimzzlabs.com` DNS record in the zone (verified: no existing record conflicts, and the zone's nameservers are already on Cloudflare),
- provision the TLS certificate,
- route the hostname to the `lanjut` worker.

No dashboard steps needed. The `workers.dev` URL stays enabled as a fallback; we can set `workers_dev: false` later if we want the custom domain to be the only entry point.

**Merge order:** merge this before release PR #17 so the very first production deploy attaches the domain. As a `feat:` it will appear in the 0.2.0 changelog.

Note: if the deploy step ever fails attaching the domain with a permissions error, the `CLOUDFLARE_API_TOKEN` needs the zone-level Workers Routes edit permission (included in the "Edit Cloudflare Workers" token template).