### PR TITLE
fix: wire the download action on library resume cards

### DIFF
--- a/src/components/editor/download-resume.ts
+++ b/src/components/editor/download-resume.ts
@@ -1,0 +1,40 @@
+import type { Resume } from "@/lib/resume";
+import { resolveTemplateId } from "@/lib/templates";
+import { resumeToPreview } from "./resume-to-preview";
+
+export type ExportFormat = "pdf" | "docx" | "txt";
+
+export const EXPORT_FORMATS: ExportFormat[] = ["pdf", "docx", "txt"];
+
+/**
+ * Exports `resume` in the chosen format and triggers the browser download.
+ * Everything renders client-side — no résumé content leaves the device. The
+ * per-format modules are loaded lazily so the heavy PDF/docx libraries stay
+ * out of the main bundle.
+ */
+export async function downloadResume(
+  resume: Resume,
+  format: ExportFormat,
+  fileName: string,
+): Promise<void> {
+  const preview = resumeToPreview(resume);
+
+  if (format === "pdf") {
+    const { downloadResumePdf } = await import("./pdf/download-resume-pdf");
+    await downloadResumePdf(
+      preview,
+      fileName,
+      resolveTemplateId(resume.templateId),
+    );
+    return;
+  }
+
+  if (format === "docx") {
+    const { downloadResumeDocx } = await import("./docx/download-resume-docx");
+    await downloadResumeDocx(preview, fileName);
+    return;
+  }
+
+  const { downloadResumeText } = await import("./download-resume-text");
+  downloadResumeText(preview, fileName);
+}

--- a/src/components/platform/platform-navbar-download.tsx
+++ b/src/components/platform/platform-navbar-download.tsx
@@ -3,17 +3,12 @@
 import { Download } from "lucide-react";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
