### PR TITLE
feat: orchestrate tours per step and port dialogs to drawers on mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "tw-animate-css": "^1.4.0",
-    "vaul": "^1.1.2",
     "zod": "^4.4.3",
     "zustand": "^5.0.14"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,9 +146,6 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
-      vaul:
-        specifier: ^1.1.2
-        version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -4694,12 +4691,6 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
-
-  vaul@1.1.2:
-    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
-    peerDependencies:
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
@@ -9534,15 +9525,6 @@ snapshots:
   validate-npm-package-name@7.0.2: {}
 
   vary@1.1.2: {}
-
-  vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
-    dependencies:
-      '@radix-ui/react-dialog': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
 
   victory-vendor@37.3.6:
     dependencies:

--- a/src/app/platform/layout.tsx
+++ b/src/app/platform/layout.tsx
@@ -2,12 +2,9 @@ import type { Metadata } from "next";
 import type { PropsWithChildren } from "react";
 import { PlatformNavbar } from "@/components/platform/platform-navbar";
 import { PlatformSidebar } from "@/components/platform/platform-sidebar";
+import { PlatformSidebarProvider } from "@/components/platform/platform-sidebar-provider";
 import { TourProvider } from "@/components/tour/tour-provider";
-import {
-  Sidebar,
-  SidebarInset,
-  SidebarProvider,
-} from "@/components/ui/sidebar";
+import { Sidebar, SidebarInset } from "@/components/ui/sidebar";
 
 // The platform is the local-first working area: its pages render each visitor's
 // own IndexedDB data, so there is nothing meaningful for crawlers to index.
