### PR TITLE
feat: move the editor sections into a sheet below xl

### DIFF
--- a/src/app/platform/editor/[id]/layout.tsx
+++ b/src/app/platform/editor/[id]/layout.tsx
@@ -1,30 +1,7 @@
-import { EditorSidebar } from "@/components/editor/editor-sidebar";
-import {
-  ResizableHandle,
-  ResizablePanel,
-  ResizablePanelGroup,
-} from "@/components/ui/resizable";
-import { ScrollArea } from "@/components/ui/scroll-area";
+import { EditorPanels } from "@/components/editor/editor-panels";
 
 export default function EditorLayoutPage(
   props: LayoutProps<"/platform/editor/[id]">,
 ) {
-  return (
-    <div className="h-[calc(100vh-4rem)] flex-1 overflow-hidden">
-      <ResizablePanelGroup>
-        <ResizablePanel defaultSize="68%" minSize="40%" maxSize="72%">
-          <ScrollArea
-            id="tour-editor-preview"
-            className="h-[calc(100vh-3.5rem)]"
-          >
-            <div className="bg-muted px-6 py-10">{props.children}</div>
-          </ScrollArea>
-        </ResizablePanel>
-
-        <ResizableHandle withHandle />
-
-        <EditorSidebar />
-      </ResizablePanelGroup>
-    </div>
-  );
+  return <EditorPanels>{props.children}</EditorPanels>;
 }

