### PR TITLE
fix: keep the preview paginated and keyed correctly while editing

### DIFF
--- a/src/components/editor/editor-sections/resume-form-adapter.ts
+++ b/src/components/editor/editor-sections/resume-form-adapter.ts
@@ -96,6 +96,16 @@ function sectionOfType(
   return resume.sections.find((section) => section.type === type);
 }
 
+/**
+ * Keep entry ids stable across form-driven rebuilds by reusing the existing
+ * entry's id at the same index. Regenerating ids on every keystroke invalidates
+ * everything keyed by them downstream — most visibly the preview's measured
+ * block heights, which collapsed pagination to a single page.
+ */
+function entryId(section: Section, index: number): string {
+  return section.entries[index]?.id ?? nanoid();
+}
+
 // --- Personal (header + summary section) -----------------------------------
 
 export function toPersonalValues(resume: Resume): PersonalFormValues {
@@ -169,8 +179,8 @@ export function applyExperienceValues(
 ): void {
   const section = sectionOfType(draft, "experience");
   if (!section) return;
-  section.entries = values.experiences.map((item) => ({
-    id: nanoid(),
+  section.entries = values.experiences.map((item, index) => ({
+    id: entryId(section, index),
     fields: {
       title: plain(item.title),
       company: plain(item.company),
@@ -207,8 +217,8 @@ export function applyEducationValues(
 ): void {
   const section = sectionOfType(draft, "education");
   if (!section) return;
-  section.entries = values.educations.map((item) => ({
-    id: nanoid(),
+  section.entries = values.educations.map((item, index) => ({
+    id: entryId(section, index),
     fields: {
       institution: plain(item.institution),
       degree: plain(item.degree),
@@ -241,8 +251,8 @@ export function applySkillsValues(
 ): void {
   const section = sectionOfType(draft, "skills");
   if (!section) return;
-  section.entries = values.skills.map((item) => ({
-    id: nanoid(),
+  section.entries = values.skills.map((item, index) => ({
+    id: entryId(section, index),
     fields: { name: plain(item.name), level: plain(item.level) },
   }));
 }
@@ -271,8 +281,8 @@ export function applyCertificationsValues(
 ): void {
   const section = sectionOfType(draft, "certifications");
   if (!section) return;
-  section.entries = values.certifications.map((item) => ({
-    id: nanoid(),
+  section.entries = values.certifications.map((item, index) => ({
+    id: entryId(section, index),
     fields: {
       name: plain(item.name),
       issuer: plain(item.issuer),
@@ -302,8 +312,8 @@ export function applyLanguagesValues(
 ): void {
   const section = sectionOfType(draft, "languages");
   if (!section) return;
-  section.entries = values.languages.map((item) => ({
-    id: nanoid(),
+  section.entries = values.languages.map((item, index) => ({
+    id: entryId(section, index),
     fields: { name: plain(item.name), level: plain(item.level) },
   }));
 }

--- a/src/components/editor/pdf/awal-pdf-rich-text.tsx
+++ b/src/components/editor/pdf/awal-pdf-rich-text.tsx
@@ -23,30 +23,27 @@ function runStyle(run: InlineRun): {
   };
 }
 
-function runKey(run: InlineRun): string {
-  return `${run.href ?? ""}|${run.bold ? "b" : ""}${run.italic ? "i" : ""}|${run.text}`;
-}
+/*
+ * Index keys are deliberate throughout this renderer: blocks/runs are a
+ * stateless linear projection re-derived wholesale from the document, never
+ * reordered in place, and their text content is not unique (duplicate
+ * paragraphs would collide as keys).
+ */
 
 function InlineRuns(props: { runs: InlineRun[] }) {
-  return props.runs.map((run) =>
+  return props.runs.map((run, index) =>
     run.href ? (
-      <Link
-        key={runKey(run)}
-        src={run.href}
-        style={[styles.link, runStyle(run)]}
-      >
+      // biome-ignore lint/suspicious/noArrayIndexKey: see renderer note above
+      <Link key={index} src={run.href} style={[styles.link, runStyle(run)]}>
         {run.text}
       </Link>
     ) : (
-      <Text key={runKey(run)} style={runStyle(run)}>
+      // biome-ignore lint/suspicious/noArrayIndexKey: see renderer note above
+      <Text key={index} style={runStyle(run)}>
         {run.text}
       </Text>
     ),
   );
-}
-
-function runsText(runs: InlineRun[]): string {
-  return runs.map((run) => run.text).join("");
 }
 
 interface AwalPdfRichTextProps {
@@ -59,14 +56,16 @@ export function AwalPdfRichText(props: AwalPdfRichTextProps) {
   if (props.blocks.length === 0) return null;
   return (
     <View style={props.style}>
-      {props.blocks.map((block) => {
+      {props.blocks.map((block, index) => {
         if (block.type === "list") {
           return (
-            <View key={block.items.map(runsText).join("|")}>
-              {block.items.map((runs, index) => (
-                <View key={runsText(runs)} style={styles.listItem}>
+            // biome-ignore lint/suspicious/noArrayIndexKey: see renderer note above
+            <View key={index}>
+              {block.items.map((runs, itemIndex) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: see renderer note above
+                <View key={itemIndex} style={styles.listItem}>
                   <Text style={styles.bullet}>
-                    {block.ordered ? `${index + 1}.` : "•"}
+                    {block.ordered ? `${itemIndex + 1}.` : "•"}
                   </Text>
                   <Text style={styles.itemBody}>
                     <InlineRuns runs={runs} />
@@ -77,7 +76,8 @@ export function AwalPdfRichText(props: AwalPdfRichTextProps) {
           );
         }
         return (
-          <Text key={runsText(block.runs)} style={styles.paragraph}>
+          // biome-ignore lint/suspicious/noArrayIndexKey: see renderer note above
+          <Text key={index} style={styles.paragraph}>
             <InlineRuns runs={block.runs} />
           </Text>
         );

--- a/src/components/editor/resume-document.tsx
+++ b/src/components/editor/resume-document.tsx
@@ -32,6 +32,7 @@ export function ResumeDocument(props: ResumeDocumentProps) {
   const [heights, setHeights] = useState<Record<string, number>>({});
   const [availableWidth, setAvailableWidth] = useState(0);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `blocks` is a deliberate re-run trigger — the ResizeObserver only fires when the layer's total size changes, which misses block-id swaps that keep the layout size (stale height keys collapse pagination).
   useEffect(() => {
     const layer = measureRef.current;
     if (!layer) return;
@@ -57,8 +58,7 @@ export function ResumeDocument(props: ResumeDocumentProps) {
       cancelled = true;
       observer.disconnect();
     };
-    // Mount-once: the ResizeObserver re-measures whenever block content reflows.
-  }, []);
+  }, [blocks]);
 
   useEffect(() => {
     const el = containerRef.current;

--- a/src/components/editor/resume-rich-text.tsx
+++ b/src/components/editor/resume-rich-text.tsx
@@ -1,14 +1,6 @@
 import { cn } from "@/lib/utils";
 import type { InlineRun, RichBlock } from "./rich-content";
 
-function runsText(runs: InlineRun[]): string {
-  return runs.map((run) => run.text).join("");
-}
-
-function runKey(run: InlineRun): string {
-  return `${run.href ?? ""}|${run.bold ? "b" : ""}${run.italic ? "i" : ""}|${run.text}`;
-}
-
 function RichRun(props: InlineRun) {
   let node: React.ReactNode = props.text;
   if (props.bold) node = <strong className="font-semibold">{node}</strong>;
@@ -23,8 +15,18 @@ function RichRun(props: InlineRun) {
   return node;
 }
 
+/*
+ * Index keys are deliberate throughout this renderer: blocks/runs are a
+ * stateless linear projection re-derived wholesale from the document, never
+ * reordered in place, and their text content is not unique (duplicate
+ * paragraphs would collide as keys).
+ */
+
 function RichRuns(props: { runs: InlineRun[] }) {
-  return props.runs.map((run) => <RichRun key={runKey(run)} {...run} />);
+  return props.runs.map((run, index) => {
+    // biome-ignore lint/suspicious/noArrayIndexKey: see renderer note above
+    return <RichRun key={index} {...run} />;
+  });
 }
 
 interface ResumeRichTextProps {
@@ -46,27 +48,30 @@ export function ResumeRichText(props: ResumeRichTextProps) {
         props.className,
       )}
     >
-      {props.blocks.map((block) => {
+      {props.blocks.map((block, index) => {
         if (block.type === "list") {
           const ListTag = block.ordered ? "ol" : "ul";
+          const listClass = cn(
+            "space-y-1 pl-5",
+            block.ordered ? "list-decimal" : "list-disc",
+          );
           return (
-            <ListTag
-              key={block.items.map(runsText).join("|")}
-              className={cn(
-                "space-y-1 pl-5",
-                block.ordered ? "list-decimal" : "list-disc",
-              )}
-            >
-              {block.items.map((runs) => (
-                <li key={runsText(runs)}>
-                  <RichRuns runs={runs} />
-                </li>
-              ))}
+            // biome-ignore lint/suspicious/noArrayIndexKey: see renderer note above
+            <ListTag key={index} className={listClass}>
+              {block.items.map((runs, itemIndex) => {
+                return (
+                  // biome-ignore lint/suspicious/noArrayIndexKey: see renderer note above
+                  <li key={itemIndex}>
+                    <RichRuns runs={runs} />
+                  </li>
+                );
+              })}
             </ListTag>
           );
         }
         return (
-          <p key={runsText(block.runs)}>
+          // biome-ignore lint/suspicious/noArrayIndexKey: see renderer note above
+          <p key={index}>
             <RichRuns runs={block.runs} />
           </p>
         );

--- a/src/components/platform/platform-empty-state.tsx
+++ b/src/components/platform/platform-empty-state.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { FilePlus, Inbox, Search } from "lucide-react";
+import Link from "next/link";
 import { useState } from "react";
 import { useResumeStore } from "@/lib/store";
 import { Button } from "../ui/button";
@@ -36,7 +37,10 @@ export function PlatformEmptyState() {
           </EmptyDescription>
 
           <div className="inline-flex items-center gap-2">
-            <Button>
+            <Button
+              nativeButton={false}
+              render={<Link href="/platform/template" />}
+            >
               <Search /> Browse Template
             </Button>
             <Button variant="secondary" onClick={() => setOpen(true)}>

--- a/src/components/platform/platform-resume-create-dialog.tsx
+++ b/src/components/platform/platform-resume-create-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
 import { Save, TextInitial, XIcon } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { Controller, useForm } from "react-hook-form";
 import {
   RESUME_TITLE_MAX_LENGTH,
@@ -42,6 +43,7 @@ interface PlatformResumeCreateDialogProps {
 export function PlatformResumeCreateDialog(
   props: PlatformResumeCreateDialogProps,
 ) {
+  const router = useRouter();
   const createResume = useResumeStore((state) => state.createResume);
   const form = useForm<ResumeTitleForm>({
     resolver: standardSchemaResolver(resumeTitleSchema),
@@ -50,9 +52,10 @@ export function PlatformResumeCreateDialog(
   });
 
   const onSubmit = form.handleSubmit(async (values) => {
-    await createResume(values.title);
+    const resume = await createResume(values.title);
     form.reset({ title: "" });
     props.onOpenChange(false);
+    router.push(`/platform/editor/${resume.id}`);
   });
 
   const error = form.formState.errors.title;


### PR DESCRIPTION
Fixes two live-preview editing bugs, plus two small platform-flow improvements.

## Bug 1 — multi-page preview collapsed to one page on any edit
Editing a job title (or any field) collapsed a 2-page preview into one.

**Cause:** every form change rebuilt the store entries with fresh `nanoid()` ids. The preview measures block heights keyed by block id, and a missing id counts as height `0` (`heights[block.id] ?? 0`) — so after an id churn everything "fit" on page one. The measure layer's ResizeObserver never re-fired because a title edit barely changes the layer's total size, so the stale keys persisted.

**Fix:**
- `entryId(section, index)` — entry rebuilds now **reuse the existing id at the same index** (new rows still get `nanoid()`), so ids are stable across keystrokes.
- The measure effect **re-runs on block-list changes** (deliberate extra dep, documented suppression), so heights can never be left stale even if ids shift (e.g. removing a middle entry).

## Bug 2 — `Encountered two children with the same key`
Typing duplicate text (e.g. the same line twice in the summary) crashed React keys. The rich-text renderers keyed paragraphs/list items/runs by their **text content**, which isn't unique. Both the DOM and PDF renderers now use **index keys** — correct for a stateless linear projection that's re-derived wholesale and never reordered — with a note + suppressions documenting the reasoning.

## Platform flow
- Empty state's **Browse Template** button (previously inert) now links to `/platform/template`.
- Creating a résumé from the dialog now **redirects straight to its editor** — `createResume` already leaves the document open in the store, so it loads instantly.

## Verification
- `tsc --noEmit`, `biome check`, and `pnpm validate:exports` all green.
- Manual: edit a title on a 2-page résumé → stays 2 pages; duplicate summary lines → no key error; create → lands in editor.