### PR TITLE
fix: scroll tour targets to top and stop nextstep from scrolling them back

### DIFF
--- a/src/components/tour/tour-provider.tsx
+++ b/src/components/tour/tour-provider.tsx
@@ -10,8 +10,12 @@ const SIDEBAR_SETTLE_MS = 400;
 
 function prepareStep(tourName: string | null, stepIndex: number) {
   const step = getTourStep(tourName, stepIndex);
-  if (!step?.sidebar) return;
-  useSidebarStore.getState().ensureVisible(step.sidebar === "open");
+  if (!step || (!step.sidebar && !step.scrollTop)) return;
+  if (step.scrollTop) window.scrollTo({ top: 0, behavior: "instant" });
+  if (step.sidebar) {
+    useSidebarStore.getState().ensureVisible(step.sidebar === "open");
+  }
+
   // NextStep re-anchors on window resize; nudge it once the sidebar settles
   // so targets that mount with the mobile sheet get a real position.
   setTimeout(
@@ -44,6 +48,7 @@ export function TourProvider(props: PropsWithChildren) {
         onStepChange={handleStepChange}
         onComplete={handleTourEnd}
         onSkip={handleTourEnd}
+        noInViewScroll
         disableConsoleLogs
       >
         {props.children}

--- a/src/lib/tour.ts
+++ b/src/lib/tour.ts
@@ -13,6 +13,7 @@ export type TourName =
 
 export interface AppStep extends Step {
   sidebar?: "open" | "closed";
+  scrollTop?: boolean;
 }
 
 export interface AppTour {
@@ -42,19 +43,22 @@ const BASE_STEP = {
   pointerRadius: 16,
 } satisfies Partial<Step>;
 
+// Library and template targets all sit at the top of a window-scrolled page.
+const TOP_STEP = { ...BASE_STEP, scrollTop: true } satisfies Partial<AppStep>;
+
 export const TOURS: AppTour[] = [
   {
     tour: LIBRARY_TOUR,
     steps: [
       {
-        ...BASE_STEP,
+        ...TOP_STEP,
         sidebar: "closed",
         title: "Welcome to Lanjut",
         content:
           "A free, local-first résumé builder. Everything you write stays in this browser — nothing is ever sent to a server.",
       },
       {
-        ...BASE_STEP,
+        ...TOP_STEP,
         sidebar: "closed",
         selector: "#tour-create-resume",
         side: "bottom-right",
@@ -63,7 +67,7 @@ export const TOURS: AppTour[] = [
           "Start a new résumé from here. You can keep as many as you like.",
       },
       {
-        ...BASE_STEP,
+        ...TOP_STEP,
         sidebar: "closed",
         selector: "#tour-search-resume",
         side: "bottom-left",
@@ -71,7 +75,7 @@ export const TOURS: AppTour[] = [
         content: "Search your library by title once it grows.",
       },
       {
-        ...BASE_STEP,
+        ...TOP_STEP,
         sidebar: "open",
         selector: "#tour-sidebar-nav",
         side: "right",
@@ -80,7 +84,7 @@ export const TOURS: AppTour[] = [
           "Switch between your dashboard and the template gallery from here.",
       },
       {
-        ...BASE_STEP,
+        ...TOP_STEP,
         sidebar: "open",
         selector: "#tour-sidebar-resumes",
         side: "right",
@@ -89,7 +93,7 @@ export const TOURS: AppTour[] = [
           "Every résumé you create shows up here — pick one to jump into the editor.",
       },
       {
-        ...BASE_STEP,
+        ...TOP_STEP,
         sidebar: "open",
         selector: "#tour-guide",
         side: "right",
@@ -103,7 +107,7 @@ export const TOURS: AppTour[] = [
     tour: TEMPLATE_TOUR,
     steps: [
       {
-        ...BASE_STEP,
+        ...TOP_STEP,
         sidebar: "closed",
         selector: "#tour-template-grid > :first-child",
         side: "right",
@@ -112,7 +116,7 @@ export const TOURS: AppTour[] = [
           "Templates change presentation only — typography, spacing, accents. The structure stays linear so ATS parsers can always read your résumé.",
       },
       {
-        ...BASE_STEP,
+        ...TOP_STEP,
         sidebar: "closed",
         selector: "#tour-search-template",
         side: "bottom-left",
@@ -120,7 +124,7 @@ export const TOURS: AppTour[] = [
         content: "Look up a template by name.",
       },
       {
-        ...BASE_STEP,
+        ...TOP_STEP,
         sidebar: "closed",
         selector: "#tour-sort-template",
         side: "bottom-right",


### PR DESCRIPTION
## Summary

Starting or replaying a tour on `/platform` or `/platform/template` while scrolled down left the spotlight floating over the sticky navbar instead of the target (screenshot in the session: the search-input step highlighted the breadcrumb).

Two changes:

- **`scrollTop` step instruction.** `AppStep` gains `scrollTop?: boolean`; all nine library/template steps carry it (via a `TOP_STEP` base — their targets all sit at the top of a window-scrolled page). `prepareStep` executes an instant `window.scrollTo({ top: 0 })` on tour start and every step change. Editor tours are untouched: their targets live in viewport-bounded ScrollAreas.
- **`noInViewScroll` on the NextStep provider.** The root cause of the remaining bug: NextStep has an IntersectionObserver-driven scroll effect whose `isInView` updates asynchronously. Right after our instant scroll it still reported the target as out-of-view and fired `scrollIntoView({ block: "start" })`, dragging the page back so the target sat exactly under the sticky navbar (`scrollY: 65`). The flag gates exactly that effect; NextStep's other scroll sites measure synchronously and now correctly no-op. Scrolling is fully owned by the tour orchestration layer.

## Verification

Reproduced and verified headlessly (playwright-core + Brave) against the dev server at 1440×900 and 390×844:

- Before: scroll to 900 mid-tour → Next → `scrollY: 65`, target pinned under the navbar (matches the reported screenshot).
- After: same sequence → `scrollY: 0`, spotlight cleanly on the search input at both widths; `/platform` create-résumé step also confirmed visually.
- `pnpm build` and `pnpm lint` pass.