### PR TITLE
chore: refresh docs and drop unused dnd-kit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,6 @@ An ATS Builder. Free, Open-Source, local-first resume builder. Customizable pres
 - open-next on Cloudflare (hosting only, no server-side handling of user resume data)
 - shadcn (base-ui variant)
 - Tailwind CSS
-- dnd-kit (section reordering, drag and drop)
 - [TipTap](https://tiptap.dev/docs) (rich text editing, restricted extension set)
 - motion/react (animation)
 - zustand (in-memory state)
@@ -45,10 +44,9 @@ Any feature request that adds structural freedom (tables, columns, floating elem
 - Schema for a resume document: versioned. Add a schema version field. Write a migration path before changing field shapes, do not silently break old saved resumes.
 
 
-## Drag and Drop (dnd-kit)
+## Reordering
 
-- Used for section reordering and field reordering within a section (e.g., experience entries).
-- Drag and drop changes ordering metadata only. It does not alter content schema.
+- Section and entry reordering (if/when built) changes ordering metadata only. It does not alter content schema.
 
 ## Export
 
@@ -66,10 +64,9 @@ Any feature request that adds structural freedom (tables, columns, floating elem
 1. Resume data schema + IndexedDB layer
 2. zustand store wired to persistence
 3. TipTap fields with restricted schemas
-4. dnd-kit section/field reordering
-5. Presentation layer (themes, typography, spacing)
-6. Export pipeline (PDF, then docx/txt)
-7. Parser validation pass
+4. Presentation layer (themes, typography, spacing)
+5. Export pipeline (PDF, then docx/txt)
+6. Parser validation pass
 
 ## Non-Goals
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ An ATS Builder. Free, Open-Source, local-first resume builder. Customizable pres
 - shadcn (base-ui variant)
 - Tailwind CSS
 - dnd-kit (section reordering, drag and drop)
-- [PlateJS](https://platejs.org/llms.txt)
+- [TipTap](https://tiptap.dev/docs) (rich text editing, restricted extension set)
 - motion/react (animation)
 - zustand (in-memory state)
 - IndexedDB via idb (persistence layer)
@@ -31,7 +31,7 @@ An ATS Builder. Free, Open-Source, local-first resume builder. Customizable pres
 
 ## Architecture Rule: Two Layers
 
-1. Structural layer. Fixed section types (header, summary, experience, education, skills, custom sections from an approved list). Each field has a restricted PlateJS schema: bold, italic, bullet list, ordered list, link. No tables, no multi-column layout, no text boxes, no inline images, no custom heading levels beyond what the section template defines.
+1. Structural layer. Fixed section types (header, summary, experience, education, skills, custom sections from an approved list). Each field has a restricted TipTap schema: bold, italic, bullet list, ordered list, link. No tables, no multi-column layout, no text boxes, no inline images, no custom heading levels beyond what the section template defines.
 
 2. Presentation layer. Typography, spacing, color, accent styles, section visual ordering. Fully customizable. Must never alter the underlying linear text structure used for parsing or export.
 
@@ -65,7 +65,7 @@ Any feature request that adds structural freedom (tables, columns, floating elem
 
 1. Resume data schema + IndexedDB layer
 2. zustand store wired to persistence
-3. PlateJS fields with restricted schemas
+3. TipTap fields with restricted schemas
 4. dnd-kit section/field reordering
 5. Presentation layer (themes, typography, spacing)
 6. Export pipeline (PDF, then docx/txt)

--- a/README.md
+++ b/README.md
@@ -1,23 +1,48 @@
-# Lanjut
+<p align="center">
+  <img src="public/favicon.svg" alt="" width="56" height="56" />
+</p>
 
-ATS Builder. Free, open-source resume builder. Runs locally in the browser. No account, no server-side storage of resume content.
+<h1 align="center">Lanjut</h1>
+
+<p align="center">
+  ATS Builder. Free, open-source resume builder. Runs locally in the browser. No account, no server-side storage of resume content.
+  <br />
+  <a href="https://lanjut.rimzzlabs.com"><strong>lanjut.rimzzlabs.com</strong></a>
+</p>
 
 ## What This Is
 
 A resume builder split into two layers:
 
-- **Structural layer**: fixed section types (header, summary, experience, education, skills) with a restricted rich-text schema per field. This keeps export output parseable by Applicant Tracking System (ATS) software.
+- **Structural layer**: fixed section types (header, summary, experience, education, skills, languages, certificates) with a restricted rich-text schema per field. This keeps export output parseable by Applicant Tracking System (ATS) software.
 - **Presentation layer**: typography, spacing, color, and theming. Fully customizable. Changes here never affect the underlying text structure used for parsing or export.
 
 Customization applies to how the resume looks. It does not extend to layouts that break ATS parsing (tables, multi-column body text, floating text boxes, embedded icons in text runs).
 
 ## Features
 
+- Six résumé templates, all sharing one linear document structure — only styling differs
+- Template gallery with search, sort, and live seed-data previews
+- Résumé library with live first-page thumbnails, rename, and delete
+- Print-accurate A4 preview with automatic pagination
 - Drag-and-drop section and entry reordering
 - Rich text editing per field, scoped to ATS-safe formatting (bold, italic, lists, links)
 - Local persistence via IndexedDB, no data leaves the browser
 - Export to PDF (linear reading order preserved) and plain text / .docx
 - Fully local: works offline after initial load
+
+## Templates
+
+| Template | Character |
+|---|---|
+| **Awal** | Clean single-column starter with room for every section |
+| **Ketat** | Compact serif classic: ruled headings, italic dates |
+| **Luasa** | Airy minimalist: letterspaced headings, generous whitespace |
+| **Tebal** | Bold modern statement: oversized name, heavy uppercase headings |
+| **Klasik** | Traditional all-serif CV: centered, quiet, formal |
+| **Ketik** | Typewriter-flavored technical look, built for developers |
+
+Every template renders the same linear block sequence, so switching templates never changes parse or export order.
 
 ## Tech Stack
 
@@ -31,6 +56,7 @@ Customization applies to how the resume looks. It does not extend to layouts tha
 | Rich text editor | TipTap |
 | Animation | motion/react |
 | State | zustand |
+| Search params state | nuqs |
 | Persistence | IndexedDB (via idb) |
 | Utilities | @mobily/ts-belt |
 | Dates | date-fns |
@@ -46,6 +72,17 @@ pnpm dev
 
 Open `http://localhost:3000`.
 
+### Useful scripts
+
+| Script | What it does |
+|---|---|
+| `pnpm dev` | Start the dev server |
+| `pnpm lint` / `pnpm format` | Check / write with Biome |
+| `pnpm validate:exports` | Regenerate PDF/DOCX/TXT from the seed résumé and verify extraction order and field mapping |
+| `pnpm preview` | Build with open-next and preview the Cloudflare worker locally |
+| `pnpm ship` | Build and deploy to Cloudflare |
+| `pnpm commit` | Commit via the commitizen prompt |
+
 ## Data and Privacy
 
 Resume content is stored in IndexedDB in the browser. No resume content is sent to any server, API route, or third-party service. Clearing browser storage deletes saved resumes; export your work before doing so.
@@ -55,9 +92,13 @@ Resume content is stored in IndexedDB in the browser. No resume content is sent 
 - **PDF**: structured text export, not a visual snapshot. Reading order is preserved for ATS text extraction.
 - **DOCX / plain text**: direct ATS-submission-safe formats, recommended over PDF for systems with strict parsing requirements.
 
+Changes to the export path are gated by `pnpm validate:exports`, which regenerates every format from the seed résumé and verifies, via real text extraction, that linear reading order is preserved and every field maps through.
+
 ## Contributing
 
-Commit messages follow Conventional Commits via commitlint and commitizen. Run `pnpm commit` instead of `git commit` to use the prompt. Pre-commit hooks (husky + lint-staged) run lint and format checks before any commit is accepted.
+Bug reports and feature requests go through the issue forms — note the scope rules there: presentation is customizable, structure is not, and accounts/server storage are non-goals.
+
+Commit messages follow Conventional Commits via commitlint and commitizen. Run `pnpm commit` instead of `git commit` to use the prompt. Pre-commit hooks (husky + lint-staged) run lint and format checks before any commit is accepted. PR titles follow the same convention with a fully lowercase subject — they become the squash-merge commit.
 
 See `AGENTS.md` for architecture rules and code conventions before submitting a PR.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Customization applies to how the resume looks. It does not extend to layouts tha
 - Template gallery with search, sort, and live seed-data previews
 - Résumé library with live first-page thumbnails, rename, and delete
 - Print-accurate A4 preview with automatic pagination
-- Drag-and-drop section and entry reordering
 - Rich text editing per field, scoped to ATS-safe formatting (bold, italic, lists, links)
 - Local persistence via IndexedDB, no data leaves the browser
 - Export to PDF (linear reading order preserved) and plain text / .docx
@@ -52,7 +51,6 @@ Every template renders the same linear block sequence, so switching templates ne
 | Hosting | open-next on Cloudflare |
 | UI components | shadcn (base-ui) |
 | Styling | Tailwind CSS |
-| Drag and drop | dnd-kit |
 | Rich text editor | TipTap |
 | Animation | motion/react |
 | State | zustand |

--- a/package.json
+++ b/package.json
@@ -22,9 +22,6 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",
-    "@dnd-kit/core": "^6.3.1",
-    "@dnd-kit/sortable": "^10.0.0",
-    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.4.0",
     "@mobily/ts-belt": "4.0.0-rc.5",
     "@opennextjs/cloudflare": "^1.20.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,15 +11,6 @@ importers:
       '@base-ui/react':
         specifier: ^1.6.0
         version: 1.6.0(@date-fns/tz@1.5.0)(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@dnd-kit/core':
-        specifier: ^6.3.1
-        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@dnd-kit/sortable':
-        specifier: ^10.0.0
-        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
-      '@dnd-kit/utilities':
-        specifier: ^3.2.2
-        version: 3.2.2(react@19.2.4)
       '@hookform/resolvers':
         specifier: ^5.4.0
         version: 5.4.0(react-hook-form@7.80.0(react@19.2.4))
@@ -819,28 +810,6 @@ packages:
 
   '@date-fns/tz@1.5.0':
     resolution: {integrity: sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==}
-
-  '@dnd-kit/accessibility@3.1.1':
-    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
-    peerDependencies:
-      react: '>=16.8.0'
-
-  '@dnd-kit/core@6.3.1':
-    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-
-  '@dnd-kit/sortable@10.0.0':
-    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
-    peerDependencies:
-      '@dnd-kit/core': ^6.3.0
-      react: '>=16.8.0'
-
-  '@dnd-kit/utilities@3.2.2':
-    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
-    peerDependencies:
-      react: '>=16.8.0'
 
   '@dotenvx/dotenvx@1.31.0':
     resolution: {integrity: sha512-GeDxvtjiRuoyWVU9nQneId879zIyNdL05bS7RKiqMkfBSKpHMWHLoRyRqjYWLaXmX/llKO1hTlqHDmatkQAjPA==}
@@ -5858,31 +5827,6 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.9
 
   '@date-fns/tz@1.5.0': {}
-
-  '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
-    dependencies:
-      react: 19.2.4
-      tslib: 2.8.1
-
-  '@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@dnd-kit/accessibility': 3.1.1(react@19.2.4)
-      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      tslib: 2.8.1
-
-  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
-      react: 19.2.4
-      tslib: 2.8.1
-
-  '@dnd-kit/utilities@3.2.2(react@19.2.4)':
-    dependencies:
-      react: 19.2.4
-      tslib: 2.8.1
 
   '@dotenvx/dotenvx@1.31.0':
     dependencies:


### PR DESCRIPTION
## Summary

### Docs refresh
- **README** brought up to date with 0.3.x reality: live-site link, six-template catalog table, gallery/thumbnail features, completed structural section list, `nuqs` in the stack, useful-scripts table (`validate:exports` documented from what the script actually does), contributing section pointing at the issue forms and the lowercase PR-title convention
- **AGENTS.md**: the rich text editor is **TipTap**, not PlateJS — `package.json` has `@tiptap/*` exclusively; the doc predated the implementation

### Dependency cleanup
- **Drop `@dnd-kit/core` / `sortable` / `utilities`** — zero imports anywhere in `src/`; the drag-and-drop reordering feature was never built
- Remove the drag-and-drop feature/stack claims from both docs; the AGENTS.md build order renumbers, and the rule that reordering (if ever built) changes ordering metadata only is kept
- `tsc` and `next build` pass after removal

## Notes
- No runtime code changes