--- a/src/components/editor/editor-panels.tsx
+++ b/src/components/editor/editor-panels.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useEditorResume } from "@/hooks/use-editor-resume";
+import { MEDIA_XL, useMediaQuery } from "@/hooks/use-media-query";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "../ui/resizable";
+import { ScrollArea } from "../ui/scroll-area";
+import { EditorSheet } from "./editor-sheet";
+import { EditorSidebar } from "./editor-sidebar";
+
+export function EditorPanels(props: { children: ReactNode }) {
+  useEditorResume();
+  const isDesktop = useMediaQuery(MEDIA_XL);
+
+  if (isDesktop) {
+    return (
+      <div className="h-[calc(100vh-4rem)] flex-1 overflow-hidden">
+        <ResizablePanelGroup>
+          <ResizablePanel defaultSize="68%" minSize="40%" maxSize="72%">
+            <EditorPreviewScroll>{props.children}</EditorPreviewScroll>
+          </ResizablePanel>
+
+          <ResizableHandle withHandle />
+
+          <EditorSidebar />
+        </ResizablePanelGroup>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-[calc(100vh-4rem)] flex-1 overflow-hidden">
+      <EditorPreviewScroll>{props.children}</EditorPreviewScroll>
+      {isDesktop === false && <EditorSheet />}
+    </div>
+  );
+}
+
+function EditorPreviewScroll(props: { children: ReactNode }) {
+  return (
+    <ScrollArea id="tour-editor-preview" className="h-[calc(100vh-3.5rem)]">
+      <div className="bg-muted px-6 py-10 min-h-screen">{props.children}</div>
+    </ScrollArea>
+  );
+}

--- a/src/components/editor/editor-resume-preview.tsx
+++ b/src/components/editor/editor-resume-preview.tsx
@@ -9,7 +9,7 @@ import { ResumeDocument } from "./resume-document";
 import { resumeToPreview } from "./resume-to-preview";
 
 /**
- * The paper preview, driven by the open résumé in the store. The editor sidebar
+ * The paper preview, driven by the open résumé in the store. `EditorPanels`
  * owns loading the document (`useEditorResume`), so this only reads `open` and
  * projects it through the `resumeToPreview` adapter into the résumé's template.
  *

--- a/src/components/editor/editor-sections/ed-section-list.tsx
+++ b/src/components/editor/editor-sections/ed-section-list.tsx
@@ -2,7 +2,6 @@
 
 import { Accordion } from "@/components/ui/accordion";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useEditorResume } from "@/hooks/use-editor-resume";
 import { useResumeStore } from "@/lib/store";
 import { EditorSectionCertifications } from "./ed-section-certifications/ed-section-certifications";
 import { EditorSectionEducation } from "./ed-section-education/ed-section-education";
@@ -15,7 +14,7 @@ import { EditorSectionSummary } from "./ed-section-summary/ed-section-summary";
 const SKELETONS = [1, 2, 3, 4, 5, 6];
 
 export function EditorSectionList() {
-  const openStatus = useEditorResume();
+  const openStatus = useResumeStore((state) => state.openStatus);
   const open = useResumeStore((state) => state.open);
 
   if (!open) {

--- a/src/components/editor/editor-sheet.tsx
+++ b/src/components/editor/editor-sheet.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { PenLine } from "lucide-react";
+import { Button } from "../ui/button";
+import { ScrollArea } from "../ui/scroll-area";
+import { Sheet, SheetContent, SheetTitle, SheetTrigger } from "../ui/sheet";
+import { EditorSidebarContent } from "./editor-sidebar-content";
+
+export function EditorSheet() {
+  return (
+    <Sheet>
+      <SheetTrigger
+        render={
+          <Button size="lg" className="fixed right-4 bottom-4 z-40 shadow-lg" />
+        }
+      >
+        <PenLine /> Edit
+      </SheetTrigger>
+
+      <SheetContent side="right" className="w-full gap-0 sm:max-w-lg">
+        <SheetTitle className="sr-only">Editor</SheetTitle>
+        <ScrollArea className="min-h-0 flex-1">
+          <EditorSidebarContent />
+        </ScrollArea>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/editor/editor-sidebar-content.tsx
+++ b/src/components/editor/editor-sidebar-content.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { EditorSectionList } from "./editor-sections/ed-section-list";
+
+export function EditorSidebarContent() {
+  return (
+    <div className="flex flex-col py-6">
+      <h2 className="pb-1 text-2xl font-bold tracking-tight px-4">Editor</h2>
+      <h3 className="pb-2 text-lg font-semibold tracking-tight px-4">
+        The Essentials
+      </h3>
+      <EditorSectionList />
+    </div>
+  );
+}

--- a/src/components/editor/editor-sidebar.tsx
+++ b/src/components/editor/editor-sidebar.tsx
@@ -3,7 +3,7 @@
 import { ResizablePanel } from "../ui/resizable";
 import { ScrollArea } from "../ui/scroll-area";
 import { useSidebar } from "../ui/sidebar";
-import { EditorSectionList } from "./editor-sections/ed-section-list";
+import { EditorSidebarContent } from "./editor-sidebar-content";
 
 export function EditorSidebar() {
   const { open } = useSidebar();
@@ -17,15 +17,7 @@ export function EditorSidebar() {
         id="tour-editor-sections"
         className="max-h-[calc(100vh-3.5rem)]"
       >
-        <div className="flex flex-col py-6">
-          <h2 className="pb-1 text-2xl font-bold tracking-tight px-4">
-            Editor
-          </h2>
-          <h3 className="pb-2 text-lg font-semibold tracking-tight px-4">
-            The Essentials
-          </h3>
-          <EditorSectionList />
-        </div>
+        <EditorSidebarContent />
       </ScrollArea>
     </ResizablePanel>
   );

--- a/src/components/platform/platform-navbar.tsx
+++ b/src/components/platform/platform-navbar.tsx
@@ -28,7 +28,7 @@ export function PlatformNavbar() {
         <SidebarTrigger />
         <PlatformNavbarBreadcrumb />
 
-        <div className="inline-flex items-center gap-2 ml-auto">
+        <div className="hidden lg:inline-flex items-center gap-2 ml-auto">
           <PlatformNavbarTheme />
           <PlatformNavbarDownload />
         </div>

--- a/src/components/platform/platform-sidebar-other.tsx
+++ b/src/components/platform/platform-sidebar-other.tsx
@@ -3,6 +3,7 @@
 import { HelpCircle } from "lucide-react";
 import { usePathname } from "next/navigation";
 import { useNextStep } from "nextstepjs";
+import { MEDIA_XL, useMediaQuery } from "@/hooks/use-media-query";
 import { useResumeStore } from "@/lib/store";
 import { EDITOR_TOUR, tourForPathname } from "@/lib/tour";
 import {
@@ -16,10 +17,12 @@ import {
 export function PlatformSidebarOther() {
   const pathname = usePathname();
   const openStatus = useResumeStore((state) => state.openStatus);
+  const isDesktop = useMediaQuery(MEDIA_XL);
   const { startNextStep } = useNextStep();
 
   const tour = tourForPathname(pathname);
-  const guideDisabled = tour === EDITOR_TOUR && openStatus !== "ready";
+  const guideDisabled =
+    tour === EDITOR_TOUR && (openStatus !== "ready" || !isDesktop);
 
   return (
     <SidebarGroup>

--- a/src/components/tour/tour-autostart-editor.tsx
+++ b/src/components/tour/tour-autostart-editor.tsx
@@ -2,22 +2,20 @@
 
 import { useNextStep } from "nextstepjs";
 import { useEffect } from "react";
+import { MEDIA_XL } from "@/hooks/use-media-query";
 import { useResumeStore, useTourStore } from "@/lib/store";
 import { EDITOR_TOUR } from "@/lib/tour";
 
 const PREVIEW_SETTLE_MS = 700;
 
-/**
- * Auto-starts the editor tour once, and only over a loaded résumé. A "missing"
- * résumé never consumes the first-run flag, so the tour still runs the first
- * time the user lands on a real one.
- */
+// Bailing out (missing résumé, sub-xl) never consumes the first-run flag.
 export function TourAutostartEditor() {
   const openStatus = useResumeStore((state) => state.openStatus);
   const { startNextStep } = useNextStep();
 
   useEffect(() => {
     if (openStatus !== "ready") return;
+    if (!window.matchMedia(MEDIA_XL).matches) return;
     if (useTourStore.getState().hasSeen(EDITOR_TOUR)) return;
     const timer = setTimeout(
       () => startNextStep(EDITOR_TOUR),

--- a/src/hooks/use-media-query.ts
+++ b/src/hooks/use-media-query.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react";
+
+export const MEDIA_XL = "(min-width: 80rem)";
+
+export function useMediaQuery(query: string) {
+  const [matches, setMatches] = useState<boolean | undefined>(undefined);
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    const onChange = () => setMatches(mql.matches);
+    mql.addEventListener("change", onChange);
+    setMatches(mql.matches);
+    return () => mql.removeEventListener("change", onChange);
+  }, [query]);
+
+  return matches;
+}


### PR DESCRIPTION
## Summary

Below the `xl` breakpoint the editor's right panel becomes a right-side sheet opened by a floating **Edit** button; on `xl+` it stays the sticky, resizable panel.

- `EditorPanels` (client) branches on a new `useMediaQuery` hook (same `matchMedia` pattern as `use-mobile.ts`); the route layout is now a thin server wrapper. Only one container is ever mounted, so there is a single set of TipTap instances.
- Both containers render the shared `EditorSidebarContent` (headings + section list).
- Document loading moved from `EditorSectionList` into `EditorPanels`: on mobile the sheet content never mounts until opened, which previously left the preview stuck on its skeleton. `useEditorResume` now runs on every breakpoint; the section list just reads `openStatus` from the store.
- Editor tour adjustments: auto-start additionally requires the `xl` query (the sections anchor lives in a closed sheet below that), without consuming the first-run flag; the Guide button disables on the editor route below `xl`.
- Navbar theme/download actions hidden below `lg`.

## Data flow

No resume content leaves the browser; this only moves existing client components between containers.

## Testing

- `pnpm build` and `pnpm lint` pass.
- Manually verified: preview loads on mobile without opening the sheet, sheet opens with forms already hydrated, desktop panels unchanged, editor tour still runs on xl.

## Known trade-off

Crossing 1280px remounts the section forms: content is safe in the store, but TipTap undo history and open accordions reset.