### PR TITLE
feat: report bugs from the sidebar via prefilled github issues

### DIFF
--- a/src/app/platform/layout.tsx
+++ b/src/app/platform/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import type { PropsWithChildren } from "react";
+import { PlatformBugReportDialog } from "@/components/platform/platform-bug-report-dialog";
 import { PlatformNavbar } from "@/components/platform/platform-navbar";
 import { PlatformSidebar } from "@/components/platform/platform-sidebar";
 import { PlatformSidebarProvider } from "@/components/platform/platform-sidebar-provider";
@@ -24,6 +25,8 @@ export default function PlatformLayout({ children }: PropsWithChildren) {
           <PlatformNavbar />
           {children}
         </SidebarInset>
+
+        <PlatformBugReportDialog />
       </PlatformSidebarProvider>
     </TourProvider>
   );

--- a/src/components/editor/rich-content.ts
+++ b/src/components/editor/rich-content.ts
@@ -86,6 +86,40 @@ function runsText(runs: InlineRun[]): string {
     .trim();
 }
 
+function runMarkdown(run: InlineRun): string {
+  // GFM emphasis markers must hug non-whitespace, so a run's edge whitespace
+  // is shifted outside the markers ("bold " -> "**bold** ").
+  const match = /^(\s*)([\s\S]*?)(\s*)$/.exec(run.text);
+  const [, lead = "", core = "", tail = ""] = match ?? [];
+  if (!core) return run.text;
+  let text = core;
+  if (run.italic) text = `*${text}*`;
+  if (run.bold) text = `**${text}**`;
+  if (run.href) text = `[${text}](${run.href})`;
+  return lead + text + tail;
+}
+
+/**
+ * Serializes rich blocks to GitHub-flavored markdown (used to prefill issue
+ * bodies, which GitHub renders as markdown). Paragraphs become blocks separated
+ * by blank lines; lists keep their `-` / `1.` markers.
+ */
+export function richBlocksToMarkdown(blocks: RichBlock[]): string {
+  const parts: string[] = [];
+  for (const block of blocks) {
+    if (block.type === "paragraph") {
+      parts.push(block.runs.map(runMarkdown).join("").trim());
+      continue;
+    }
+    const lines = block.items.map((item, index) => {
+      const marker = block.ordered ? `${index + 1}.` : "-";
+      return `${marker} ${item.map(runMarkdown).join("").trim()}`;
+    });
+    parts.push(lines.join("\n"));
+  }
+  return parts.join("\n\n");
+}
+
 /**
  * Flattens rich blocks to plain-text lines — one per paragraph, and each list
  * item prefixed with "- " — for the .txt export. Marks are dropped (plain text

--- a/src/components/platform/platform-bug-report-dialog.tsx
+++ b/src/components/platform/platform-bug-report-dialog.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useBugReportStore } from "@/lib/store";
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "../shared/responsive-dialog";
+import { PlatformBugReportForm } from "./platform-bug-report-form";
+
+/**
+ * Rendered once at the platform layout level, outside the sidebar: on mobile
+ * the sidebar is a sheet that closes when this dialog opens, and a dialog
+ * mounted inside it would be unmounted mid-open. Opened via useBugReportStore.
+ */
+export function PlatformBugReportDialog() {
+  const open = useBugReportStore((state) => state.open);
+  const setOpen = useBugReportStore((state) => state.setOpen);
+
+  return (
+    <ResponsiveDialog open={open} onOpenChange={setOpen}>
+      <ResponsiveDialogContent className="sm:max-w-lg">
+        <ResponsiveDialogHeader>
+          <ResponsiveDialogTitle>Report a bug</ResponsiveDialogTitle>
+          <ResponsiveDialogDescription className="text-balance">
+            This opens a prefilled GitHub issue for you to review and submit — a
+            GitHub account is required, and your browser details are filled in
+            for you.
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
+
+        <PlatformBugReportForm onSubmitted={() => setOpen(false)} />
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  );
+}

