### PR TITLE
chore: add issue forms and pull request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,72 @@
+name: Bug report
+description: Something in Lanjut is broken or behaving unexpectedly.
+title: "fix: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Lanjut is local-first — your résumé data lives only in your browser, so maintainers can't look anything up on a server. The details you provide here are all we have to go on.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug. Screenshots and screen recordings help a lot.
+      placeholder: The editor preview goes blank when...
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Create a résumé from the Ketat template
+        2. Add a second experience entry
+        3. Drag it above the first one
+        4. The preview...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Where does the bug show up?
+      options:
+        - Editor
+        - Résumé preview
+        - Templates
+        - Export (PDF / DOCX / TXT)
+        - Dashboard / library
+        - Landing page
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: browser
+    attributes:
+      label: Browser and OS
+      description: Storage is per-browser (IndexedDB), so this matters more than usual.
+      placeholder: e.g. Chrome 138 on macOS 15, Firefox 140 on Windows 11
+    validations:
+      required: true
+  - type: textarea
+    id: console
+    attributes:
+      label: Console errors
+      description: Open the browser devtools console and paste any errors that appear when the bug happens.
+      render: text
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this hasn't been reported yet.
+          required: true
+        - label: I understand my résumé data never leaves my browser, so I've included enough detail (or a sample export) to reproduce the problem without it.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,49 @@
+name: Feature request
+description: Suggest an improvement or a new capability for Lanjut.
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before writing, a quick note on scope: Lanjut deliberately restricts the *structure* of a résumé so it parses cleanly in applicant tracking systems. Presentation (typography, spacing, color, section order) is fully customizable; structure (tables, multi-column layouts, text boxes, inline images) is not — regardless of how the request is framed. Accounts and server-side storage are also non-goals.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the situation where you needed this, rather than the solution itself.
+      placeholder: When I tailor my résumé for different roles, I have to...
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How do you imagine it working?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you use today, or other ways this could be solved.
+  - type: dropdown
+    id: layer
+    attributes:
+      label: Which layer does this touch?
+      options:
+        - Presentation (typography, spacing, color, ordering)
+        - Editor experience (no change to the document itself)
+        - Export (PDF / DOCX / TXT)
+        - Other / not sure
+    validations:
+      required: true
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this hasn't been requested yet.
+          required: true
+        - label: This request doesn't add structural freedom that breaks ATS parseability (tables, columns, floating elements, decorative icons in text), and doesn't require accounts or server-side storage.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+# Summary
+
+<!-- What does this PR do, and why? Link the issue it addresses if there is one. -->
+
+Closes #
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] Feature
+
+## How was this tested?
+
+<!-- Manual steps, browsers checked, screenshots/recordings for UI changes. -->
+
+## Checklist
+
+- [ ] The PR title follows the commitlint convention (`feat: ...` / `fix: ...`, subject fully lowercase — it becomes the squash-merge commit).
+- [ ] Lint and format pass locally (`biome check`); commits were made without `--no-verify`.
+- [ ] No résumé content is sent to any server, API route, or open-next function (confirm on every PR touching data flow).
+- [ ] Changes keep the structural layer intact: presentation-only styling, no tables/columns/floating elements in the document model.
+- [ ] If the export path changed: text extraction order verified (e.g. `pdftotext`) and output checked against at least one real ATS parser.
+- [ ] If the résumé schema changed: schema version bumped and a migration path added for existing saved résumés.


### PR DESCRIPTION
## Summary
- Add GitHub issue forms for the two categories: **bug report** (`fix:` pre-title, `bug` label) and **feature request** (`feat:` pre-title, `enhancement` label)
- Bug form asks for area, required browser/OS (IndexedDB storage is per-browser), steps, and console errors — and reminds reporters that maintainers can't inspect any server-side data, so the report must carry the reproduction
- Feature form leads with the problem statement, asks which layer the request touches, and requires acknowledging the ATS-parseability / no-accounts non-goals from AGENTS.md
- `config.yml` disables blank issues so everything comes through a form
- PR template: summary, bug fix / feature type, testing notes, and a checklist encoding the repo's gates (lowercase commitlint PR titles, Biome without `--no-verify`, no résumé content sent to any server, structural layer intact, export-path verification, schema version + migration)

## Notes
- Forms render on GitHub's web UI — worth opening the New Issue page after merge to confirm they read well