### PR TITLE
feat: render live resume thumbnails on template and resume cards

### DIFF
--- a/src/components/editor/resume-thumbnail.tsx
+++ b/src/components/editor/resume-thumbnail.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { TemplateId } from "@/lib/templates";
+import { buildResumeBlocks } from "./resume-blocks";
+import { A4 } from "./resume-geometry";
+import { ResumePage } from "./resume-page";
+import type { ResumePreview } from "./resume-preview";
+import { TEMPLATE_BLOCK_VIEWS } from "./templates/template-block-view";
+
+interface ResumeThumbnailProps {
+  resume: ResumePreview;
+  template: TemplateId;
+}
+
+/**
+ * A miniature, non-interactive render of a résumé's first page, scaled with a
+ * CSS transform to fill the container width. Unlike ResumeDocument there is no
+ * measurement or pagination pass — blocks flow linearly and the page frame's
+ * overflow clipping cuts everything past page one — so it is cheap enough to
+ * render per card in a grid.
+ */
+export function ResumeThumbnail(props: ResumeThumbnailProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(0);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) setWidth(entry.contentRect.width);
+    });
+    observer.observe(el);
+
+    return () => observer.disconnect();
+  }, []);
+
+  const blocks = useMemo(() => buildResumeBlocks(props.resume), [props.resume]);
+  const BlockView = TEMPLATE_BLOCK_VIEWS[props.template];
+  const scale = width > 0 ? width / A4.widthPx : 0;
+
+  return (
+    <div
+      ref={containerRef}
+      inert
+      aria-hidden
+      data-template={props.template}
+      className="pointer-events-none w-full select-none"
+    >
+      {scale > 0 && (
+        <div style={{ height: A4.heightPx * scale }}>
+          <div
+            style={{
+              width: A4.widthPx,
+              transform: `scale(${scale})`,
+              transformOrigin: "top left",
+            }}
+          >
+            <ResumePage page={1} total={1}>
+              {blocks.map((block, index) => (
+                <div
+                  key={block.id}
+                  style={{ marginTop: index === 0 ? 0 : block.gapBefore }}
+                >
+                  <BlockView block={block} />
+                </div>
+              ))}
+            </ResumePage>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/platform/platform-empty-state.tsx
+++ b/src/components/platform/platform-empty-state.tsx
@@ -30,10 +30,10 @@ export function PlatformEmptyState() {
             <Inbox />
           </EmptyMedia>
 
-          <EmptyTitle>No Résumé Yet</EmptyTitle>
+          <EmptyTitle>No résumés yet</EmptyTitle>
           <EmptyDescription>
-            You have not yet create a résumé on this device. You can create a
-            new résumé from scratch or from sample below.
+            Nothing is saved on this device yet. Start from a template, or
+            create a blank résumé.
           </EmptyDescription>
 
           <div className="inline-flex items-center gap-2">
@@ -41,10 +41,10 @@ export function PlatformEmptyState() {
               nativeButton={false}
               render={<Link href="/platform/template" />}
             >
-              <Search /> Browse Template
+              <Search /> Browse templates
             </Button>
             <Button variant="secondary" onClick={() => setOpen(true)}>
-              <FilePlus /> New Résumé
+              <FilePlus /> New résumé
             </Button>
           </div>
         </EmptyHeader>

--- a/src/components/platform/platform-paper-frame.tsx
+++ b/src/components/platform/platform-paper-frame.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from "react";
+
+/**
+ * The card "desk": a dotted work surface with an A4 sheet resting on it. The
+ * sheet is pinned near the top and clipped by the frame, so the paper visibly
+ * runs past the bottom edge — the page continues — and lifts on card hover.
+ */
+export function PlatformPaperFrame(props: { children: ReactNode }) {
+  return (
+    <div className="relative aspect-4/3 overflow-hidden border-b bg-muted/40 bg-[radial-gradient(color-mix(in_oklab,var(--color-foreground)_7%,transparent)_1px,transparent_1px)] bg-size-[0.625rem_0.625rem]">
+      <div className="absolute inset-x-5 top-5 overflow-hidden rounded-xs bg-white shadow-md ring-1 ring-black/5 transition-[translate,box-shadow] duration-300 ease-out group-hover/card:-translate-y-1 group-hover/card:shadow-lg motion-reduce:transition-none motion-reduce:group-hover/card:translate-y-0">
+        {props.children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/platform/platform-resume-create-dialog.tsx
+++ b/src/components/platform/platform-resume-create-dialog.tsx
@@ -3,6 +3,7 @@
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
 import { Save, TextInitial, XIcon } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import {
   RESUME_TITLE_MAX_LENGTH,
@@ -10,6 +11,7 @@ import {
   resumeTitleSchema,
 } from "@/lib/forms/resume";
 import { useResumeStore } from "@/lib/store";
+import { DEFAULT_TEMPLATE_ID, resolveTemplateId } from "@/lib/templates";
 import { Button } from "../ui/button";
 import {
   Dialog,
@@ -32,6 +34,7 @@ import {
   InputGroupAddon,
   InputGroupInput,
 } from "../ui/input-group";
+import { PlatformTemplateRadioGroup } from "./platform-template-radio-group";
 
 interface PlatformResumeCreateDialogProps {
   open: boolean;
@@ -47,6 +50,9 @@ export function PlatformResumeCreateDialog(
 ) {
   const router = useRouter();
   const createResume = useResumeStore((state) => state.createResume);
+  const [templateId, setTemplateId] = useState(() =>
+    resolveTemplateId(props.templateId ?? DEFAULT_TEMPLATE_ID),
+  );
   const form = useForm<ResumeTitleForm>({
     resolver: standardSchemaResolver(resumeTitleSchema),
     defaultValues: { title: props.initialTitle ?? "" },
@@ -54,13 +60,11 @@ export function PlatformResumeCreateDialog(
   });
 
   const onSubmit = form.handleSubmit(async (values) => {
-    const resume = await createResume(values.title, props.templateId);
+    const resume = await createResume(values.title, templateId);
     form.reset({ title: "" });
     props.onOpenChange(false);
     router.push(`/platform/editor/${resume.id}`);
   });
-
-  const error = form.formState.errors.title;
 
   return (
     <Dialog open={props.open} onOpenChange={props.onOpenChange}>
@@ -74,37 +78,42 @@ export function PlatformResumeCreateDialog(
 
         <form onSubmit={onSubmit}>
           <FieldGroup>
-            <Field data-invalid={error ? true : undefined}>
-              <FieldLabel htmlFor="create-resume-title">
-                Résumé label
-              </FieldLabel>
-              <InputGroup>
-                <InputGroupAddon>
-                  <TextInitial />
-                </InputGroupAddon>
-
-                <Controller
-                  control={form.control}
-                  name="title"
-                  render={({ field }) => (
+            <Controller
+              control={form.control}
+              name="title"
+              render={({ field, fieldState }) => (
+                <Field data-invalid={fieldState.invalid}>
+                  <FieldLabel htmlFor="create-resume-title">
+                    Résumé label
+                  </FieldLabel>
+                  <InputGroup>
+                    <InputGroupAddon>
+                      <TextInitial />
+                    </InputGroupAddon>
                     <InputGroupInput
                       id="create-resume-title"
                       maxLength={RESUME_TITLE_MAX_LENGTH}
                       placeholder="Software Engineer"
-                      aria-invalid={error ? true : undefined}
+                      aria-invalid={fieldState.invalid}
                       {...field}
                     />
-                  )}
-                />
-              </InputGroup>
+                  </InputGroup>
 
-              {error ? (
-                <FieldError>{error.message}</FieldError>
-              ) : (
-                <FieldDescription>
-                  At least 3 characters or more, maximum 100 chars at most.
-                </FieldDescription>
+                  <FieldDescription>
+                    At least 3 characters or more, maximum 100 chars at most.
+                  </FieldDescription>
+
+                  <FieldError errors={[fieldState.error]} />
+                </Field>
               )}
+            />
+
+            <Field>
+              <FieldLabel>Template</FieldLabel>
+              <PlatformTemplateRadioGroup
+                value={templateId}
+                onValueChange={setTemplateId}
+              />
             </Field>
           </FieldGroup>
 

--- a/src/components/platform/platform-resume-grid/platform-resume-grid-item-new.tsx
+++ b/src/components/platform/platform-resume-grid/platform-resume-grid-item-new.tsx
@@ -1,39 +1,26 @@
 "use client";
 
-import { FilePlus2, Plus } from "lucide-react";
+import { FilePlus2 } from "lucide-react";
 import { useState } from "react";
-import { Button } from "@/components/ui/button";
-import {
-  Empty,
-  EmptyContent,
-  EmptyDescription,
-  EmptyHeader,
-  EmptyMedia,
-  EmptyTitle,
-} from "@/components/ui/empty";
 import { PlatformResumeCreateDialog } from "../platform-resume-create-dialog";
 
 export function PlatformResumeGridItemNew() {
   const [open, setOpen] = useState(false);
 
   return (
-    <Empty className="py-4 gap-2 border border-dashed">
-      <EmptyHeader className="gap-1">
-        <EmptyMedia variant="icon" className="size-7">
-          <FilePlus2 className="size-3.5" />
-        </EmptyMedia>
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="flex h-full min-h-56 w-full cursor-pointer flex-col items-center justify-center gap-3 rounded-[min(var(--radius-4xl),24px)] border border-dashed text-muted-foreground transition-colors hover:border-ring/60 hover:bg-muted/40 hover:text-foreground focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring"
+      >
+        <span className="flex size-10 items-center justify-center rounded-xl border bg-muted/60">
+          <FilePlus2 className="size-4" />
+        </span>
+        <span className="text-sm font-medium">New résumé</span>
+      </button>
 
-        <EmptyTitle className="text-sm">Add Résumé</EmptyTitle>
-        <EmptyDescription className="sr-only">Add more resume</EmptyDescription>
-      </EmptyHeader>
-
-      <EmptyContent>
-        <Button variant="secondary" size="sm" onClick={() => setOpen(true)}>
-          <Plus /> Résumé
-        </Button>
-
-        <PlatformResumeCreateDialog open={open} onOpenChange={setOpen} />
-      </EmptyContent>
-    </Empty>
+      <PlatformResumeCreateDialog open={open} onOpenChange={setOpen} />
+    </>
   );
 }

--- a/src/components/platform/platform-resume-grid/platform-resume-grid-item-thumbnail.tsx
+++ b/src/components/platform/platform-resume-grid/platform-resume-grid-item-thumbnail.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useMemo } from "react";
+import { ResumeThumbnail } from "@/components/editor/resume-thumbnail";
+import { resumeToPreview } from "@/components/editor/resume-to-preview";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useResumeDocument } from "@/hooks/use-resume-document";
+import type { ResumeIndexEntry } from "@/lib/resume";
+import { resolveTemplateId } from "@/lib/templates";
+import { PlatformPaperFrame } from "../platform-paper-frame";
+
+interface PlatformResumeGridItemThumbnailProps {
+  resume: ResumeIndexEntry;
+}
+
+export function PlatformResumeGridItemThumbnail({
+  resume,
+}: PlatformResumeGridItemThumbnailProps) {
+  const document = useResumeDocument(resume.id, resume.updatedAt);
+  const preview = useMemo(
+    () => (document ? resumeToPreview(document) : null),
+    [document],
+  );
+
+  return (
+    <PlatformPaperFrame>
+      {document && preview ? (
+        <ResumeThumbnail
+          resume={preview}
+          template={resolveTemplateId(document.templateId)}
+        />
+      ) : (
+        <Skeleton className="aspect-210/297 w-full rounded-none" />
+      )}
+    </PlatformPaperFrame>
+  );
+}

--- a/src/components/platform/platform-resume-grid/platform-resume-grid-item.tsx
+++ b/src/components/platform/platform-resume-grid/platform-resume-grid-item.tsx
@@ -1,12 +1,9 @@
 import { format, formatDistanceStrict } from "date-fns";
-import { Eye } from "lucide-react";
 import Link from "next/link";
-import { Button } from "@/components/ui/button";
 import {
   Card,
   CardAction,
   CardDescription,
-  CardFooter,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
@@ -17,6 +14,7 @@ import {
 } from "@/components/ui/tooltip";
 import type { ResumeIndexEntry } from "@/lib/resume";
 import { PlatformResumeGridItemMenu } from "./platform-resume-grid-item-menu";
+import { PlatformResumeGridItemThumbnail } from "./platform-resume-grid-item-thumbnail";
 
 interface PlatformResumeGridItemProps {
   resume: ResumeIndexEntry;
@@ -26,13 +24,30 @@ export function PlatformResumeGridItem({
   resume,
 }: PlatformResumeGridItemProps) {
   const updatedAt = new Date(resume.updatedAt);
+  const href = `/platform/editor/${resume.id}`;
 
   return (
-    <Card size="sm">
+    <Card size="sm" className="pt-0">
+      <div className="relative">
+        <PlatformResumeGridItemThumbnail resume={resume} />
+        <Link
+          href={href}
+          aria-label={`Open ${resume.title}`}
+          className="absolute inset-0 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring"
+        />
+      </div>
+
       <CardHeader>
-        <CardTitle className="truncate">{resume.title}</CardTitle>
+        <CardTitle className="truncate">
+          <Link
+            href={href}
+            className="rounded-xs hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+          >
+            {resume.title}
+          </Link>
+        </CardTitle>
         <CardDescription className="text-xs">
-          Last modified:{" "}
+          Edited{" "}
           <Tooltip>
             <TooltipTrigger render={<time dateTime={resume.updatedAt} />}>
               {formatDistanceStrict(updatedAt, Date.now(), { addSuffix: true })}
@@ -47,17 +62,6 @@ export function PlatformResumeGridItem({
           <PlatformResumeGridItemMenu resume={resume} />
         </CardAction>
       </CardHeader>
-
-      <CardFooter className="justify-end gap-2 mt-auto">
-        <Button
-          size="sm"
-          nativeButton={false}
-          render={<Link href={`/platform/editor/${resume.id}`} />}
-        >
-          <Eye />
-          View
-        </Button>
-      </CardFooter>
     </Card>
   );
 }

--- a/src/components/platform/platform-resume-grid/platform-resume-grid-skeleton.tsx
+++ b/src/components/platform/platform-resume-grid/platform-resume-grid-skeleton.tsx
@@ -1,12 +1,23 @@
+import { Card, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { PlatformPaperFrame } from "../platform-paper-frame";
 
 const PLACEHOLDERS = ["a", "b", "c", "d", "e", "f"];
 
 export function PlatformResumeGridSkeleton() {
   return (
-    <div className="grid grid-cols-[repeat(auto-fill,minmax(min(100%,16rem),1fr))] gap-4">
+    <div className="grid grid-cols-[repeat(auto-fill,minmax(min(100%,21rem),1fr))] gap-4">
       {PLACEHOLDERS.map((key) => (
-        <Skeleton key={key} className="h-40 rounded-xl" />
+        <Card key={key} size="sm" className="pt-0">
+          <PlatformPaperFrame>
+            <Skeleton className="aspect-210/297 w-full rounded-none" />
+          </PlatformPaperFrame>
+
+          <CardHeader>
+            <Skeleton className="h-5 w-2/5" />
+            <Skeleton className="h-4 w-1/4" />
+          </CardHeader>
+        </Card>
       ))}
     </div>
   );

--- a/src/components/platform/platform-resume-grid/platform-resume-grid.tsx
+++ b/src/components/platform/platform-resume-grid/platform-resume-grid.tsx
@@ -25,7 +25,7 @@ export function PlatformResumeGrid() {
   }
 
   return (
-    <div className="grid grid-cols-[repeat(auto-fill,minmax(min(100%,16rem),1fr))] gap-4">
+    <div className="grid grid-cols-[repeat(auto-fill,minmax(min(100%,21rem),1fr))] gap-4">
       {results.map((resume) => (
         <PlatformResumeGridItem key={resume.id} resume={resume} />
       ))}

--- a/src/components/platform/platform-sidebar-resume-create.tsx
+++ b/src/components/platform/platform-sidebar-resume-create.tsx
@@ -12,7 +12,7 @@ export function PlatformSidebarResumeCreate() {
     <>
       <Button
         size="icon-xs"
-        className="ml-auto -mr-3"
+        className="ml-auto"
         variant="ghost"
         onClick={() => setOpen(true)}
       >

--- a/src/components/platform/platform-template-grid/platform-template-grid-item.tsx
+++ b/src/components/platform/platform-template-grid/platform-template-grid-item.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState } from "react";
+import { ResumeThumbnail } from "@/components/editor/resume-thumbnail";
+import { resumeToPreview } from "@/components/editor/resume-to-preview";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -9,8 +11,12 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { SEED_RESUME } from "@/lib/resume";
 import type { TemplateSummary } from "@/lib/templates";
+import { PlatformPaperFrame } from "../platform-paper-frame";
 import { PlatformResumeCreateDialog } from "../platform-resume-create-dialog";
+
+const SEED_PREVIEW = resumeToPreview(SEED_RESUME);
 
 interface PlatformTemplateGridItemProps {
   template: TemplateSummary;
@@ -22,7 +28,19 @@ export function PlatformTemplateGridItem({
   const [open, setOpen] = useState(false);
 
   return (
-    <Card size="sm">
+    <Card size="sm" className="pt-0">
+      <div className="relative">
+        <PlatformPaperFrame>
+          <ResumeThumbnail resume={SEED_PREVIEW} template={template.id} />
+        </PlatformPaperFrame>
+        <button
+          type="button"
+          aria-label={`Use ${template.name}`}
+          onClick={() => setOpen(true)}
+          className="absolute inset-0 cursor-pointer focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring"
+        />
+      </div>
+
       <CardHeader>
         <CardTitle className="truncate">{template.name}</CardTitle>
         <CardDescription className="line-clamp-3 text-xs">
@@ -30,9 +48,9 @@ export function PlatformTemplateGridItem({
         </CardDescription>
       </CardHeader>
 
-      <CardFooter className="mt-auto justify-end">
-        <Button size="sm" onClick={() => setOpen(true)}>
-          Use template
+      <CardFooter className="mt-auto">
+        <Button size="lg" className="w-full" onClick={() => setOpen(true)}>
+          Use {template.name}
         </Button>
       </CardFooter>
 

--- a/src/components/platform/platform-template-grid/platform-template-grid.tsx
+++ b/src/components/platform/platform-template-grid/platform-template-grid.tsx
@@ -22,7 +22,7 @@ export function PlatformTemplateGrid() {
   }
 
   return (
-    <div className="grid grid-cols-[repeat(auto-fill,minmax(min(100%,16rem),1fr))] gap-4">
+    <div className="grid grid-cols-[repeat(auto-fill,minmax(min(100%,24rem),1fr))] gap-4">
       {results.map((template) => (
         <PlatformTemplateGridItem key={template.id} template={template} />
       ))}

--- a/src/components/platform/platform-template-radio-group.tsx
+++ b/src/components/platform/platform-template-radio-group.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { Radio as RadioPrimitive } from "@base-ui/react/radio";
+import { CheckIcon } from "lucide-react";
+import { motion } from "motion/react";
+import { ResumeThumbnail } from "@/components/editor/resume-thumbnail";
+import { resumeToPreview } from "@/components/editor/resume-to-preview";
+import { RadioGroup } from "@/components/ui/radio-group";
+import { SEED_RESUME } from "@/lib/resume";
+import { TEMPLATES, type TemplateId } from "@/lib/templates";
+
+const SEED_PREVIEW = resumeToPreview(SEED_RESUME);
+
+interface PlatformTemplateRadioGroupProps {
+  value: TemplateId;
+  onValueChange: (next: TemplateId) => void;
+}
+
+/**
+ * Template chooser: a radio list of template names beside one live seed-data
+ * preview of the selected template. A single legible preview beats a tile per
+ * template — at dialog size six mini-renders are unreadable.
+ */
+export function PlatformTemplateRadioGroup(
+  props: PlatformTemplateRadioGroupProps,
+) {
+  return (
+    <div className="grid grid-cols-[1fr_11rem] gap-3">
+      <RadioGroup
+        value={props.value}
+        onValueChange={(value) => props.onValueChange(value as TemplateId)}
+        className="flex flex-col gap-0"
+      >
+        {TEMPLATES.map((template) => (
+          <RadioPrimitive.Root
+            key={template.id}
+            value={template.id}
+            className="group/option flex cursor-pointer items-center gap-2 rounded-lg border border-transparent px-3 py-2 text-left text-sm outline-none transition-colors hover:bg-accent/50 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 data-checked:border-border data-checked:bg-accent data-checked:font-medium"
+          >
+            {template.name}
+            <CheckIcon className="ml-auto size-3.5 text-primary opacity-0 transition-opacity group-data-checked/option:opacity-100" />
+          </RadioPrimitive.Root>
+        ))}
+      </RadioGroup>
+
+      <div
+        aria-hidden
+        className="pointer-events-none relative overflow-hidden rounded-xl border bg-muted/40 bg-[radial-gradient(color-mix(in_oklab,var(--color-foreground)_7%,transparent)_1px,transparent_1px)] bg-size-[0.625rem_0.625rem]"
+      >
+        <motion.div
+          key={props.value}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.18, ease: "easeOut" }}
+          className="absolute inset-x-4 top-4 overflow-hidden rounded-xs bg-white shadow-md ring-1 ring-black/5"
+        >
+          <ResumeThumbnail resume={SEED_PREVIEW} template={props.value} />
+        </motion.div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/platform/platform-template-toolbar.tsx
+++ b/src/components/platform/platform-template-toolbar.tsx
@@ -44,6 +44,7 @@ export function PlatformTemplateToolbar() {
 
       <div className="ml-auto">
         <Select
+          items={SORT_OPTIONS}
           value={sort}
           onValueChange={(value) => setSort(value as TemplateSort)}
         >

--- a/src/hooks/use-resume-document.ts
+++ b/src/hooks/use-resume-document.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getResume } from "@/lib/db";
+import type { Resume } from "@/lib/resume";
+
+/**
+ * Loads one full résumé document from IndexedDB for read-only display (card
+ * thumbnails). Reading IndexedDB is an external-system effect; `updatedAt`
+ * keys the fetch so the document is re-read when the index reports a newer
+ * write.
+ */
+export function useResumeDocument(id: string, updatedAt: string) {
+  const [resume, setResume] = useState<Resume | null>(null);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `updatedAt` is a deliberate re-fetch trigger — the id alone doesn't change when the document is edited.
+  useEffect(() => {
+    let cancelled = false;
+    void getResume(id).then((document) => {
+      if (!cancelled) setResume(document ?? null);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [id, updatedAt]);
+
+  return resume;
+}


### PR DESCRIPTION
## Summary
- **Live thumbnails instead of screenshots.** New `ResumeThumbnail` renders a résumé's real first page — same `ResumePage` frame and per-template block views as the editor preview — at fixed A4 size, CSS-scaled to the card. No measurement/pagination pass: blocks flow linearly and the page frame clips past page one, so it's cheap enough for grids. The subtree is `inert` (its rendered anchors must not join the tab order).
- **Paper-on-desk card design.** Both grids share a `PlatformPaperFrame`: a dotted work surface with the A4 sheet pinned near the top, visibly running off the bottom edge, lifting on card hover (`motion-reduce` respected). The sheet is the card's primary click target via an overlay link/button — the thumbnail contains real `<a>` elements, so wrapping it in an anchor or button would nest interactive elements.
- **Dashboard cards** show each résumé's actual content, loaded per card from IndexedDB by the new `useResumeDocument` hook (re-fetched when `updatedAt` changes). The redundant View button is gone — paper and title both link to the editor.
- **Template cards** show the seed résumé styled per template, with specific action copy ("Use Ketat").
- **Create dialog template chooser**: a radio list of template names beside one legible live preview of the selection (six mini-tiles were unreadable), defaulting to Awal, preselecting the template when opened from a template card, arrow-key navigation drives the preview.
- **Fixes**: template sort select now shows its label instead of the raw value (`items` on the Select root); skeleton/empty state/new-résumé tile match the new card design; grid columns widened.

## Notes
- Presentation-only; the structural layer is untouched. All document reads are local IndexedDB — no resume content is sent to any server.
- Keyboard pass done: no hidden tab stops inside thumbnails (`inert`), inset focus outlines on overlay targets survive card clipping.