-import { resumeToPreview } from "@/components/editor/resume-to-preview";
-import { useResumeStore } from "@/lib/store";
-import { resolveTemplateId } from "@/lib/templates";
-import { Button } from "../ui/button";
-import { Field, FieldLabel } from "../ui/field";
 import {
-  InputGroup,
-  InputGroupAddon,
-  InputGroupInput,
-  InputGroupText,
-} from "../ui/input-group";
+  downloadResume,
+  type ExportFormat,
+} from "@/components/editor/download-resume";
+import { useResumeStore } from "@/lib/store";
+import { Button } from "../ui/button";
 import {
   Popover,
   PopoverContent,
@@ -22,55 +17,21 @@ import {
   PopoverTitle,
   PopoverTrigger,
 } from "../ui/popover";
-import { Spinner } from "../ui/spinner";
-import { ToggleGroup, ToggleGroupItem } from "../ui/toggle-group";
-
-type ExportFormat = "pdf" | "docx" | "txt";
-
-const FORMATS: ExportFormat[] = ["pdf", "docx", "txt"];
+import { PlatformResumeDownloadForm } from "./platform-resume-download-form";
 
 export function PlatformNavbarDownload() {
   const pathname = usePathname();
   const open = useResumeStore((state) => state.open);
   const [popoverOpen, setPopoverOpen] = useState(false);
-  const [fileName, setFileName] = useState("");
-  const [format, setFormat] = useState<ExportFormat>("pdf");
   const [generating, setGenerating] = useState(false);
 
   if (!pathname.includes("/editor/")) return null;
 
-  const onOpenChange = (next: boolean) => {
-    // Prefill the name with the résumé title each time the popover opens.
-    if (next && open) setFileName(open.title);
-    setPopoverOpen(next);
-  };
-
-  const onDownload = async () => {
+  const onDownload = async (format: ExportFormat, fileName: string) => {
     if (!open) return;
     setGenerating(true);
     try {
-      // Lazy-loaded so the heavy PDF/docx libraries stay out of the main bundle.
-      const preview = resumeToPreview(open);
-      if (format === "pdf") {
-        const { downloadResumePdf } = await import(
-          "@/components/editor/pdf/download-resume-pdf"
-        );
-        await downloadResumePdf(
-          preview,
-          fileName,
-          resolveTemplateId(open.templateId),
-        );
-      } else if (format === "docx") {
-        const { downloadResumeDocx } = await import(
-          "@/components/editor/docx/download-resume-docx"
-        );
-        await downloadResumeDocx(preview, fileName);
-      } else {
-        const { downloadResumeText } = await import(
-          "@/components/editor/download-resume-text"
-        );
-        downloadResumeText(preview, fileName);
-      }
+      await downloadResume(open, format, fileName);
       setPopoverOpen(false);
     } finally {
       setGenerating(false);
@@ -78,7 +39,7 @@ export function PlatformNavbarDownload() {
   };
 
   return (
-    <Popover open={popoverOpen} onOpenChange={onOpenChange}>
+    <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
       <PopoverTrigger render={<Button disabled={!open} />}>
         <Download /> Download Résumé
       </PopoverTrigger>
@@ -90,55 +51,12 @@ export function PlatformNavbarDownload() {
           </PopoverDescription>
         </PopoverHeader>
 
-        <form
-          onSubmit={(event) => {
-            event.preventDefault();
-            void onDownload();
-          }}
-        >
-          <Field>
-            <FieldLabel>Format</FieldLabel>
-            <ToggleGroup
-              variant="outline"
-              spacing={0}
-              className="w-full"
-              value={[format]}
-              onValueChange={(value) => {
-                const next = value[0] as ExportFormat | undefined;
-                if (next) setFormat(next);
-              }}
-            >
-              {FORMATS.map((value) => (
-                <ToggleGroupItem key={value} value={value} className="flex-1">
-                  {value.toUpperCase()}
-                </ToggleGroupItem>
-              ))}
-            </ToggleGroup>
-          </Field>
-
-          <Field className="mt-3">
-            <FieldLabel htmlFor="download-file-name">File name</FieldLabel>
-            <InputGroup>
-              <InputGroupInput
-                id="download-file-name"
-                value={fileName}
-                placeholder="resume"
-                onChange={(event) => setFileName(event.target.value)}
-              />
-              <InputGroupAddon align="inline-end">
-                <InputGroupText>.{format}</InputGroupText>
-              </InputGroupAddon>
-            </InputGroup>
-          </Field>
-
-          <Button
-            type="submit"
-            className="mt-3 w-full"
-            disabled={generating || !fileName.trim()}
-          >
-            {generating ? <Spinner /> : <Download />} Download
-          </Button>
-        </form>
+        <PlatformResumeDownloadForm
+          key={`${open?.id}-${popoverOpen}`}
+          defaultFileName={open?.title ?? ""}
+          generating={generating}
+          onSubmit={(format, fileName) => void onDownload(format, fileName)}
+        />
       </PopoverContent>
     </Popover>
   );

--- a/src/components/platform/platform-resume-action-download.tsx
+++ b/src/components/platform/platform-resume-action-download.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import {
+  downloadResume,
+  type ExportFormat,
+} from "@/components/editor/download-resume";
+import { getResume } from "@/lib/db";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "../ui/dialog";
+import { PlatformResumeDownloadForm } from "./platform-resume-download-form";
+
+interface PlatformResumeActionDownloadProps {
+  open: boolean;
+  onOpenChange: (next: boolean) => void;
+  resume: { id: string; title: string };
+}
+
+export function PlatformResumeActionDownload(
+  props: PlatformResumeActionDownloadProps,
+) {
+  const [generating, setGenerating] = useState(false);
+  const [missing, setMissing] = useState(false);
+
+  async function handleDownload(format: ExportFormat, fileName: string) {
+    setGenerating(true);
+    try {
+      const document = await getResume(props.resume.id);
+      if (!document) {
+        setMissing(true);
+        return;
+      }
+      await downloadResume(document, format, fileName);
+      props.onOpenChange(false);
+    } finally {
+      setGenerating(false);
+    }
+  }
+
+  return (
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Download {props.resume.title}</DialogTitle>
+          <DialogDescription>
+            Pick a format and name your file. The export is generated in your
+            browser.
+          </DialogDescription>
+        </DialogHeader>
+
+        {missing ? (
+          <p className="text-sm text-destructive">
+            This résumé could not be loaded from this browser's storage.
+          </p>
+        ) : (
+          <PlatformResumeDownloadForm
+            key={props.resume.title}
+            defaultFileName={props.resume.title}
+            generating={generating}
+            onSubmit={(format, fileName) =>
+              void handleDownload(format, fileName)
+            }
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/platform/platform-resume-download-form.tsx
+++ b/src/components/platform/platform-resume-download-form.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { Download } from "lucide-react";
+import { useState } from "react";
+import {
+  EXPORT_FORMATS,
+  type ExportFormat,
+} from "@/components/editor/download-resume";
+import { Button } from "../ui/button";
+import { Field, FieldLabel } from "../ui/field";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+  InputGroupText,
+} from "../ui/input-group";
+import { Spinner } from "../ui/spinner";
+import { ToggleGroup, ToggleGroupItem } from "../ui/toggle-group";
+
+interface PlatformResumeDownloadFormProps {
+  defaultFileName: string;
+  generating: boolean;
+  onSubmit: (format: ExportFormat, fileName: string) => void;
+}
+
+/**
+ * The format + file name form shared by every download surface (editor navbar
+ * popover, library card dialog). Remount via `key` to re-seed the file name.
+ */
+export function PlatformResumeDownloadForm(
+  props: PlatformResumeDownloadFormProps,
+) {
+  const [format, setFormat] = useState<ExportFormat>("pdf");
+  const [fileName, setFileName] = useState(props.defaultFileName);
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        props.onSubmit(format, fileName);
+      }}
+    >
+      <Field>
+        <FieldLabel>Format</FieldLabel>
+        <ToggleGroup
+          variant="outline"
+          spacing={0}
+          className="w-full"
+          value={[format]}
+          onValueChange={(value) => {
+            const next = value[0] as ExportFormat | undefined;
+            if (next) setFormat(next);
+          }}
+        >
+          {EXPORT_FORMATS.map((value) => (
+            <ToggleGroupItem key={value} value={value} className="flex-1">
+              {value.toUpperCase()}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+      </Field>
+
+      <Field className="mt-3">
+        <FieldLabel htmlFor="download-file-name">File name</FieldLabel>
+        <InputGroup>
+          <InputGroupInput
+            id="download-file-name"
+            value={fileName}
+            placeholder="resume"
+            onChange={(event) => setFileName(event.target.value)}
+          />
+          <InputGroupAddon align="inline-end">
+            <InputGroupText>.{format}</InputGroupText>
+          </InputGroupAddon>
+        </InputGroup>
+      </Field>
+
+      <Button
+        type="submit"
+        className="mt-3 w-full"
+        disabled={props.generating || !fileName.trim()}
+      >
+        {props.generating ? <Spinner /> : <Download />} Download
+      </Button>
+    </form>
+  );
+}

--- a/src/components/platform/platform-resume-grid/platform-resume-grid-item-menu.tsx
+++ b/src/components/platform/platform-resume-grid/platform-resume-grid-item-menu.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { PlatformResumeActionDelete } from "../platform-resume-action-delete";
+import { PlatformResumeActionDownload } from "../platform-resume-action-download";
 import { PlatformResumeActionRename } from "../platform-resume-action-rename";
 
 interface PlatformResumeGridItemMenuProps {
@@ -22,7 +23,11 @@ interface PlatformResumeGridItemMenuProps {
 export function PlatformResumeGridItemMenu({
   resume,
 }: PlatformResumeGridItemMenuProps) {
-  const [open, setOpen] = useState({ rename: false, remove: false });
+  const [open, setOpen] = useState({
+    rename: false,
+    remove: false,
+    download: false,
+  });
 
   const openRemoveDialog = () => setOpen((prev) => ({ ...prev, remove: true }));
   const onOpenRemove = (next: boolean) => {
@@ -32,6 +37,12 @@ export function PlatformResumeGridItemMenu({
   const openRenameDialog = () => setOpen((prev) => ({ ...prev, rename: true }));
   const onOpenRename = (next: boolean) => {
     setOpen((prev) => ({ ...prev, rename: next }));
+  };
+
+  const openDownloadDialog = () =>
+    setOpen((prev) => ({ ...prev, download: true }));
+  const onOpenDownload = (next: boolean) => {
+    setOpen((prev) => ({ ...prev, download: next }));
   };
 
   return (
@@ -47,7 +58,7 @@ export function PlatformResumeGridItemMenu({
             <DropdownMenuItem onClick={openRenameDialog}>
               <Pen /> Rename
             </DropdownMenuItem>
-            <DropdownMenuItem>
+            <DropdownMenuItem onClick={openDownloadDialog}>
               <Download />
               Download
             </DropdownMenuItem>
@@ -72,6 +83,12 @@ export function PlatformResumeGridItemMenu({
         resume={resume}
         open={open.remove}
         onOpenChange={onOpenRemove}
+      />
+
+      <PlatformResumeActionDownload
+        resume={resume}
+        open={open.download}
+        onOpenChange={onOpenDownload}
       />
     </Fragment>
   );


### PR DESCRIPTION
## Summary
- The resume card menu's **Download** item rendered with no handler since #27 — a dead menu item on every card
- Extract the navbar's per-format export switch into a shared `downloadResume(resume, format, fileName)` helper (`src/components/editor/download-resume.ts`) and the format/file-name form into `PlatformResumeDownloadForm`, shared by both download surfaces
- New `PlatformResumeActionDownload` dialog on the card menu (same pattern as the rename/delete actions): loads the full document from IndexedDB by id at download time, prefills the file name with the résumé title, shows an inline error if the document can't be loaded
- Navbar download rewired to the shared pieces — ~145 lines down to ~65, identical behavior

## Notes
- Lazy `import()`s preserved: react-pdf and docx stay out of the main bundle
- All export generation remains client-side — no résumé content leaves the browser
- Export pipeline itself untouched; this only feeds it a document loaded by id instead of the store's open one