### PR TITLE
feat: guide users with one-time page tours and a sidebar replay button

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "nanoid": "^5.1.16",
     "next": "16.2.9",
     "next-themes": "^0.4.6",
+    "nextstepjs": "^2.2.0",
     "nuqs": "^2.9.0",
     "react": "19.2.4",
     "react-day-picker": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      nextstepjs:
+        specifier: ^2.2.0
+        version: 2.2.0(motion@12.42.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(next@16.2.9(@babel/core@7.29.7)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       nuqs:
         specifier: ^2.9.0
         version: 2.9.0(next@16.2.9(@babel/core@7.29.7)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
@@ -3835,6 +3838,23 @@ packages:
       babel-plugin-react-compiler:
         optional: true
       sass:
+        optional: true
+
+  nextstepjs@2.2.0:
+    resolution: {integrity: sha512-VpUvKpIMbxBaLAMM3O8mc5Tavao4UBpKZ0+KyUGXxZhqdJt2ejS2l7pXLtlq2r62NG3EV0yv1wit5mgte7c3Vw==}
+    peerDependencies:
+      '@remix-run/react': '>=1.0.0'
+      motion: '>=11'
+      next: '>=13.0.0'
+      react: '>=18'
+      react-dom: '>=18'
+      react-router: '>=7.0.0'
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      next:
+        optional: true
+      react-router:
         optional: true
 
   node-domexception@1.0.0:
@@ -8637,6 +8657,14 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+
+  nextstepjs@2.2.0(motion@12.42.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(next@16.2.9(@babel/core@7.29.7)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      motion: 12.42.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      next: 16.2.9(@babel/core@7.29.7)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
   node-domexception@1.0.0: {}
 

--- a/src/app/platform/editor/[id]/layout.tsx
+++ b/src/app/platform/editor/[id]/layout.tsx
@@ -13,7 +13,10 @@ export default function EditorLayoutPage(
     <div className="h-[calc(100vh-4rem)] flex-1 overflow-hidden">
       <ResizablePanelGroup>
         <ResizablePanel defaultSize="68%" minSize="40%" maxSize="72%">
-          <ScrollArea className="h-[calc(100vh-3.5rem)]">
+          <ScrollArea
+            id="tour-editor-preview"
+            className="h-[calc(100vh-3.5rem)]"
+          >
             <div className="bg-muted px-6 py-10">{props.children}</div>
           </ScrollArea>
         </ResizablePanel>

--- a/src/app/platform/editor/[id]/page.tsx
+++ b/src/app/platform/editor/[id]/page.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
 import { EditorResumePreview } from "@/components/editor/editor-resume-preview";
+import { TourAutostartEditor } from "@/components/tour/tour-autostart-editor";
 
 export const metadata: Metadata = {
   title: "Editor",
 };
 
 export default function EditorPage() {
-  return <EditorResumePreview />;
+  return (
+    <>
+      <EditorResumePreview />
+      <TourAutostartEditor />
+    </>
+  );
 }

--- a/src/app/platform/layout.tsx
+++ b/src/app/platform/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import type { PropsWithChildren } from "react";
 import { PlatformNavbar } from "@/components/platform/platform-navbar";
 import { PlatformSidebar } from "@/components/platform/platform-sidebar";
+import { TourProvider } from "@/components/tour/tour-provider";
 import {
   Sidebar,
   SidebarInset,
@@ -16,15 +17,17 @@ export const metadata: Metadata = {
 
 export default function PlatformLayout({ children }: PropsWithChildren) {
   return (
-    <SidebarProvider>
-      <Sidebar>
-        <PlatformSidebar />
-      </Sidebar>
+    <TourProvider>
+      <SidebarProvider>
+        <Sidebar>
+          <PlatformSidebar />
+        </Sidebar>
 
-      <SidebarInset>
-        <PlatformNavbar />
-        {children}
-      </SidebarInset>
-    </SidebarProvider>
+        <SidebarInset>
+          <PlatformNavbar />
+          {children}
+        </SidebarInset>
+      </SidebarProvider>
+    </TourProvider>
   );
 }

--- a/src/app/platform/page.tsx
+++ b/src/app/platform/page.tsx
@@ -3,6 +3,8 @@ import { Suspense } from "react";
 import { PlatformEmptyState } from "@/components/platform/platform-empty-state";
 import { PlatformResumeGrid } from "@/components/platform/platform-resume-grid/platform-resume-grid";
 import { PlatformResumeToolbar } from "@/components/platform/platform-resume-toolbar";
+import { TourAutostart } from "@/components/tour/tour-autostart";
+import { LIBRARY_TOUR } from "@/lib/tour";
 
 export const metadata: Metadata = {
   title: "Dashboard",
@@ -16,6 +18,7 @@ export default function PlatformPage() {
         <PlatformResumeGrid />
       </Suspense>
       <PlatformEmptyState />
+      <TourAutostart tour={LIBRARY_TOUR} />
     </div>
   );
 }

--- a/src/app/platform/template/page.tsx
+++ b/src/app/platform/template/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { Suspense } from "react";
 import { PlatformTemplateGrid } from "@/components/platform/platform-template-grid/platform-template-grid";
 import { PlatformTemplateToolbar } from "@/components/platform/platform-template-toolbar";
+import { TourAutostart } from "@/components/tour/tour-autostart";
+import { TEMPLATE_TOUR } from "@/lib/tour";
 
 export const metadata: Metadata = {
   title: "Browse templates",
@@ -14,6 +16,7 @@ export default function PlatformTemplatePage() {
         <PlatformTemplateToolbar />
         <PlatformTemplateGrid />
       </Suspense>
+      <TourAutostart tour={TEMPLATE_TOUR} />
     </div>
   );
 }

--- a/src/components/editor/editor-sidebar.tsx
+++ b/src/components/editor/editor-sidebar.tsx
@@ -13,7 +13,10 @@ export function EditorSidebar() {
       minSize={open ? "28%" : "30%"}
       maxSize="40%"
     >
-      <ScrollArea className="max-h-[calc(100vh-3.5rem)]">
+      <ScrollArea
+        id="tour-editor-sections"
+        className="max-h-[calc(100vh-3.5rem)]"
+      >
         <div className="flex flex-col py-6">
           <h2 className="pb-1 text-2xl font-bold tracking-tight px-4">
             Editor

--- a/src/components/platform/platform-navbar-download.tsx
+++ b/src/components/platform/platform-navbar-download.tsx
@@ -40,7 +40,7 @@ export function PlatformNavbarDownload() {
 
   return (
     <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
-      <PopoverTrigger render={<Button disabled={!open} />}>
+      <PopoverTrigger render={<Button id="tour-download" disabled={!open} />}>
         <Download /> Download Résumé
       </PopoverTrigger>
       <PopoverContent align="end">

--- a/src/components/platform/platform-resume-toolbar.tsx
+++ b/src/components/platform/platform-resume-toolbar.tsx
@@ -17,7 +17,7 @@ export function PlatformResumeToolbar() {
 
   return (
     <div className="flex items-center gap-2">
-      <InputGroup className="max-w-xs">
+      <InputGroup id="tour-search-resume" className="max-w-xs">
         <InputGroupAddon>
           <Search />
         </InputGroupAddon>
@@ -29,7 +29,7 @@ export function PlatformResumeToolbar() {
       </InputGroup>
 
       <nav className="inline-flex items-center gap-2 ml-auto">
-        <Button onClick={() => setOpen(true)}>
+        <Button id="tour-create-resume" onClick={() => setOpen(true)}>
           <Plus /> Résumé
         </Button>
       </nav>

--- a/src/components/platform/platform-sidebar-other.tsx
+++ b/src/components/platform/platform-sidebar-other.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { HelpCircle } from "lucide-react";
+import { usePathname } from "next/navigation";
+import { useNextStep } from "nextstepjs";
+import { useResumeStore } from "@/lib/store";
+import { EDITOR_TOUR, tourForPathname } from "@/lib/tour";
+import {
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "../ui/sidebar";
+
+export function PlatformSidebarOther() {
+  const pathname = usePathname();
+  const openStatus = useResumeStore((state) => state.openStatus);
+  const { startNextStep } = useNextStep();
+
+  const tour = tourForPathname(pathname);
+  const guideDisabled = tour === EDITOR_TOUR && openStatus !== "ready";
+
+  return (
+    <SidebarGroup>
+      <SidebarGroupLabel>Other</SidebarGroupLabel>
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton
+            id="tour-guide"
+            disabled={guideDisabled}
+            onClick={() => startNextStep(tour)}
+          >
+            <HelpCircle /> Guide
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    </SidebarGroup>
+  );
+}

--- a/src/components/platform/platform-sidebar-platform.tsx
+++ b/src/components/platform/platform-sidebar-platform.tsx
@@ -15,7 +15,7 @@ export function PlatformSidebarPlatform() {
   const pathname = usePathname();
 
   return (
-    <SidebarGroup>
+    <SidebarGroup id="tour-sidebar-nav">
       <SidebarGroupLabel>Platform</SidebarGroupLabel>
       <SidebarMenu>
         <SidebarMenuItem>
@@ -34,12 +34,6 @@ export function PlatformSidebarPlatform() {
             <LayoutTemplate /> Browse Template
           </SidebarMenuButton>
         </SidebarMenuItem>
-        {/* wired with react tour */}
-        {/* <SidebarMenuItem>
-          <SidebarMenuButton disabled>
-            <HelpCircle /> Guide
-          </SidebarMenuButton>
-        </SidebarMenuItem> */}
       </SidebarMenu>
     </SidebarGroup>
   );

--- a/src/components/platform/platform-sidebar-resume.tsx
+++ b/src/components/platform/platform-sidebar-resume.tsx
@@ -29,7 +29,7 @@ export function PlatformSidebarResume() {
   const indexStatus = useResumeStore((state) => state.indexStatus);
 
   return (
-    <SidebarGroup>
+    <SidebarGroup id="tour-sidebar-resumes">
       <SidebarGroupLabel>
         <span>My Résumé</span>
 

--- a/src/components/platform/platform-sidebar.tsx
+++ b/src/components/platform/platform-sidebar.tsx
@@ -1,5 +1,6 @@
 import { SidebarContent } from "../ui/sidebar";
 import { PlatformSidebarHeader } from "./platform-sidebar-header";
+import { PlatformSidebarOther } from "./platform-sidebar-other";
 import { PlatformSidebarPlatform } from "./platform-sidebar-platform";
 import { PlatformSidebarResume } from "./platform-sidebar-resume";
 
@@ -9,6 +10,7 @@ export function PlatformSidebar() {
       <PlatformSidebarHeader />
       <PlatformSidebarPlatform />
       <PlatformSidebarResume />
+      <PlatformSidebarOther />
     </SidebarContent>
   );
 }

--- a/src/components/platform/platform-template-grid/platform-template-grid.tsx
+++ b/src/components/platform/platform-template-grid/platform-template-grid.tsx
@@ -22,7 +22,10 @@ export function PlatformTemplateGrid() {
   }
 
   return (
-    <div className="grid grid-cols-[repeat(auto-fill,minmax(min(100%,24rem),1fr))] gap-4">
+    <div
+      id="tour-template-grid"
+      className="grid grid-cols-[repeat(auto-fill,minmax(min(100%,24rem),1fr))] gap-4"
+    >
       {results.map((template) => (
         <PlatformTemplateGridItem key={template.id} template={template} />
       ))}

--- a/src/components/platform/platform-template-toolbar.tsx
+++ b/src/components/platform/platform-template-toolbar.tsx
@@ -31,7 +31,7 @@ export function PlatformTemplateToolbar() {
 
   return (
     <div className="flex items-center gap-2">
-      <InputGroup className="max-w-xs">
+      <InputGroup id="tour-search-template" className="max-w-xs">
         <InputGroupAddon>
           <Search />
         </InputGroupAddon>
@@ -42,7 +42,7 @@ export function PlatformTemplateToolbar() {
         />
       </InputGroup>
 
-      <div className="ml-auto">
+      <div id="tour-sort-template" className="ml-auto">
         <Select
           items={SORT_OPTIONS}
           value={sort}

--- a/src/components/tour/tour-autostart-editor.tsx
+++ b/src/components/tour/tour-autostart-editor.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useNextStep } from "nextstepjs";
+import { useEffect } from "react";
+import { useResumeStore, useTourStore } from "@/lib/store";
+import { EDITOR_TOUR } from "@/lib/tour";
+
+const PREVIEW_SETTLE_MS = 700;
+
+/**
+ * Auto-starts the editor tour once, and only over a loaded résumé. A "missing"
+ * résumé never consumes the first-run flag, so the tour still runs the first
+ * time the user lands on a real one.
+ */
+export function TourAutostartEditor() {
+  const openStatus = useResumeStore((state) => state.openStatus);
+  const { startNextStep } = useNextStep();
+
+  useEffect(() => {
+    if (openStatus !== "ready") return;
+    if (useTourStore.getState().hasSeen(EDITOR_TOUR)) return;
+    const timer = setTimeout(
+      () => startNextStep(EDITOR_TOUR),
+      PREVIEW_SETTLE_MS,
+    );
+    return () => clearTimeout(timer);
+  }, [openStatus, startNextStep]);
+
+  return null;
+}

--- a/src/components/tour/tour-autostart.tsx
+++ b/src/components/tour/tour-autostart.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useNextStep } from "nextstepjs";
+import { useEffect } from "react";
+import { useTourStore } from "@/lib/store";
+import type { TourName } from "@/lib/tour";
+
+const ENTRANCE_SETTLE_MS = 400;
+
+export function TourAutostart(props: { tour: TourName }) {
+  const { startNextStep } = useNextStep();
+
+  useEffect(() => {
+    if (useTourStore.getState().hasSeen(props.tour)) return;
+    const timer = setTimeout(
+      () => startNextStep(props.tour),
+      ENTRANCE_SETTLE_MS,
+    );
+    return () => clearTimeout(timer);
+  }, [props.tour, startNextStep]);
+
+  return null;
+}

--- a/src/components/tour/tour-card.tsx
+++ b/src/components/tour/tour-card.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import type { CardComponentProps } from "nextstepjs";
+import { Button } from "../ui/button";
+
+export function TourCard(props: CardComponentProps) {
+  const isLastStep = props.currentStep === props.totalSteps - 1;
+
+  return (
+    <div className="w-72 rounded-2xl border bg-popover p-4 text-popover-foreground shadow-lg">
+      <h2 className="text-sm font-semibold tracking-tight">
+        {props.step.title}
+      </h2>
+      <div className="pt-1.5 text-sm text-muted-foreground">
+        {props.step.content}
+      </div>
+
+      {props.step.showControls && (
+        <div className="flex items-center gap-2 pt-4">
+          <span className="text-xs tabular-nums text-muted-foreground">
+            {props.currentStep + 1} / {props.totalSteps}
+          </span>
+
+          <div className="ml-auto inline-flex items-center gap-1.5">
+            {props.step.showSkip && props.skipTour && !isLastStep && (
+              <Button size="sm" variant="ghost" onClick={props.skipTour}>
+                Skip
+              </Button>
+            )}
+            {props.currentStep > 0 && (
+              <Button size="sm" variant="outline" onClick={props.prevStep}>
+                Back
+              </Button>
+            )}
+            <Button size="sm" onClick={props.nextStep}>
+              {isLastStep ? "Done" : "Next"}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <span className="text-popover">{props.arrow}</span>
+    </div>
+  );
+}

--- a/src/components/tour/tour-provider.tsx
+++ b/src/components/tour/tour-provider.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { NextStep, NextStepProvider } from "nextstepjs";
+import type { PropsWithChildren } from "react";
+import { useTourStore } from "@/lib/store";
+import { TOURS } from "@/lib/tour";
+import { TourCard } from "./tour-card";
+
+function handleTourStart(tourName: string | null) {
+  if (tourName) useTourStore.getState().markSeen(tourName);
+}
+
+export function TourProvider(props: PropsWithChildren) {
+  return (
+    <NextStepProvider>
+      <NextStep
+        steps={TOURS}
+        cardComponent={TourCard}
+        onStart={handleTourStart}
+        disableConsoleLogs
+      >
+        {props.children}
+      </NextStep>
+    </NextStepProvider>
+  );
+}

--- a/src/lib/store/index.ts
+++ b/src/lib/store/index.ts
@@ -3,3 +3,4 @@ export {
   registerResumeFlushListeners,
 } from "./persistence";
 export { useResumeStore } from "./resume-store";
+export { useTourStore } from "./tour-store";

--- a/src/lib/store/tour-store.ts
+++ b/src/lib/store/tour-store.ts
@@ -1,0 +1,20 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface TourStoreState {
+  seen: Record<string, boolean>;
+  markSeen: (tour: string) => void;
+  hasSeen: (tour: string) => boolean;
+}
+
+export const useTourStore = create<TourStoreState>()(
+  persist(
+    (set, get) => ({
+      seen: {},
+      markSeen: (tour) =>
+        set((state) => ({ seen: { ...state.seen, [tour]: true } })),
+      hasSeen: (tour) => get().seen[tour] === true,
+    }),
+    { name: "lanjut:tour-seen" },
+  ),
+);

--- a/src/lib/tour.ts
+++ b/src/lib/tour.ts
@@ -1,0 +1,133 @@
+import type { Step, Tour } from "nextstepjs";
+
+export const LIBRARY_TOUR = "library";
+export const TEMPLATE_TOUR = "template";
+export const EDITOR_TOUR = "editor";
+
+export type TourName =
+  | typeof LIBRARY_TOUR
+  | typeof TEMPLATE_TOUR
+  | typeof EDITOR_TOUR;
+
+export function tourForPathname(pathname: string): TourName {
+  if (pathname.startsWith("/platform/editor")) return EDITOR_TOUR;
+  if (pathname.startsWith("/platform/template")) return TEMPLATE_TOUR;
+  return LIBRARY_TOUR;
+}
+
+const BASE_STEP = {
+  icon: null,
+  showControls: true,
+  showSkip: true,
+  pointerPadding: 12,
+  pointerRadius: 16,
+} satisfies Partial<Step>;
+
+export const TOURS: Tour[] = [
+  {
+    tour: LIBRARY_TOUR,
+    steps: [
+      {
+        ...BASE_STEP,
+        title: "Welcome to Lanjut",
+        content:
+          "A free, local-first résumé builder. Everything you write stays in this browser — nothing is ever sent to a server.",
+      },
+      {
+        ...BASE_STEP,
+        selector: "#tour-sidebar-nav",
+        side: "right",
+        title: "Get around",
+        content:
+          "Switch between your dashboard and the template gallery from here.",
+      },
+      {
+        ...BASE_STEP,
+        selector: "#tour-create-resume",
+        side: "bottom-right",
+        title: "Create a résumé",
+        content:
+          "Start a new résumé from here. You can keep as many as you like.",
+      },
+      {
+        ...BASE_STEP,
+        selector: "#tour-search-resume",
+        side: "bottom-left",
+        title: "Find it later",
+        content: "Search your library by title once it grows.",
+      },
+      {
+        ...BASE_STEP,
+        selector: "#tour-sidebar-resumes",
+        side: "right",
+        title: "Your résumés",
+        content:
+          "Every résumé you create shows up here — pick one to jump into the editor.",
+      },
+      {
+        ...BASE_STEP,
+        selector: "#tour-guide",
+        side: "right",
+        title: "Replay anytime",
+        content:
+          "Rerun the guide for whichever page you are on with this button.",
+      },
+    ],
+  },
+  {
+    tour: TEMPLATE_TOUR,
+    steps: [
+      {
+        ...BASE_STEP,
+        selector: "#tour-template-grid > :first-child",
+        side: "right",
+        title: "Browse templates",
+        content:
+          "Templates change presentation only — typography, spacing, accents. The structure stays linear so ATS parsers can always read your résumé.",
+      },
+      {
+        ...BASE_STEP,
+        selector: "#tour-search-template",
+        side: "bottom-left",
+        title: "Search",
+        content: "Look up a template by name.",
+      },
+      {
+        ...BASE_STEP,
+        selector: "#tour-sort-template",
+        side: "bottom-right",
+        title: "Sort",
+        content: "Order the gallery by name or by newest.",
+      },
+    ],
+  },
+  {
+    tour: EDITOR_TOUR,
+    steps: [
+      {
+        ...BASE_STEP,
+        selector: "#tour-editor-preview",
+        side: "right",
+        title: "Live preview",
+        content:
+          "This paper is your résumé exactly as it will export. It updates as you type and is saved to this browser automatically.",
+      },
+      {
+        ...BASE_STEP,
+        selector: "#tour-editor-sections",
+        side: "left",
+        title: "Fill in your details",
+        content:
+          "Each section maps to a fixed, ATS-parseable structure. Work top to bottom.",
+      },
+      {
+        ...BASE_STEP,
+        selector: "#tour-download",
+        side: "bottom-right",
+        title: "Download",
+        content:
+          "Export as PDF, DOCX, or plain text when you are ready to apply.",
+      },
+    ],
+  },
+];


### PR DESCRIPTION
## Summary

Adds guided onboarding tours with [nextstepjs](https://nextstepjs.com), which animates with the `motion` dependency we already ship and renders tour cards as our own React components.

- Three named tours, one per surface: **library** (`/platform`), **template** (`/platform/template`), and **editor** (`/platform/editor/[id]`).
- Each tour auto-starts once on the user's first visit to that page; seen-flags live in a new zustand `persist` store (`src/lib/store/tour-store.ts`), accessed outside React via `getState()`.
- The **Guide** button in the sidebar replays the tour for whichever page you're on. On the editor route it stays disabled until a résumé is loaded.
- The editor tour only auto-starts once `openStatus === "ready"`, after the preview entrance animation settles. A `missing` résumé never consumes the first-run flag, so the tour still runs the first time the user opens a real résumé.
- Custom tour card (`src/components/tour/tour-card.tsx`) built on our shadcn/base-ui primitives, dark-mode aware.
- Anchors are `id="tour-*"` attributes on stable app chrome only — no resume content is touched, so the structural/presentation two-layer rule is unaffected. Steps target viewport-bounded containers (ScrollAreas, first grid card) so spotlight and card placement stay on-screen regardless of accordion state or paper height.

## Data flow

No resume content is sent to any server; the tour reads only `openStatus` from the resume store and persists boolean seen-flags to localStorage.

## Testing

- `pnpm build`, `pnpm lint`, `pnpm validate:exports` all pass.
- Manually walked all three tours (first-run auto-start and Guide replay), including the editor found/not-found states and card placement fixes for right-edge targets, open accordions, and the full-height preview panel.