--- a/src/components/platform/platform-bug-report-form.tsx
+++ b/src/components/platform/platform-bug-report-form.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
+import { ExternalLink, XIcon } from "lucide-react";
+import { usePathname } from "next/navigation";
+import { Controller, useForm } from "react-hook-form";
+import {
+  areaForPathname,
+  bugReportTitle,
+  buildBugReportUrl,
+} from "@/lib/bug-report";
+import {
+  BUG_AREAS,
+  type BugReportForm,
+  bugReportSchema,
+} from "@/lib/forms/bug-report";
+import { emptyRichTextValue } from "@/lib/resume";
+import { PROSE_FEATURES } from "@/lib/resume/schema-registry";
+import {
+  richBlocksToMarkdown,
+  richBlocksToText,
+  tiptapToRichBlocks,
+} from "../editor/rich-content";
+import { RichTextEditor } from "../editor/rich-text/rich-text-editor";
+import {
+  ResponsiveDialogClose,
+  ResponsiveDialogFooter,
+} from "../shared/responsive-dialog";
+import { Button } from "../ui/button";
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from "../ui/field";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
+
+interface PlatformBugReportFormProps {
+  onSubmitted: () => void;
+}
+
+export function PlatformBugReportForm(props: PlatformBugReportFormProps) {
+  const pathname = usePathname();
+  const form = useForm<BugReportForm>({
+    resolver: standardSchemaResolver(bugReportSchema),
+    defaultValues: {
+      whatHappened: emptyRichTextValue(),
+      steps: emptyRichTextValue(),
+      area: areaForPathname(pathname),
+    },
+    mode: "onChange",
+  });
+
+  const onSubmit = form.handleSubmit((values) => {
+    const whatHappened = tiptapToRichBlocks(values.whatHappened);
+    const steps = tiptapToRichBlocks(values.steps);
+    const url = buildBugReportUrl({
+      title: bugReportTitle(richBlocksToText(whatHappened)[0] ?? ""),
+      whatHappened: richBlocksToMarkdown(whatHappened),
+      steps: richBlocksToMarkdown(steps),
+      area: values.area,
+    });
+    window.open(url, "_blank", "noopener,noreferrer");
+    props.onSubmitted();
+  });
+
+  return (
+    <form onSubmit={onSubmit}>
+      <FieldGroup>
+        <Controller
+          control={form.control}
+          name="whatHappened"
+          render={({ field, fieldState }) => (
+            <Field data-invalid={fieldState.invalid}>
+              <FieldLabel htmlFor="bug-report-what-happened">
+                What happened?
+              </FieldLabel>
+              <RichTextEditor
+                id="bug-report-what-happened"
+                features={PROSE_FEATURES}
+                placeholder="The editor preview goes blank when..."
+                value={field.value}
+                onChange={field.onChange}
+                onBlur={field.onBlur}
+              />
+              <FieldError errors={[fieldState.error]} />
+            </Field>
+          )}
+        />
+
+        <Controller
+          control={form.control}
+          name="steps"
+          render={({ field }) => (
+            <Field>
+              <FieldLabel htmlFor="bug-report-steps">
+                Steps to reproduce
+              </FieldLabel>
+              <RichTextEditor
+                id="bug-report-steps"
+                features={PROSE_FEATURES}
+                placeholder="1. Create a résumé — a numbered list works great here"
+                value={field.value}
+                onChange={field.onChange}
+                onBlur={field.onBlur}
+              />
+              <FieldDescription>
+                Optional here — you can also fill this in on GitHub.
+              </FieldDescription>
+            </Field>
+          )}
+        />
+
+        <Controller
+          control={form.control}
+          name="area"
+          render={({ field }) => (
+            <Field>
+              <FieldLabel>Where does the bug show up?</FieldLabel>
+              <Select
+                value={field.value}
+                onValueChange={(value) => field.onChange(value)}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Area" />
+                </SelectTrigger>
+                <SelectContent
+                  alignItemWithTrigger={false}
+                  align="start"
+                  className="w-[--anchor-width]"
+                >
+                  <SelectGroup>
+                    {BUG_AREAS.map((area) => (
+                      <SelectItem key={area} value={area}>
+                        {area}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            </Field>
+          )}
+        />
+      </FieldGroup>
+
+      <ResponsiveDialogFooter className="mt-6">
+        <ResponsiveDialogClose type="button" variant="outline">
+          <XIcon /> Cancel
+        </ResponsiveDialogClose>
+        <Button type="submit">
+          <ExternalLink />
+          Open GitHub issue
+        </Button>
+      </ResponsiveDialogFooter>
+    </form>
+  );
+}

--- a/src/components/platform/platform-sidebar-other.tsx
+++ b/src/components/platform/platform-sidebar-other.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { HelpCircle } from "lucide-react";
+import { Bug, HelpCircle, HelpingHand } from "lucide-react";
 import { usePathname } from "next/navigation";
 import { useNextStep } from "nextstepjs";
 import { MEDIA_XL, useMediaQuery } from "@/hooks/use-media-query";
-import { useResumeStore } from "@/lib/store";
+import { useBugReportStore, useResumeStore } from "@/lib/store";
 import { EDITOR_SHEET_TOUR, EDITOR_TOUR, tourForPathname } from "@/lib/tour";
 import {
   SidebarGroup,
@@ -12,13 +12,16 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  useSidebar,
 } from "../ui/sidebar";
 
 export function PlatformSidebarOther() {
   const pathname = usePathname();
   const openStatus = useResumeStore((state) => state.openStatus);
+  const setBugReportOpen = useBugReportStore((state) => state.setOpen);
   const isDesktop = useMediaQuery(MEDIA_XL);
   const { startNextStep } = useNextStep();
+  const { isMobile, setOpenMobile } = useSidebar();
 
   const baseTour = tourForPathname(pathname);
   const tour =
@@ -38,6 +41,22 @@ export function PlatformSidebarOther() {
             <HelpCircle /> Guide
           </SidebarMenuButton>
         </SidebarMenuItem>
+
+        <SidebarMenuItem>
+          <SidebarMenuButton
+            onClick={() => {
+              if (isMobile) setOpenMobile(false);
+              setBugReportOpen(true);
+            }}
+          >
+            <Bug /> Report a bug
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+        {/* <SidebarMenuItem>
+          <SidebarMenuButton>
+            <HelpingHand /> Feature request
+          </SidebarMenuButton>
+        </SidebarMenuItem> */}
       </SidebarMenu>
     </SidebarGroup>
   );

--- a/src/lib/bug-report.ts
+++ b/src/lib/bug-report.ts
@@ -1,0 +1,45 @@
+import type { BUG_AREAS } from "./forms/bug-report";
+
+const NEW_ISSUE_URL = "https://github.com/rimzzlabs/lanjut/issues/new";
+const TITLE_SUBJECT_MAX_LENGTH = 72;
+
+export interface BugReportIssue {
+  title: string;
+  whatHappened: string;
+  steps: string;
+  area: (typeof BUG_AREAS)[number];
+}
+
+export function areaForPathname(pathname: string): (typeof BUG_AREAS)[number] {
+  if (pathname.startsWith("/platform/editor")) return "Editor";
+  if (pathname.startsWith("/platform")) return "Dashboard / library";
+  if (pathname === "/") return "Landing page";
+  return "Other";
+}
+
+/** Issue title from the report's first line, marked as coming from the app. */
+export function bugReportTitle(summaryLine: string): string {
+  const subject = summaryLine
+    .replace(/^- /, "")
+    .trim()
+    .slice(0, TITLE_SUBJECT_MAX_LENGTH);
+  return `fix(bug,via app): ${subject}`;
+}
+
+/**
+ * GitHub prefills issue-form fields from query params keyed by the field ids
+ * in .github/ISSUE_TEMPLATE/bug-report.yml — keep the param names in sync
+ * with that file. `whatHappened` and `steps` are markdown strings; GitHub
+ * renders those textareas as GFM.
+ */
+export function buildBugReportUrl(issue: BugReportIssue): string {
+  const params = new URLSearchParams({
+    template: "bug-report.yml",
+    title: issue.title,
+    "what-happened": issue.whatHappened,
+    area: issue.area,
+    browser: navigator.userAgent,
+  });
+  if (issue.steps) params.set("steps", issue.steps);
+  return `${NEW_ISSUE_URL}?${params.toString()}`;
+}

--- a/src/lib/forms/bug-report.ts
+++ b/src/lib/forms/bug-report.ts
@@ -1,0 +1,33 @@
+import type { JSONContent } from "@tiptap/core";
+import { z } from "zod";
+
+/** Must match the `area` dropdown options in .github/ISSUE_TEMPLATE/bug-report.yml. */
+export const BUG_AREAS = [
+  "Editor",
+  "Résumé preview",
+  "Templates",
+  "Export (PDF / DOCX / TXT)",
+  "Dashboard / library",
+  "Landing page",
+  "Other",
+] as const;
+
+function plainTextOf(node: JSONContent): string {
+  if (node.type === "text") return node.text ?? "";
+  return (node.content ?? []).map(plainTextOf).join("");
+}
+
+const richTextDoc = z.custom<JSONContent>(
+  (value) => typeof value === "object" && value !== null,
+);
+
+export const bugReportSchema = z.object({
+  whatHappened: richTextDoc.refine(
+    (doc) => plainTextOf(doc).trim().length > 0,
+    "Describe what went wrong.",
+  ),
+  steps: richTextDoc,
+  area: z.enum(BUG_AREAS),
+});
+
+export type BugReportForm = z.infer<typeof bugReportSchema>;

--- a/src/lib/store/bug-report-store.ts
+++ b/src/lib/store/bug-report-store.ts
@@ -1,0 +1,17 @@
+import { create } from "zustand";
+
+interface BugReportStoreState {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+/**
+ * The bug-report dialog is triggered from the sidebar but rendered at the
+ * platform layout level: on mobile the sidebar is a sheet that closes (and
+ * unmounts its children) when the dialog opens, so the dialog cannot live
+ * inside it. This store carries the open flag across that boundary.
+ */
+export const useBugReportStore = create<BugReportStoreState>()((set) => ({
+  open: false,
+  setOpen: (open) => set({ open }),
+}));

--- a/src/lib/store/index.ts
+++ b/src/lib/store/index.ts
@@ -1,3 +1,4 @@
+export { useBugReportStore } from "./bug-report-store";
 export {
   flushOpenResumePersist,
   registerResumeFlushListeners,


### PR DESCRIPTION
# Summary

Wires the sidebar's "Report a bug" button to GitHub. Lanjut is local-first with no backend, so instead of calling the GitHub API the app opens a small in-app form and hands off to a prefilled issue-form URL (`issues/new?template=bug-report.yml&...`) — the reporter reviews, ticks the confirmation checkboxes, and submits on GitHub.

- In-app form (responsive dialog → drawer on mobile) with three inputs: what happened (required), steps to reproduce (optional), and area.
- "What happened" and "Steps" use the restricted TipTap `RichTextEditor`; a new `richBlocksToMarkdown` serializer in `rich-content.ts` converts them to GFM so formatting arrives on GitHub 1:1.
- Issue title is prefilled as `fix(bug,via app): <first line of what happened>` (72-char cap).
- Browser/OS is auto-filled from `navigator.userAgent`; the area dropdown is pre-selected from the current route.
- The dialog is rendered at the platform layout level and driven by a small zustand store: on mobile the sidebar is a sheet that closes when the dialog opens, so a dialog mounted inside it would be unmounted mid-open. The button closes the mobile sheet explicitly before opening the drawer.

Note for reviewers: the prefill query params are keyed by the field ids in `.github/ISSUE_TEMPLATE/bug-report.yml`, and `BUG_AREAS` must match the template's dropdown options exactly — rewording either side silently breaks that field's prefill.

## Type of change

- [ ] Bug fix
- [x] Feature

## How was this tested?

- Manual: opened the form from the sidebar, submitted, and confirmed the GitHub issue arrives with title, body fields, area, and browser prefilled (screenshot-verified on the real repo).
- Mobile viewport: sidebar sheet closes cleanly and the drawer opens without unmounting (this was a bug in an earlier iteration, fixed by hoisting the dialog to the layout).
- Markdown serializer verified with a runtime test covering bold/italic/link runs and ordered lists.
- `tsc --noEmit` and `biome check` pass.

## Checklist

- [x] The PR title follows the commitlint convention (`feat: ...` / `fix: ...`, subject fully lowercase — it becomes the squash-merge commit).
- [x] Lint and format pass locally (`biome check`); commits were made without `--no-verify`.
- [x] No résumé content is sent to any server, API route, or open-next function (confirm on every PR touching data flow). The prefilled URL contains only what the reporter typed into the bug form.
- [x] Changes keep the structural layer intact: presentation-only styling, no tables/columns/floating elements in the document model.
- [x] If the export path changed: text extraction order verified (e.g. `pdftotext`) and output checked against at least one real ATS parser. — N/A, export path untouched (`rich-content.ts` only gains a new function).
- [x] If the résumé schema changed: schema version bumped and a migration path added for existing saved résumés. — N/A.