@@ -18,7 +15,7 @@ export const metadata: Metadata = {
 export default function PlatformLayout({ children }: PropsWithChildren) {
   return (
     <TourProvider>
-      <SidebarProvider>
+      <PlatformSidebarProvider>
         <Sidebar>
           <PlatformSidebar />
         </Sidebar>
@@ -27,7 +24,7 @@ export default function PlatformLayout({ children }: PropsWithChildren) {
           <PlatformNavbar />
           {children}
         </SidebarInset>
-      </SidebarProvider>
+      </PlatformSidebarProvider>
     </TourProvider>
   );
 }

--- a/src/components/platform/platform-navbar-download.tsx
+++ b/src/components/platform/platform-navbar-download.tsx
@@ -3,11 +3,7 @@
 import { Download } from "lucide-react";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
-import {
-  downloadResume,
-  type ExportFormat,
-} from "@/components/editor/download-resume";
-import { useResumeStore } from "@/lib/store";
+import { useResumeDownload } from "@/hooks/use-resume-download";
 import { Button } from "../ui/button";
 import {
   Popover,
@@ -21,22 +17,10 @@ import { PlatformResumeDownloadForm } from "./platform-resume-download-form";
 
 export function PlatformNavbarDownload() {
   const pathname = usePathname();
-  const open = useResumeStore((state) => state.open);
+  const { resume, generating, download } = useResumeDownload();
   const [popoverOpen, setPopoverOpen] = useState(false);
-  const [generating, setGenerating] = useState(false);
 
   if (!pathname.includes("/editor/")) return null;
-
-  const onDownload = async (format: ExportFormat, fileName: string) => {
-    if (!open) return;
-    setGenerating(true);
-    try {
-      await downloadResume(open, format, fileName);
-      setPopoverOpen(false);
-    } finally {
-      setGenerating(false);
-    }
-  };
 
   return (
     <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
@@ -44,7 +28,7 @@ export function PlatformNavbarDownload() {
         render={
           <Button
             id="tour-download"
-            disabled={!open}
+            disabled={!resume}
             className="max-md:hidden"
           />
         }
@@ -60,10 +44,14 @@ export function PlatformNavbarDownload() {
         </PopoverHeader>
 
         <PlatformResumeDownloadForm
-          key={`${open?.id}-${popoverOpen}`}
-          defaultFileName={open?.title ?? ""}
+          key={`${resume?.id}-${popoverOpen}`}
+          defaultFileName={resume?.title ?? ""}
           generating={generating}
-          onSubmit={(format, fileName) => void onDownload(format, fileName)}
+          onSubmit={(format, fileName) =>
+            void download(format, fileName).then(
+              (done) => done && setPopoverOpen(false),
+            )
+          }
         />
       </PopoverContent>
     </Popover>

--- a/src/components/platform/platform-navbar-mobile-menu.tsx
+++ b/src/components/platform/platform-navbar-mobile-menu.tsx
@@ -1,14 +1,10 @@
 "use client";
 
-import {
-  Contrast,
-  Download,
-  Laptop2,
-  LayoutList,
-  Moon,
-  Sun,
-} from "lucide-react";
+import { Contrast, Download, Laptop2, Menu, Moon, Sun } from "lucide-react";
+import { usePathname } from "next/navigation";
 import { useTheme } from "next-themes";
+import { useState } from "react";
+import { useResumeStore } from "@/lib/store";
 import { Button } from "../ui/button";
 import {
   DropdownMenu,
@@ -25,16 +21,23 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "../ui/dropdown-menu";
+import { PlatformResumeDownloadDrawer } from "./platform-resume-download-drawer";
 
 export function PlatformNavbarMobileMenu() {
+  const pathname = usePathname();
   const { theme, setTheme } = useTheme();
+  const resume = useResumeStore((state) => state.open);
+  const [downloadOpen, setDownloadOpen] = useState(false);
 
+  const isEditor = pathname.includes("/editor/");
   const onChangeTheme = (next: string) => setTheme(next);
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger render={<Button size="icon" variant="outline" />}>
-        <LayoutList />
+      <DropdownMenuTrigger
+        render={<Button size="icon" variant="outline" className="lg:hidden" />}
+      >
+        <Menu />
         <span className="sr-only">Menu</span>
       </DropdownMenuTrigger>
 
@@ -69,13 +72,26 @@ export function PlatformNavbarMobileMenu() {
             </DropdownMenuPortal>
           </DropdownMenuSub>
 
-          <DropdownMenuSeparator />
+          {isEditor && (
+            <>
+              <DropdownMenuSeparator className="md:hidden" />
 
-          <DropdownMenuItem>
-            <Download /> Download Resume
-          </DropdownMenuItem>
+              <DropdownMenuItem
+                className="md:hidden"
+                disabled={!resume}
+                onClick={() => setDownloadOpen(true)}
+              >
+                <Download /> Download Résumé
+              </DropdownMenuItem>
+            </>
+          )}
         </DropdownMenuGroup>
       </DropdownMenuContent>
+
+      <PlatformResumeDownloadDrawer
+        open={downloadOpen}
+        onOpenChange={setDownloadOpen}
+      />
     </DropdownMenu>
   );
 }

--- a/src/components/platform/platform-resume-action-delete.tsx
+++ b/src/components/platform/platform-resume-action-delete.tsx
@@ -11,6 +11,17 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { useResumeStore } from "@/lib/store";
 
 interface PlatformResumeActionDeleteProps {
@@ -22,6 +33,7 @@ interface PlatformResumeActionDeleteProps {
 export function PlatformResumeActionDelete(
   props: PlatformResumeActionDeleteProps,
 ) {
+  const isMobile = useIsMobile();
   const removeResume = useResumeStore((state) => state.removeResume);
   const [pending, setPending] = useState(false);
 
@@ -32,17 +44,54 @@ export function PlatformResumeActionDelete(
     props.onOpenChange(false);
   }
 
+  const title = (
+    <>
+      Delete <strong>{props.resume.title}</strong>?
+    </>
+  );
+  const description = (
+    <>
+      This will delete <strong>{props.resume.title}</strong>.{" "}
+      <strong>This action cannot be undone</strong>. Are you sure?
+    </>
+  );
+
+  if (isMobile) {
+    return (
+      <Drawer
+        showSwipeHandle
+        open={props.open}
+        onOpenChange={props.onOpenChange}
+      >
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>{title}</DrawerTitle>
+            <DrawerDescription>{description}</DrawerDescription>
+          </DrawerHeader>
+
+          <DrawerFooter>
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={pending}
+            >
+              Delete
+            </Button>
+            <DrawerClose render={<Button variant="outline" />}>
+              Cancel
+            </DrawerClose>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+
   return (
     <AlertDialog open={props.open} onOpenChange={props.onOpenChange}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>
-            Delete <strong>{props.resume.title}</strong>?
-          </AlertDialogTitle>
-          <AlertDialogDescription>
-            This will delete <strong>{props.resume.title}</strong>.{" "}
-            <strong>This action cannot be undone</strong>. Are you sure?
-          </AlertDialogDescription>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
         </AlertDialogHeader>
 
         <AlertDialogFooter>

--- a/src/components/platform/platform-resume-action-download.tsx
+++ b/src/components/platform/platform-resume-action-download.tsx
@@ -7,12 +7,12 @@ import {
 } from "@/components/editor/download-resume";
 import { getResume } from "@/lib/db";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "../ui/dialog";
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "../shared/responsive-dialog";
 import { PlatformResumeDownloadForm } from "./platform-resume-download-form";
 
 interface PlatformResumeActionDownloadProps {
@@ -43,15 +43,17 @@ export function PlatformResumeActionDownload(
   }
 
   return (
-    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
-      <DialogContent className="sm:max-w-sm">
-        <DialogHeader>
-          <DialogTitle>Download {props.resume.title}</DialogTitle>
-          <DialogDescription>
+    <ResponsiveDialog open={props.open} onOpenChange={props.onOpenChange}>
+      <ResponsiveDialogContent className="sm:max-w-sm">
+        <ResponsiveDialogHeader>
+          <ResponsiveDialogTitle>
+            Download {props.resume.title}
+          </ResponsiveDialogTitle>
+          <ResponsiveDialogDescription>
             Pick a format and name your file. The export is generated in your
             browser.
-          </DialogDescription>
-        </DialogHeader>
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
 
         {missing ? (
           <p className="text-sm text-destructive">
@@ -67,7 +69,7 @@ export function PlatformResumeActionDownload(
             }
           />
         )}
-      </DialogContent>
-    </Dialog>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
   );
 }

--- a/src/components/platform/platform-resume-action-rename.tsx
+++ b/src/components/platform/platform-resume-action-rename.tsx
@@ -3,16 +3,16 @@
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
 import { Save, TextInitial, XIcon } from "lucide-react";
 import { Controller, useForm } from "react-hook-form";
-import { Button } from "@/components/ui/button";
 import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+  ResponsiveDialog,
+  ResponsiveDialogClose,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogFooter,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "@/components/shared/responsive-dialog";
+import { Button } from "@/components/ui/button";
 import {
   Field,
   FieldDescription,
@@ -56,15 +56,15 @@ export function PlatformResumeActionRename(
   });
 
   return (
-    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
-      <DialogContent showCloseButton={false}>
-        <DialogHeader>
-          <DialogTitle>Rename </DialogTitle>
-          <DialogDescription>
+    <ResponsiveDialog open={props.open} onOpenChange={props.onOpenChange}>
+      <ResponsiveDialogContent showCloseButton={false}>
+        <ResponsiveDialogHeader>
+          <ResponsiveDialogTitle>Rename </ResponsiveDialogTitle>
+          <ResponsiveDialogDescription>
             You can rename this resume label to whatever you want. If the value
             of the label is same as before, it won&apos;t be saved.
-          </DialogDescription>
-        </DialogHeader>
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
 
         <form onSubmit={onSubmit}>
           <FieldGroup>
@@ -99,17 +99,17 @@ export function PlatformResumeActionRename(
             />
           </FieldGroup>
 
-          <DialogFooter className="mt-6">
-            <DialogClose render={<Button type="button" variant="outline" />}>
+          <ResponsiveDialogFooter className="mt-6">
+            <ResponsiveDialogClose type="button" variant="outline">
               <XIcon /> Cancel
-            </DialogClose>
+            </ResponsiveDialogClose>
 
             <Button type="submit" disabled={form.formState.isSubmitting}>
               <Save /> Save
             </Button>
-          </DialogFooter>
+          </ResponsiveDialogFooter>
         </form>
-      </DialogContent>
-    </Dialog>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
   );
 }

--- a/src/components/platform/platform-resume-create-dialog.tsx
+++ b/src/components/platform/platform-resume-create-dialog.tsx
@@ -12,16 +12,16 @@ import {
 } from "@/lib/forms/resume";
 import { useResumeStore } from "@/lib/store";
 import { DEFAULT_TEMPLATE_ID, resolveTemplateId } from "@/lib/templates";
-import { Button } from "../ui/button";
 import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "../ui/dialog";
+  ResponsiveDialog,
+  ResponsiveDialogClose,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogFooter,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "../shared/responsive-dialog";
+import { Button } from "../ui/button";
 import {
   Field,
   FieldDescription,
@@ -67,14 +67,14 @@ export function PlatformResumeCreateDialog(
   });
 
   return (
-    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
-      <DialogContent className="sm:max-w-lg">
-        <DialogHeader>
-          <DialogTitle>Create a new resume</DialogTitle>
-          <DialogDescription className="text-balance">
+    <ResponsiveDialog open={props.open} onOpenChange={props.onOpenChange}>
+      <ResponsiveDialogContent className="sm:max-w-lg">
+        <ResponsiveDialogHeader>
+          <ResponsiveDialogTitle>Create a new resume</ResponsiveDialogTitle>
+          <ResponsiveDialogDescription className="text-balance">
             You can create a new resume. But let&apos;s name your résumé first.
-          </DialogDescription>
-        </DialogHeader>
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
 
         <form onSubmit={onSubmit}>
           <FieldGroup>
@@ -117,17 +117,17 @@ export function PlatformResumeCreateDialog(
             </Field>
           </FieldGroup>
 
-          <DialogFooter className="mt-6">
-            <DialogClose render={<Button type="button" variant="outline" />}>
+          <ResponsiveDialogFooter className="mt-6">
+            <ResponsiveDialogClose type="button" variant="outline">
               <XIcon /> Cancel
-            </DialogClose>
+            </ResponsiveDialogClose>
             <Button type="submit" disabled={form.formState.isSubmitting}>
               <Save />
               Save
             </Button>
-          </DialogFooter>
+          </ResponsiveDialogFooter>
         </form>
-      </DialogContent>
-    </Dialog>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
   );
 }

--- a/src/components/platform/platform-resume-download-drawer.tsx
+++ b/src/components/platform/platform-resume-download-drawer.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useResumeDownload } from "@/hooks/use-resume-download";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from "../ui/drawer";
+import { PlatformResumeDownloadForm } from "./platform-resume-download-form";
+
+export function PlatformResumeDownloadDrawer(props: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { resume, generating, download } = useResumeDownload();
+
+  return (
+    <Drawer showSwipeHandle open={props.open} onOpenChange={props.onOpenChange}>
+      <DrawerContent>
+        <DrawerHeader>
+          <DrawerTitle>Download résumé</DrawerTitle>
+          <DrawerDescription>
+            Pick a format and name your file.
+          </DrawerDescription>
+        </DrawerHeader>
+
+        <div className="px-4 pb-6">
+          <PlatformResumeDownloadForm
+            key={`${resume?.id}-${props.open}`}
+            defaultFileName={resume?.title ?? ""}
+            generating={generating}
+            onSubmit={(format, fileName) =>
+              void download(format, fileName).then(
+                (done) => done && props.onOpenChange(false),
+              )
+            }
+          />
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/src/components/platform/platform-sidebar-other.tsx
+++ b/src/components/platform/platform-sidebar-other.tsx
@@ -12,14 +12,12 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-  useSidebar,
 } from "../ui/sidebar";
 
 export function PlatformSidebarOther() {
   const pathname = usePathname();
   const openStatus = useResumeStore((state) => state.openStatus);
   const isDesktop = useMediaQuery(MEDIA_XL);
-  const { setOpenMobile } = useSidebar();
   const { startNextStep } = useNextStep();
 
   const baseTour = tourForPathname(pathname);
@@ -35,10 +33,7 @@ export function PlatformSidebarOther() {
           <SidebarMenuButton
             id="tour-guide"
             disabled={guideDisabled}
-            onClick={() => {
-              setOpenMobile(false);
-              startNextStep(tour);
-            }}
+            onClick={() => startNextStep(tour)}
           >
             <HelpCircle /> Guide
           </SidebarMenuButton>

--- a/src/components/platform/platform-sidebar-provider.tsx
+++ b/src/components/platform/platform-sidebar-provider.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { type ReactNode, useEffect } from "react";
+import { useSidebarStore } from "@/lib/store";
+import { SidebarProvider, useSidebar } from "../ui/sidebar";
+
+export function PlatformSidebarProvider(props: { children: ReactNode }) {
+  const open = useSidebarStore((state) => state.open);
+  const setOpen = useSidebarStore((state) => state.setOpen);
+
+  useEffect(() => {
+    void useSidebarStore.persist.rehydrate();
+  }, []);
+
+  return (
+    <SidebarProvider open={open} onOpenChange={setOpen}>
+      <SidebarMobileBridge />
+      {props.children}
+    </SidebarProvider>
+  );
+}
+
+// The shadcn provider keeps the mobile sheet state internal; registering its
+// setter lets non-React callers (the tour) drive it through the store.
+function SidebarMobileBridge() {
+  const { setOpenMobile } = useSidebar();
+
+  useEffect(() => {
+    useSidebarStore.getState().registerMobileControl(setOpenMobile);
+    return () => useSidebarStore.getState().registerMobileControl(null);
+  }, [setOpenMobile]);
+
+  return null;
+}

--- a/src/components/shared/responsive-dialog.tsx
+++ b/src/components/shared/responsive-dialog.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import {
+  type ComponentProps,
+  createContext,
+  type ReactNode,
+  useContext,
+} from "react";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { cn } from "@/lib/utils";
+import { Button } from "../ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../ui/dialog";
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from "../ui/drawer";
+
+const MobileContext = createContext(false);
+
+interface SectionProps {
+  className?: string;
+  children?: ReactNode;
+}
+
+export function ResponsiveDialog(props: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: ReactNode;
+}) {
+  const isMobile = useIsMobile();
+
+  if (isMobile) {
+    return (
+      <MobileContext.Provider value={isMobile}>
+        <Drawer
+          showSwipeHandle
+          open={props.open}
+          onOpenChange={props.onOpenChange}
+        >
+          {props.children}
+        </Drawer>
+      </MobileContext.Provider>
+    );
+  }
+
+  return (
+    <MobileContext.Provider value={isMobile}>
+      <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+        {props.children}
+      </Dialog>
+    </MobileContext.Provider>
+  );
+}
+
+export function ResponsiveDialogContent(props: {
+  className?: string;
+  children?: ReactNode;
+  showCloseButton?: boolean;
+}) {
+  const isMobile = useContext(MobileContext);
+
+  if (isMobile) {
+    return (
+      <DrawerContent>
+        <div className="overflow-y-auto px-4 pb-4">{props.children}</div>
+      </DrawerContent>
+    );
+  }
+
+  return (
+    <DialogContent
+      className={props.className}
+      showCloseButton={props.showCloseButton}
+    >
+      {props.children}
+    </DialogContent>
+  );
+}
+
+export function ResponsiveDialogHeader(props: SectionProps) {
+  const isMobile = useContext(MobileContext);
+
+  if (isMobile) {
+    return (
+      <DrawerHeader className={cn("px-0", props.className)}>
+        {props.children}
+      </DrawerHeader>
+    );
+  }
+
+  return <DialogHeader {...props} />;
+}
+
+export function ResponsiveDialogTitle(props: SectionProps) {
+  const isMobile = useContext(MobileContext);
+  const Title = isMobile ? DrawerTitle : DialogTitle;
+  return <Title {...props} />;
+}
+
+export function ResponsiveDialogDescription(props: SectionProps) {
+  const isMobile = useContext(MobileContext);
+  const Description = isMobile ? DrawerDescription : DialogDescription;
+  return <Description {...props} />;
+}
+
+export function ResponsiveDialogFooter(props: SectionProps) {
+  const isMobile = useContext(MobileContext);
+
+  if (isMobile) {
+    return (
+      <DrawerFooter className={cn("px-0 pb-0", props.className)}>
+        {props.children}
+      </DrawerFooter>
+    );
+  }
+
+  return <DialogFooter {...props} />;
+}
+
+export function ResponsiveDialogClose({
+  children,
+  ...buttonProps
+}: ComponentProps<typeof Button>) {
+  const isMobile = useContext(MobileContext);
+
+  if (isMobile) {
+    return (
+      <DrawerClose render={<Button {...buttonProps} />}>{children}</DrawerClose>
+    );
+  }
+
+  return (
+    <DialogClose render={<Button {...buttonProps} />}>{children}</DialogClose>
+  );
+}

--- a/src/components/tour/tour-provider.tsx
+++ b/src/components/tour/tour-provider.tsx
@@ -2,12 +2,36 @@
 
 import { NextStep, NextStepProvider } from "nextstepjs";
 import type { PropsWithChildren } from "react";
-import { useTourStore } from "@/lib/store";
-import { TOURS } from "@/lib/tour";
+import { useSidebarStore, useTourStore } from "@/lib/store";
+import { getTourStep, TOURS } from "@/lib/tour";
 import { TourCard } from "./tour-card";
 
+const SIDEBAR_SETTLE_MS = 400;
+
+function prepareStep(tourName: string | null, stepIndex: number) {
+  const step = getTourStep(tourName, stepIndex);
+  if (!step?.sidebar) return;
+  useSidebarStore.getState().ensureVisible(step.sidebar === "open");
+  // NextStep re-anchors on window resize; nudge it once the sidebar settles
+  // so targets that mount with the mobile sheet get a real position.
+  setTimeout(
+    () => window.dispatchEvent(new Event("resize")),
+    SIDEBAR_SETTLE_MS,
+  );
+}
+
 function handleTourStart(tourName: string | null) {
-  if (tourName) useTourStore.getState().markSeen(tourName);
+  if (!tourName) return;
+  useTourStore.getState().markSeen(tourName);
+  prepareStep(tourName, 0);
+}
+
+function handleStepChange(stepIndex: number, tourName: string | null) {
+  prepareStep(tourName, stepIndex);
+}
+
+function handleTourEnd() {
+  useSidebarStore.getState().ensureVisible(false);
 }
 
 export function TourProvider(props: PropsWithChildren) {
@@ -17,6 +41,9 @@ export function TourProvider(props: PropsWithChildren) {
         steps={TOURS}
         cardComponent={TourCard}
         onStart={handleTourStart}
+        onStepChange={handleStepChange}
+        onComplete={handleTourEnd}
+        onSkip={handleTourEnd}
         disableConsoleLogs
       >
         {props.children}

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -1,44 +1,95 @@
 "use client";
 
-// biome-ignore lint/style/useImportType: ignore
+import { Drawer as DrawerPrimitive } from "@base-ui/react/drawer";
 import * as React from "react";
-import { Drawer as DrawerPrimitive } from "vaul";
 
 import { cn } from "@/lib/utils";
 
-function Drawer({
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
-  return <DrawerPrimitive.Root data-slot="drawer" {...props} />;
+type DrawerContextProps = {
+  hasSnapPoints: boolean;
+  modal: DrawerPrimitive.Root.Props["modal"];
+  showSwipeHandle: boolean;
+  swipeDirection: NonNullable<DrawerPrimitive.Root.Props["swipeDirection"]>;
+};
+
+const DrawerContext = React.createContext<DrawerContextProps | null>(null);
+
+function useDrawer() {
+  const context = React.useContext(DrawerContext);
+
+  if (!context) {
+    throw new Error("useDrawer must be used within a Drawer.");
+  }
+
+  return context;
 }
 
-function DrawerTrigger({
+function Drawer({
+  modal = true,
+  showSwipeHandle = false,
+  snapPoints,
+  swipeDirection = "down",
   ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+}: DrawerPrimitive.Root.Props & {
+  showSwipeHandle?: boolean;
+}) {
+  const hasSnapPoints = snapPoints != null && snapPoints.length > 0;
+  const contextValue = React.useMemo(
+    () => ({ hasSnapPoints, modal, showSwipeHandle, swipeDirection }),
+    [hasSnapPoints, modal, showSwipeHandle, swipeDirection],
+  );
+
+  return (
+    <DrawerContext.Provider value={contextValue}>
+      <DrawerPrimitive.Root
+        data-slot="drawer"
+        modal={modal}
+        snapPoints={snapPoints}
+        swipeDirection={swipeDirection}
+        {...props}
+      />
+    </DrawerContext.Provider>
+  );
+}
+
+function DrawerTrigger({ ...props }: DrawerPrimitive.Trigger.Props) {
   return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />;
 }
 
-function DrawerPortal({
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+function DrawerPortal({ ...props }: DrawerPrimitive.Portal.Props) {
   return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />;
 }
 
-function DrawerClose({
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+function DrawerClose({ ...props }: DrawerPrimitive.Close.Props) {
   return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />;
 }
 
 function DrawerOverlay({
   className,
   ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+}: DrawerPrimitive.Backdrop.Props) {
   return (
-    <DrawerPrimitive.Overlay
+    <DrawerPrimitive.Backdrop
       data-slot="drawer-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/30 supports-backdrop-filter:backdrop-blur-sm data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        "fixed inset-0 z-50 min-h-dvh bg-black/30 opacity-[max(var(--drawer-overlay-min-opacity,0),calc(1-var(--drawer-swipe-progress)))] transition-opacity duration-450 ease-[cubic-bezier(0.32,0.72,0,1)] select-none data-ending-style:pointer-events-none data-ending-style:opacity-0 data-ending-style:duration-[calc(var(--drawer-swipe-strength)*400ms)] data-snap-points:[--drawer-overlay-min-opacity:0.5] data-starting-style:opacity-0 data-swiping:duration-0 supports-backdrop-filter:backdrop-blur-sm supports-[-webkit-touch-callout:none]:absolute",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DrawerSwipeHandle({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-swipe-handle"
+      aria-hidden="true"
+      className={cn(
+        "relative z-10 flex shrink-0 cursor-grab transition-opacity duration-200 group-data-nested-drawer-open/drawer-popup:opacity-0 group-data-nested-drawer-swiping/drawer-popup:opacity-100 group-data-[swipe-axis=x]/drawer-popup:h-full group-data-[swipe-axis=x]/drawer-popup:w-3 group-data-[swipe-axis=x]/drawer-popup:items-center group-data-[swipe-axis=y]/drawer-popup:h-3 group-data-[swipe-axis=y]/drawer-popup:w-full group-data-[swipe-axis=y]/drawer-popup:justify-center group-data-[swipe-direction=down]/drawer-popup:items-end group-data-[swipe-direction=left]/drawer-popup:order-last group-data-[swipe-direction=left]/drawer-popup:justify-start group-data-[swipe-direction=right]/drawer-popup:justify-end group-data-[swipe-direction=up]/drawer-popup:order-last group-data-[swipe-direction=up]/drawer-popup:items-start after:block after:shrink-0 after:rounded-full after:bg-muted group-data-[swipe-axis=x]/drawer-popup:after:h-[100px] group-data-[swipe-axis=x]/drawer-popup:after:w-1.5 group-data-[swipe-axis=y]/drawer-popup:after:h-1.5 group-data-[swipe-axis=y]/drawer-popup:after:w-[100px] active:cursor-grabbing",
         className,
       )}
       {...props}
@@ -50,21 +101,65 @@ function DrawerContent({
   className,
   children,
   ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+}: DrawerPrimitive.Popup.Props) {
+  const { hasSnapPoints, modal, showSwipeHandle, swipeDirection } = useDrawer();
+  const swipeAxis =
+    swipeDirection === "down" || swipeDirection === "up" ? "y" : "x";
+
   return (
     <DrawerPortal data-slot="drawer-portal">
-      <DrawerOverlay />
-      <DrawerPrimitive.Content
-        data-slot="drawer-content"
-        className={cn(
-          "group/drawer-content fixed z-50 flex h-auto flex-col bg-transparent p-4 text-sm before:absolute before:inset-2 before:-z-10 before:rounded-[min(var(--radius-4xl),24px)] before:border before:border-border before:bg-popover before:shadow-xl data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=left]:sm:max-w-sm data-[vaul-drawer-direction=right]:sm:max-w-sm",
-          className,
-        )}
-        {...props}
+      {modal === true && (
+        <DrawerOverlay data-snap-points={hasSnapPoints ? "" : undefined} />
+      )}
+      <DrawerPrimitive.Viewport
+        data-slot="drawer-viewport"
+        data-modal={modal}
+        className="pointer-events-none fixed inset-0 z-50 select-none data-[modal=true]:pointer-events-auto"
       >
-        <div className="mx-auto mt-4 hidden h-1.5 w-[100px] shrink-0 rounded-full bg-muted group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
-        {children}
-      </DrawerPrimitive.Content>
+        <DrawerPrimitive.Popup
+          data-slot="drawer-popup"
+          data-swipe-axis={swipeAxis}
+          data-snap-points={hasSnapPoints ? "" : undefined}
+          className={cn(
+            // Base.
+            "group/drawer-popup pointer-events-auto fixed z-50 m-(--drawer-inset,0px) flex h-(--drawer-content-height) max-h-(--drawer-content-max-height,none) min-h-0 w-(--drawer-content-width,auto) transform-[translate3d(var(--translate-x,0px),var(--translate-y,0px),0)_scale(var(--stack-scale))] flex-col rounded-[min(var(--radius-4xl),24px)] border border-popover bg-popover text-sm text-popover-foreground shadow-xl transition-[transform,height,opacity,filter] duration-450 ease-[cubic-bezier(0.22,1,0.36,1)] will-change-transform outline-none select-none [--drawer-bleed-background:transparent] [--drawer-inset:--spacing(2)] [--drawer-stacked-shadow:0_-20px_25px_-5px_rgb(0_0_0/0.1),0_-8px_10px_-6px_rgb(0_0_0/0.1)] [interpolate-size:allow-keywords] data-[swipe-direction=down]:data-nested-drawer-open:shadow-(--drawer-stacked-shadow) dark:border-border",
+            // Nested.
+            "data-nested-drawer-open:overflow-hidden data-nested-drawer-open:brightness-95",
+            // Bleed.
+            "after:pointer-events-none after:absolute after:bg-(--drawer-bleed-background,var(--color-popover)) data-[swipe-axis=x]:after:inset-y-0 data-[swipe-axis=x]:after:w-(--bleed) data-[swipe-axis=y]:after:inset-x-0 data-[swipe-axis=y]:after:h-(--bleed) data-[swipe-direction=down]:after:top-full data-[swipe-direction=left]:after:right-full data-[swipe-direction=right]:after:left-full data-[swipe-direction=up]:after:bottom-full",
+            // Sizing.
+            "[--drawer-content-height:var(--drawer-height,auto)] data-[swipe-axis=x]:[--drawer-content-width:75%] data-[swipe-axis=y]:[--drawer-content-max-height:calc(100dvh-6rem)] data-[swipe-axis=y]:data-snap-points:[--drawer-content-height:100dvh] data-[swipe-axis=x]:sm:[--drawer-content-width:24rem]",
+            // Stack.
+            "[--bleed:3rem] [--peek:1rem] [--stack-height:var(--drawer-frontmost-height,var(--drawer-height,0px))] [--stack-peek-offset:max(0px,calc((var(--nested-drawers)-var(--stack-progress))*var(--peek)))] [--stack-progress:clamp(0,var(--drawer-swipe-progress),1)] [--stack-scale-base:max(0,calc(1-(var(--nested-drawers)*var(--stack-step))))] [--stack-scale:clamp(0,calc(var(--stack-scale-base)+(var(--stack-step)*var(--stack-progress))),1)] [--stack-shrink:calc(1-var(--stack-scale))] [--stack-step:0.05]",
+            // Transitions.
+            "data-ending-style:transform-(--closed-transform) data-ending-style:opacity-[0.9999] data-ending-style:duration-[calc(var(--drawer-swipe-strength)*400ms)] data-nested-drawer-swiping:duration-0 data-ending-style:data-nested-drawer-swiping:duration-[calc(var(--drawer-swipe-strength)*400ms)] data-starting-style:transform-(--closed-transform) data-swiping:duration-0 data-ending-style:data-swiping:duration-[calc(var(--drawer-swipe-strength)*400ms)]",
+            // Axis: y.
+            "data-[swipe-axis=y]:inset-x-0 data-[swipe-axis=y]:data-nested-drawer-open:h-(--stack-height)",
+            // Axis: x.
+            "data-[swipe-axis=x]:inset-y-0 data-[swipe-axis=x]:flex-row",
+            // Direction: down.
+            "data-[swipe-direction=down]:bottom-0 data-[swipe-direction=down]:origin-bottom data-[swipe-direction=down]:[--closed-transform:translate3d(0,calc(100%+var(--drawer-inset,0px)+2px),0)] data-[swipe-direction=down]:[--translate-y:calc(var(--drawer-snap-point-offset,0px)+var(--drawer-swipe-movement-y)-var(--stack-peek-offset)-(var(--stack-shrink)*var(--stack-height)))]",
+            // Direction: up.
+            "data-[swipe-direction=up]:top-0 data-[swipe-direction=up]:origin-top data-[swipe-direction=up]:[--closed-transform:translate3d(0,calc(-100%-var(--drawer-inset,0px)-2px),0)] data-[swipe-direction=up]:[--translate-y:calc(var(--drawer-snap-point-offset,0px)+var(--drawer-swipe-movement-y)+var(--stack-peek-offset)+(var(--stack-shrink)*var(--stack-height)))]",
+            // Direction: left.
+            "data-[swipe-direction=left]:left-0 data-[swipe-direction=left]:origin-left data-[swipe-direction=left]:[--closed-transform:translate3d(calc(-100%-var(--drawer-inset,0px)-2px),0,0)] data-[swipe-direction=left]:[--translate-x:calc(var(--drawer-swipe-movement-x)+var(--stack-peek-offset)+(var(--stack-shrink)*100%))]",
+            // Direction: right.
+            "data-[swipe-direction=right]:right-0 data-[swipe-direction=right]:origin-right data-[swipe-direction=right]:[--closed-transform:translate3d(calc(100%+var(--drawer-inset,0px)+2px),0,0)] data-[swipe-direction=right]:[--translate-x:calc(var(--drawer-swipe-movement-x)-var(--stack-peek-offset)-(var(--stack-shrink)*100%))]",
+            className,
+          )}
+          {...props}
+        >
+          {showSwipeHandle && <DrawerSwipeHandle />}
+          <DrawerPrimitive.Content
+            data-slot="drawer-content"
+            className={cn(
+              "flex min-h-0 flex-1 flex-col overflow-hidden overscroll-contain rounded-[inherit] transition-opacity duration-300 ease-[cubic-bezier(0.45,1.005,0,1.005)] select-text group-data-nested-drawer-open/drawer-popup:opacity-0 group-data-nested-drawer-swiping/drawer-popup:opacity-100 group-data-swiping/drawer-popup:select-none",
+            )}
+          >
+            {children}
+          </DrawerPrimitive.Content>
+        </DrawerPrimitive.Popup>
+      </DrawerPrimitive.Viewport>
     </DrawerPortal>
   );
 }
@@ -74,7 +169,7 @@ function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="drawer-header"
       className={cn(
-        "flex flex-col gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-1.5 md:text-left",
+        "flex shrink-0 flex-col gap-0.5 p-4 pb-0 group-data-[swipe-axis=y]/drawer-popup:text-center md:gap-1.5 md:text-left",
         className,
       )}
       {...props}
@@ -86,16 +181,13 @@ function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="drawer-footer"
-      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      className={cn("mt-auto flex shrink-0 flex-col gap-2 p-4 pt-0", className)}
       {...props}
     />
   );
 }
 
-function DrawerTitle({
-  className,
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+function DrawerTitle({ className, ...props }: DrawerPrimitive.Title.Props) {
   return (
     <DrawerPrimitive.Title
       data-slot="drawer-title"
@@ -111,11 +203,11 @@ function DrawerTitle({
 function DrawerDescription({
   className,
   ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+}: DrawerPrimitive.Description.Props) {
   return (
     <DrawerPrimitive.Description
       data-slot="drawer-description"
-      className={cn("text-sm text-muted-foreground", className)}
+      className={cn("text-sm text-balance text-muted-foreground", className)}
       {...props}
     />
   );
@@ -125,6 +217,7 @@ export {
   Drawer,
   DrawerPortal,
   DrawerOverlay,
+  DrawerSwipeHandle,
   DrawerTrigger,
   DrawerClose,
   DrawerContent,

--- a/src/hooks/use-resume-download.ts
+++ b/src/hooks/use-resume-download.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useState } from "react";
+import {
+  downloadResume,
+  type ExportFormat,
+} from "@/components/editor/download-resume";
+import { useResumeStore } from "@/lib/store";
+
+export function useResumeDownload() {
+  const resume = useResumeStore((state) => state.open);
+  const [generating, setGenerating] = useState(false);
+
+  async function download(format: ExportFormat, fileName: string) {
+    if (!resume) return false;
+    setGenerating(true);
+    try {
+      await downloadResume(resume, format, fileName);
+      return true;
+    } finally {
+      setGenerating(false);
+    }
+  }
+
+  return { resume, generating, download };
+}

--- a/src/lib/store/index.ts
+++ b/src/lib/store/index.ts
@@ -3,4 +3,5 @@ export {
   registerResumeFlushListeners,
 } from "./persistence";
 export { useResumeStore } from "./resume-store";
+export { useSidebarStore } from "./sidebar-store";
 export { useTourStore } from "./tour-store";

--- a/src/lib/store/sidebar-store.ts
+++ b/src/lib/store/sidebar-store.ts
@@ -1,0 +1,37 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+// Must match MOBILE_BREAKPOINT in hooks/use-mobile.ts — below it the sidebar
+// renders as a sheet controlled via `mobileControl`, not `open`.
+const MOBILE_QUERY = "(max-width: 767px)";
+
+interface SidebarStoreState {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  mobileControl: ((open: boolean) => void) | null;
+  registerMobileControl: (control: ((open: boolean) => void) | null) => void;
+  ensureVisible: (visible: boolean) => void;
+}
+
+export const useSidebarStore = create<SidebarStoreState>()(
+  persist(
+    (set, get) => ({
+      open: true,
+      setOpen: (open) => set({ open }),
+      mobileControl: null,
+      registerMobileControl: (control) => set({ mobileControl: control }),
+      ensureVisible: (visible) => {
+        if (window.matchMedia(MOBILE_QUERY).matches) {
+          get().mobileControl?.(visible);
+          return;
+        }
+        if (visible) get().setOpen(true);
+      },
+    }),
+    {
+      name: "lanjut:sidebar",
+      skipHydration: true,
+      partialize: (state) => ({ open: state.open }),
+    },
+  ),
+);

--- a/src/lib/tour.ts
+++ b/src/lib/tour.ts
@@ -1,4 +1,4 @@
-import type { Step, Tour } from "nextstepjs";
+import type { Step } from "nextstepjs";
 
 export const LIBRARY_TOUR = "library";
 export const TEMPLATE_TOUR = "template";
@@ -11,10 +11,27 @@ export type TourName =
   | typeof EDITOR_TOUR
   | typeof EDITOR_SHEET_TOUR;
 
+export interface AppStep extends Step {
+  sidebar?: "open" | "closed";
+}
+
+export interface AppTour {
+  tour: TourName;
+  steps: AppStep[];
+}
+
 export function tourForPathname(pathname: string): TourName {
   if (pathname.startsWith("/platform/editor")) return EDITOR_TOUR;
   if (pathname.startsWith("/platform/template")) return TEMPLATE_TOUR;
   return LIBRARY_TOUR;
+}
+
+export function getTourStep(
+  tourName: string | null,
+  stepIndex: number,
+): AppStep | undefined {
+  const tour = TOURS.find((t) => t.tour === tourName);
+  return tour?.steps[stepIndex];
 }
 
 const BASE_STEP = {
@@ -25,26 +42,20 @@ const BASE_STEP = {
   pointerRadius: 16,
 } satisfies Partial<Step>;
 
-export const TOURS: Tour[] = [
+export const TOURS: AppTour[] = [
   {
     tour: LIBRARY_TOUR,
     steps: [
       {
         ...BASE_STEP,
+        sidebar: "closed",
         title: "Welcome to Lanjut",
         content:
           "A free, local-first résumé builder. Everything you write stays in this browser — nothing is ever sent to a server.",
       },
       {
         ...BASE_STEP,
-        selector: "#tour-sidebar-nav",
-        side: "right",
-        title: "Get around",
-        content:
-          "Switch between your dashboard and the template gallery from here.",
-      },
-      {
-        ...BASE_STEP,
+        sidebar: "closed",
         selector: "#tour-create-resume",
         side: "bottom-right",
         title: "Create a résumé",
@@ -53,6 +64,7 @@ export const TOURS: Tour[] = [
       },
       {
         ...BASE_STEP,
+        sidebar: "closed",
         selector: "#tour-search-resume",
         side: "bottom-left",
         title: "Find it later",
@@ -60,6 +72,16 @@ export const TOURS: Tour[] = [
       },
       {
         ...BASE_STEP,
+        sidebar: "open",
+        selector: "#tour-sidebar-nav",
+        side: "right",
+        title: "Get around",
+        content:
+          "Switch between your dashboard and the template gallery from here.",
+      },
+      {
+        ...BASE_STEP,
+        sidebar: "open",
         selector: "#tour-sidebar-resumes",
         side: "right",
         title: "Your résumés",
@@ -68,6 +90,7 @@ export const TOURS: Tour[] = [
       },
       {
         ...BASE_STEP,
+        sidebar: "open",
         selector: "#tour-guide",
         side: "right",
         title: "Replay anytime",
@@ -81,6 +104,7 @@ export const TOURS: Tour[] = [
     steps: [
       {
         ...BASE_STEP,
+        sidebar: "closed",
         selector: "#tour-template-grid > :first-child",
         side: "right",
         title: "Browse templates",
@@ -89,6 +113,7 @@ export const TOURS: Tour[] = [
       },
       {
         ...BASE_STEP,
+        sidebar: "closed",
         selector: "#tour-search-template",
         side: "bottom-left",
         title: "Search",
@@ -96,6 +121,7 @@ export const TOURS: Tour[] = [
       },
       {
         ...BASE_STEP,
+        sidebar: "closed",
         selector: "#tour-sort-template",
         side: "bottom-right",
         title: "Sort",
@@ -137,12 +163,14 @@ export const TOURS: Tour[] = [
     steps: [
       {
         ...BASE_STEP,
+        sidebar: "closed",
         title: "Live preview",
         content:
           "This paper is your résumé exactly as it will export. It updates as you type and is saved to this browser automatically.",
       },
       {
         ...BASE_STEP,
+        sidebar: "closed",
         selector: "#tour-editor-edit",
         side: "top-right",
         title: "Fill in your details",


### PR DESCRIPTION
## Summary

Three related mobile/UX improvements:

### Tour orchestration
- Every tour step now declares what the app must arrange before it shows (`sidebar: "open" | "closed"` on `AppStep`); a central `prepareStep` in the tour provider executes it on `onStart` and every `onStepChange`, for auto-started and Guide-replayed tours alike.
- The sidebar's desktop open state moved into a persisted zustand store (`sidebar-store.ts`), driving the shadcn `SidebarProvider` in controlled mode. The mobile sheet (internal to shadcn) is reachable through a registered control handle, so the tour can open/close it too — previously the library tour spotlighted a zero-size point on mobile because its targets lived in an unmounted sheet.
- After toggling the sidebar, a synthetic window `resize` is dispatched once it settles; NextStep re-queries the step selector on resize, which re-anchors targets that mount with the sheet.
- Library tour reordered (toolbar steps first, sidebar steps last) so the mobile sheet flips once. `onComplete`/`onSkip` close the sheet.

### Mobile download
- Shared `useResumeDownload` hook extracted from the navbar popover; the mobile menu's dead "Download Résumé" item now opens a bottom drawer with the same form, gated to the editor route and hidden at `md+` where the standalone button exists.

### Responsive dialogs + vaul removal
- New `ResponsiveDialog*` family in `components/shared/` renders base-ui Dialog on desktop and a Drawer below 768px; create/rename/download dialogs swapped onto it. The delete confirm keeps `AlertDialog` semantics on desktop with a local drawer branch on mobile.
- `ui/drawer.tsx` replaced with the base-ui Drawer from the base-rhea shadcn registry (swipe-to-dismiss, swipe handle); **vaul removed from dependencies**. Consumers updated for base-ui's `render` prop (vs Radix `asChild`) and the new padded-header/unpadded-body anatomy.

## Data flow

No resume content leaves the browser. New persisted state is limited to UI booleans (sidebar open) in localStorage.

## Testing

- `pnpm build`, `pnpm lint` pass.
- Manually verified tours on desktop and mobile viewports (sidebar spotlights now anchor correctly), mobile download drawer, and the responsive dialog swaps.