### PR TITLE
feat: add Browse Templates page with search and sort

### DIFF
--- a/src/app/platform/template/page.tsx
+++ b/src/app/platform/template/page.tsx
@@ -1,0 +1,14 @@
+import { Suspense } from "react";
+import { PlatformTemplateGrid } from "@/components/platform/platform-template-grid/platform-template-grid";
+import { PlatformTemplateToolbar } from "@/components/platform/platform-template-toolbar";
+
+export default function PlatformTemplatePage() {
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <Suspense>
+        <PlatformTemplateToolbar />
+        <PlatformTemplateGrid />
+      </Suspense>
+    </div>
+  );
+}

--- a/src/components/platform/platform-navbar-breadcrumb.tsx
+++ b/src/components/platform/platform-navbar-breadcrumb.tsx
@@ -34,6 +34,16 @@ export function PlatformNavbarBreadcrumb() {
             </BreadcrumbItem>
           </>
         )}
+
+        {pathname.includes("/template") && (
+          <>
+            <BreadcrumbSeparator />
+
+            <BreadcrumbItem>
+              <BreadcrumbPage>Browse Templates</BreadcrumbPage>
+            </BreadcrumbItem>
+          </>
+        )}
       </BreadcrumbList>
     </Breadcrumb>
   );

--- a/src/components/platform/platform-sidebar-platform.tsx
+++ b/src/components/platform/platform-sidebar-platform.tsx
@@ -1,4 +1,4 @@
-import { HelpCircle, Layout } from "lucide-react";
+import { HelpCircle, Layout, LayoutTemplate } from "lucide-react";
 import Link from "next/link";
 import {
   SidebarGroup,
@@ -16,6 +16,11 @@ export function PlatformSidebarPlatform() {
         <SidebarMenuItem>
           <SidebarMenuButton render={<Link href="/platform" />}>
             <Layout /> Dashboard
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+        <SidebarMenuItem>
+          <SidebarMenuButton render={<Link href="/platform/template" />}>
+            <LayoutTemplate /> Browse Template
           </SidebarMenuButton>
         </SidebarMenuItem>
         <SidebarMenuItem>

--- a/src/components/platform/platform-template-grid/platform-template-grid-item.tsx
+++ b/src/components/platform/platform-template-grid/platform-template-grid-item.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { TemplateSummary } from "@/lib/templates";
+import { PlatformResumeCreateDialog } from "../platform-resume-create-dialog";
+
+interface PlatformTemplateGridItemProps {
+  template: TemplateSummary;
+}
+
+export function PlatformTemplateGridItem({
+  template,
+}: PlatformTemplateGridItemProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Card size="sm">
+      <CardHeader>
+        <CardTitle className="truncate">{template.name}</CardTitle>
+        <CardDescription className="line-clamp-3 text-xs">
+          {template.description}
+        </CardDescription>
+      </CardHeader>
+
+      <CardFooter className="mt-auto justify-end">
+        <Button size="sm" onClick={() => setOpen(true)}>
+          Use template
+        </Button>
+      </CardFooter>
+
+      <PlatformResumeCreateDialog open={open} onOpenChange={setOpen} />
+    </Card>
+  );
+}

--- a/src/components/platform/platform-template-grid/platform-template-grid.tsx
+++ b/src/components/platform/platform-template-grid/platform-template-grid.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import {
+  useTemplateSearchQuery,
+  useTemplateSort,
+} from "@/hooks/use-template-search";
+import { filterTemplates, sortTemplates, TEMPLATES } from "@/lib/templates";
+import { PlatformTemplateGridItem } from "./platform-template-grid-item";
+
+export function PlatformTemplateGrid() {
+  const [query] = useTemplateSearchQuery();
+  const [sort] = useTemplateSort();
+
+  const results = sortTemplates(filterTemplates(TEMPLATES, query), sort);
+
+  if (results.length === 0) {
+    return (
+      <p className="py-12 text-center text-sm text-muted-foreground">
+        No templates match “{query.trim()}”.
+      </p>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-[repeat(auto-fill,minmax(min(100%,16rem),1fr))] gap-4">
+      {results.map((template) => (
+        <PlatformTemplateGridItem key={template.id} template={template} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/platform/platform-template-toolbar.tsx
+++ b/src/components/platform/platform-template-toolbar.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { Search } from "lucide-react";
+import {
+  useTemplateSearchQuery,
+  useTemplateSort,
+} from "@/hooks/use-template-search";
+import type { TemplateSort } from "@/lib/templates";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "../ui/input-group";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
+
+const SORT_OPTIONS: { value: TemplateSort; label: string }[] = [
+  { value: "name-asc", label: "Name (A–Z)" },
+  { value: "name-desc", label: "Name (Z–A)" },
+  { value: "newest", label: "Newest" },
+];
+
+export function PlatformTemplateToolbar() {
+  const [query, setQuery] = useTemplateSearchQuery();
+  const [sort, setSort] = useTemplateSort();
+
+  return (
+    <div className="flex items-center gap-2">
+      <InputGroup className="max-w-xs">
+        <InputGroupAddon>
+          <Search />
+        </InputGroupAddon>
+        <InputGroupInput
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search templates"
+        />
+      </InputGroup>
+
+      <div className="ml-auto">
+        <Select
+          value={sort}
+          onValueChange={(value) => setSort(value as TemplateSort)}
+        >
+          <SelectTrigger className="w-40">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {SORT_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/use-template-search.ts
+++ b/src/hooks/use-template-search.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { parseAsString, parseAsStringLiteral, useQueryState } from "nuqs";
+import { TEMPLATE_SORTS } from "@/lib/templates";
+
+/**
+ * Browse-Templates search query, held in the `q` URL param so it survives reload
+ * and is shareable. Throttled and dropped from the URL when empty.
+ */
+export function useTemplateSearchQuery() {
+  return useQueryState(
+    "q",
+    parseAsString
+      .withDefault("")
+      .withOptions({ clearOnDefault: true, throttleMs: 200 }),
+  );
+}
+
+/** Browse-Templates sort order, held in the `sort` URL param (default name A–Z). */
+export function useTemplateSort() {
+  return useQueryState(
+    "sort",
+    parseAsStringLiteral(TEMPLATE_SORTS)
+      .withDefault("name-asc")
+      .withOptions({ clearOnDefault: true }),
+  );
+}

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -1,0 +1,58 @@
+/**
+ * The catalog of résumé templates shown on the Browse Templates page. Presentation
+ * metadata only — the rendering/adapter for each template lives under
+ * `@/components/editor`. Currently a single starter template ("Awal").
+ */
+export interface TemplateSummary {
+  id: string;
+  name: string;
+  description: string;
+  /** ISO 8601 — when the template was added, for "newest" sorting. */
+  addedAt: string;
+}
+
+export type TemplateSort = "name-asc" | "name-desc" | "newest";
+
+export const TEMPLATE_SORTS: TemplateSort[] = [
+  "name-asc",
+  "name-desc",
+  "newest",
+];
+
+export const TEMPLATES: TemplateSummary[] = [
+  {
+    id: "awal",
+    name: "Awal",
+    description:
+      "A clean, single-column ATS-safe starter. Linear reading order, no columns or tables, with room for every section.",
+    addedAt: "2026-01-01T00:00:00.000Z",
+  },
+];
+
+export function filterTemplates(
+  templates: TemplateSummary[],
+  query: string,
+): TemplateSummary[] {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return templates;
+  return templates.filter(
+    (template) =>
+      template.name.toLowerCase().includes(needle) ||
+      template.description.toLowerCase().includes(needle),
+  );
+}
+
+export function sortTemplates(
+  templates: TemplateSummary[],
+  sort: TemplateSort,
+): TemplateSummary[] {
+  const sorted = [...templates];
+  switch (sort) {
+    case "name-asc":
+      return sorted.sort((a, b) => a.name.localeCompare(b.name));
+    case "name-desc":
+      return sorted.sort((a, b) => b.name.localeCompare(a.name));
+    case "newest":
+      return sorted.sort((a, b) => b.addedAt.localeCompare(a.addedAt));
+  }
+}


### PR DESCRIPTION
Adds a **Browse Templates** page at \`/platform/template\`, linked from a new **Browse Template** item in the Platform sidebar.

## Toolbar
- **Search on the left** — filters templates by name/description; held in the \`q\` URL param (nuqs, throttled, cleared when empty).
- **Sort on the right** — a select (Name A–Z / Z–A / Newest); held in the \`sort\` URL param. Both survive reload and are shareable.

## Page
- \`src/app/platform/template/page.tsx\` — mirrors the library page (Suspense + client toolbar/grid), inheriting the platform navbar + sidebar.
- \`src/lib/templates.ts\` — the template catalog + \`filterTemplates\`/\`sortTemplates\`. Currently one entry (**Awal**), data-driven so more slot in.
- Grid of cards (container + item split); each card has a **Use template** action that opens the existing create dialog.
- Breadcrumb shows **Browse Templates** on the route.

## Verification
- \`tsc --noEmit\` + \`biome check\` clean.
- Pattern mirrors the working library page (same nuqs + Suspense setup).

## Notes
- Template selection isn't persisted on résumés yet, so "Use template" creates a résumé via the normal flow (all templates currently render as Awal). Wiring a per-résumé template choice is a natural follow-up.