### PR TITLE
feat: flesh out the Awal starter résumé data

### DIFF
--- a/src/lib/resume/seed.ts
+++ b/src/lib/resume/seed.ts
@@ -1,4 +1,3 @@
-import { A, F, pipe } from "@mobily/ts-belt";
 import type { JSONContent } from "@tiptap/core";
 import type { Field, Resume } from "./types";
 import { CURRENT_SCHEMA_VERSION } from "./types";
@@ -7,19 +6,32 @@ function plain(value: string): Field {
   return { kind: "plain", value };
 }
 
-function paragraph(text: string): JSONContent {
-  return { type: "paragraph", content: [{ type: "text", text }] };
+function t(text: string): JSONContent {
+  return { type: "text", text };
 }
 
-function bulletList(items: string[]): JSONContent {
-  return {
-    type: "bulletList",
-    content: pipe(
-      items,
-      A.map((text) => ({ type: "listItem", content: [paragraph(text)] })),
-      F.toMutable,
-    ),
-  };
+function b(text: string): JSONContent {
+  return { type: "text", text, marks: [{ type: "bold" }] };
+}
+
+function i(text: string): JSONContent {
+  return { type: "text", text, marks: [{ type: "italic" }] };
+}
+
+function link(text: string, href: string): JSONContent {
+  return { type: "text", text, marks: [{ type: "link", attrs: { href } }] };
+}
+
+function p(...runs: JSONContent[]): JSONContent {
+  return { type: "paragraph", content: runs };
+}
+
+function li(...runs: JSONContent[]): JSONContent {
+  return { type: "listItem", content: [p(...runs)] };
+}
+
+function ul(...items: JSONContent[]): JSONContent {
+  return { type: "bulletList", content: items };
 }
 
 function prose(...blocks: JSONContent[]): Field {
@@ -30,6 +42,8 @@ function prose(...blocks: JSONContent[]): Field {
  * The single code-defined sample Resume. Every newly created Resume is cloned
  * from this fixture, and the export Parser gate reuses it as its test document.
  * The stable ids here are placeholders — cloneResumeAsNew reassigns fresh ids.
+ * It doubles as the "Awal" template showcase, so it exercises every section plus
+ * bold / italic / link marks.
  */
 export const SEED_RESUME: Resume = {
   id: "seed",
@@ -60,8 +74,20 @@ export const SEED_RESUME: Resume = {
           id: "seed-summary-1",
           fields: {
             body: prose(
-              paragraph(
-                "Frontend engineer with 8 years building accessible, performant web applications. Focused on design systems, developer experience, and shipping measurable outcomes.",
+              p(
+                t("Senior frontend engineer with "),
+                b("8+ years"),
+                t(
+                  " building accessible, high-performance web applications for fintech and SaaS. Deep experience with ",
+                ),
+                b("React"),
+                t(", "),
+                b("Next.js"),
+                t(", and design systems, with a focus on "),
+                i("developer experience"),
+                t(
+                  " and shipping measurable outcomes. Comfortable leading projects end to end and mentoring teams.",
+                ),
               ),
             ),
           },
@@ -82,11 +108,53 @@ export const SEED_RESUME: Resume = {
             startDate: plain("Mar 2022"),
             endDate: plain("Present"),
             description: prose(
-              bulletList([
-                "Led migration of a 200k-line codebase to a typed component library, cutting UI defects by 40%.",
-                "Owned the design-system accessibility program, reaching WCAG 2.1 AA across all shipped components.",
-                "Mentored four engineers and established the team's code-review and testing standards.",
-              ]),
+              ul(
+                li(
+                  t(
+                    "Led migration of a 200k-line codebase to a typed component library, cutting UI defects by ",
+                  ),
+                  b("40%"),
+                  t("."),
+                ),
+                li(
+                  t(
+                    "Architected the design-system accessibility program, reaching ",
+                  ),
+                  b("WCAG 2.1 AA"),
+                  t(" across every shipped component."),
+                ),
+                li(
+                  t("Cut initial bundle size "),
+                  b("55%"),
+                  t(
+                    " with code-splitting and dependency audits, improving LCP from 3.1s to ",
+                  ),
+                  b("1.4s"),
+                  t("."),
+                ),
+                li(
+                  t(
+                    "Built a real-time analytics dashboard over WebSockets, adopted by ",
+                  ),
+                  b("12k weekly"),
+                  t(" active users."),
+                ),
+                li(
+                  t("Maintain "),
+                  link(
+                    "react-a11y-kit",
+                    "https://github.com/johndoe/react-a11y-kit",
+                  ),
+                  t(", an open-source accessibility toolkit with "),
+                  b("2k+ stars"),
+                  t("."),
+                ),
+                li(
+                  t(
+                    "Mentored four engineers and set the team's code-review, testing, and release standards.",
+                  ),
+                ),
+              ),
             ),
           },
         },
@@ -99,10 +167,65 @@ export const SEED_RESUME: Resume = {
             startDate: plain("Jul 2018"),
             endDate: plain("Feb 2022"),
             description: prose(
-              bulletList([
-                "Built the customer-facing analytics dashboard used by 12k weekly active users.",
-                "Reduced initial bundle size by 55% through code-splitting and dependency audits.",
-              ]),
+              ul(
+                li(
+                  t(
+                    "Delivered the customer-facing analytics dashboard used by ",
+                  ),
+                  b("12k"),
+                  t(" weekly active users."),
+                ),
+                li(
+                  t(
+                    "Introduced a shared component library and Storybook, cutting feature delivery time by ~",
+                  ),
+                  b("30%"),
+                  t("."),
+                ),
+                li(
+                  t(
+                    "Integrated analytics and A/B testing (Mixpanel, GrowthBook) to drive data-informed UI decisions.",
+                  ),
+                ),
+                li(
+                  t("Moved all marketing sites to "),
+                  b("Good"),
+                  t(
+                    " Core Web Vitals through image, font, and caching optimizations.",
+                  ),
+                ),
+              ),
+            ),
+          },
+        },
+        {
+          id: "seed-experience-3",
+          fields: {
+            title: plain("Junior Frontend Developer"),
+            company: plain("Initech"),
+            website: plain("initech.example.com"),
+            startDate: plain("Aug 2016"),
+            endDate: plain("Jun 2018"),
+            description: prose(
+              ul(
+                li(
+                  t(
+                    "Built responsive, cross-browser interfaces from Figma designs for enterprise clients.",
+                  ),
+                ),
+                li(
+                  t(
+                    "Automated form-heavy QA workflows, reducing manual testing time by ",
+                  ),
+                  b("20%"),
+                  t("."),
+                ),
+                li(
+                  t(
+                    "Shipped a reusable form-validation library still used across three internal apps.",
+                  ),
+                ),
+              ),
             ),
           },
         },
@@ -122,8 +245,27 @@ export const SEED_RESUME: Resume = {
             startDate: plain("2014"),
             endDate: plain("2018"),
             details: prose(
-              paragraph(
-                "Graduated with honors. Coursework in HCI, distributed systems, and algorithms.",
+              p(
+                t(
+                  "Graduated with honors (GPA 3.8). Coursework in HCI, distributed systems, and algorithms; led the campus Web Development Club.",
+                ),
+              ),
+            ),
+          },
+        },
+        {
+          id: "seed-education-2",
+          fields: {
+            institution: plain("Recurse Center"),
+            degree: plain("Software Residency"),
+            location: plain("New York, NY"),
+            startDate: plain("2019"),
+            endDate: plain("2019"),
+            details: prose(
+              p(
+                t(
+                  "A self-directed residency focused on systems programming, compilers, and open-source contribution.",
+                ),
               ),
             ),
           },
@@ -141,16 +283,55 @@ export const SEED_RESUME: Resume = {
         },
         {
           id: "seed-skills-2",
-          fields: { name: plain("React & Next.js"), level: plain("Expert") },
+          fields: {
+            name: plain("JavaScript (ES2023)"),
+            level: plain("Expert"),
+          },
         },
         {
           id: "seed-skills-3",
-          fields: { name: plain("Node.js"), level: plain("Advanced") },
+          fields: { name: plain("React & Next.js"), level: plain("Expert") },
         },
         {
           id: "seed-skills-4",
+          fields: { name: plain("Node.js"), level: plain("Advanced") },
+        },
+        {
+          id: "seed-skills-5",
           fields: {
-            name: plain("Testing (Playwright)"),
+            name: plain("GraphQL & REST APIs"),
+            level: plain("Advanced"),
+          },
+        },
+        {
+          id: "seed-skills-6",
+          fields: { name: plain("Tailwind CSS"), level: plain("Advanced") },
+        },
+        {
+          id: "seed-skills-7",
+          fields: {
+            name: plain("Testing (Playwright, Vitest)"),
+            level: plain("Advanced"),
+          },
+        },
+        {
+          id: "seed-skills-8",
+          fields: {
+            name: plain("State (Zustand, React Query)"),
+            level: plain("Advanced"),
+          },
+        },
+        {
+          id: "seed-skills-9",
+          fields: {
+            name: plain("Web Accessibility (WCAG)"),
+            level: plain("Advanced"),
+          },
+        },
+        {
+          id: "seed-skills-10",
+          fields: {
+            name: plain("CI/CD & Docker"),
             level: plain("Intermediate"),
           },
         },
@@ -164,9 +345,25 @@ export const SEED_RESUME: Resume = {
         {
           id: "seed-certifications-1",
           fields: {
-            name: plain("AWS Certified Solutions Architect"),
+            name: plain("AWS Certified Solutions Architect – Associate"),
             issuer: plain("Amazon Web Services"),
-            url: plain("aws.amazon.com/certification"),
+            url: plain("aws.amazon.com/verification"),
+          },
+        },
+        {
+          id: "seed-certifications-2",
+          fields: {
+            name: plain("Meta Front-End Developer"),
+            issuer: plain("Coursera"),
+            url: plain("coursera.org/verify/meta-frontend"),
+          },
+        },
+        {
+          id: "seed-certifications-3",
+          fields: {
+            name: plain("Certified Professional in Web Accessibility (CPACC)"),
+            issuer: plain("IAAP"),
+            url: plain("accessibilityassociation.org"),
           },
         },
       ],
@@ -183,6 +380,10 @@ export const SEED_RESUME: Resume = {
         {
           id: "seed-languages-2",
           fields: { name: plain("Spanish"), level: plain("Professional") },
+        },
+        {
+          id: "seed-languages-3",
+          fields: { name: plain("French"), level: plain("Conversational") },
         },
       ],
     },


### PR DESCRIPTION
The seed résumé — cloned by every new résumé, and the fixture the export validation gate runs against — was thin (one summary line, 2 jobs, 1 education, 4 skills, 1 cert). Expand it into a complete, realistic example that also **showcases the template's rich text**.

## Changes to `SEED_RESUME`
| Section | Before → After |
|---|---|
| Summary | 1 plain line → fuller, with **bold** + *italic* marks |
| Experience | 2 roles → **3** (added a Junior role), richer bullets with **bold** metrics and a **link** |
| Education | 1 → **2** |
| Skills | 4 → **10** |
| Certifications | 1 → **3** |
| Languages | 2 → **3** |

Also added small rich-text seed helpers (`t`/`b`/`i`/`link`/`p`/`li`/`ul`) and dropped the ts-belt builders.

## Verification
- `tsc` + `biome` clean.
- `pnpm validate:exports` passes PDF/DOCX/TXT (reading order + every field), now ~2700 extracted chars vs ~1200.
- Rendered the PDF: bold/italic/links all render; flows cleanly onto a 2nd page.

## Note
No schema change — same v4 shape, just richer content. Education sorts newest-first, so the 2019 residency shows above the 2014–2018 degree (the intended date sort).