### PR TITLE
feat: show a user-facing what's new changelog in the navbar

### DIFF
--- a/src/components/platform/platform-navbar-changelog.tsx
+++ b/src/components/platform/platform-navbar-changelog.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { format } from "date-fns";
+import { ArrowUpRight, Sparkles } from "lucide-react";
+import { useState } from "react";
+import { useIsClient } from "@/hooks/use-is-client";
+import {
+  CHANGELOG,
+  type ChangelogEntry,
+  LATEST_CHANGELOG_VERSION,
+} from "@/lib/changelog";
+import { useChangelogStore } from "@/lib/store";
+import { Button } from "../ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "../ui/sheet";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
+
+export function PlatformNavbarChangelog() {
+  const mounted = useIsClient();
+  const [open, setOpen] = useState(false);
+  const lastSeenVersion = useChangelogStore((state) => state.lastSeenVersion);
+
+  const hasUnseen = lastSeenVersion !== LATEST_CHANGELOG_VERSION;
+
+  const onOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (nextOpen) {
+      useChangelogStore.getState().markSeen(LATEST_CHANGELOG_VERSION);
+    }
+  };
+
+  if (!mounted) return null;
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <SheetTrigger
+              render={
+                <Button size="icon" variant="outline" className="relative" />
+              }
+            />
+          }
+        >
+          <Sparkles />
+          <span className="sr-only">What&apos;s new</span>
+          {hasUnseen && (
+            <span
+              aria-hidden
+              className="absolute -top-0.5 -right-0.5 size-2 rounded-full bg-primary animate-pulse motion-reduce:animate-none"
+            />
+          )}
+        </TooltipTrigger>
+        <TooltipContent>What&apos;s new</TooltipContent>
+      </Tooltip>
+
+      <SheetContent side="right">
+        <SheetHeader>
+          <SheetTitle>What&apos;s new</SheetTitle>
+          <SheetDescription>
+            The latest improvements to Lanjut, in plain language.
+          </SheetDescription>
+        </SheetHeader>
+
+        <ul className="flex-1 space-y-8 overflow-y-auto px-6 pb-6">
+          {CHANGELOG.map((entry, index) => (
+            <PlatformNavbarChangelogEntry
+              key={entry.version}
+              entry={entry}
+              isLatest={index === 0}
+            />
+          ))}
+        </ul>
+
+        <SheetFooter className="border-t">
+          <a
+            href="https://github.com/rimzzlabs/lanjut/releases"
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Full changelog on GitHub
+            <ArrowUpRight className="size-4" />
+          </a>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function PlatformNavbarChangelogEntry(props: {
+  entry: ChangelogEntry;
+  isLatest: boolean;
+}) {
+  return (
+    <li>
+      <div className="flex items-center gap-2">
+        <span className="rounded-md border bg-muted px-1.5 py-0.5 font-mono text-xs">
+          v{props.entry.version}
+        </span>
+        {props.isLatest && (
+          <span className="rounded-md bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary">
+            Latest
+          </span>
+        )}
+        <span className="text-xs text-muted-foreground">
+          {format(new Date(props.entry.date), "MMM d, yyyy")}
+        </span>
+      </div>
+      <ul className="mt-3 list-disc space-y-2 pl-4 text-sm text-foreground/80">
+        {props.entry.highlights.map((highlight) => (
+          <li key={highlight}>{highlight}</li>
+        ))}
+      </ul>
+    </li>
+  );
+}

--- a/src/components/platform/platform-navbar.tsx
+++ b/src/components/platform/platform-navbar.tsx
@@ -2,6 +2,7 @@
 
 import { SidebarTrigger } from "../ui/sidebar";
 import { PlatformNavbarBreadcrumb } from "./platform-navbar-breadcrumb";
+import { PlatformNavbarChangelog } from "./platform-navbar-changelog";
 import { PlatformNavbarDownload } from "./platform-navbar-download";
 import { PlatformNavbarMobileMenu } from "./platform-navbar-mobile-menu";
 import { PlatformNavbarTheme } from "./platform-navbar-theme";
@@ -14,6 +15,7 @@ export function PlatformNavbar() {
         <PlatformNavbarBreadcrumb />
 
         <div className="lg:inline-flex items-center gap-2 ml-auto">
+          <PlatformNavbarChangelog />
           <PlatformNavbarTheme />
           <PlatformNavbarDownload />
           <PlatformNavbarMobileMenu />

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,0 +1,44 @@
+export interface ChangelogEntry {
+  version: string;
+  date: string;
+  highlights: string[];
+}
+
+/**
+ * User-facing release notes shown in the "What's new" sheet, newest first.
+ * Hand-written in plain language — not generated from commits. Add an entry
+ * here as part of each release PR; skip versions with nothing user-visible.
+ */
+export const CHANGELOG: ChangelogEntry[] = [
+  {
+    version: "0.4.0",
+    date: "2026-07-05",
+    highlights: [
+      "A guided tour now walks you through the dashboard, the templates, and the editor on your first visit.",
+      "The landing page walks through how Lanjut works, ending with a one-click way to start a new résumé.",
+      "Found a bug or missing a feature? Report it from the sidebar — we prefill the GitHub issue for you.",
+      "On your phone, dialogs now open as drawers that are easier to reach and swipe away.",
+    ],
+  },
+  {
+    version: "0.3.0",
+    date: "2026-07-04",
+    highlights: [
+      "Browse templates on their own page, with search and sorting.",
+      "Five new templates: Ketat, Luasa, Tebal, Klasik, and Ketik.",
+      "Template and résumé cards now show a live thumbnail of your actual document.",
+      "The sidebar highlights where you are, and each résumé gets a quick actions menu.",
+    ],
+  },
+  {
+    version: "0.2.0",
+    date: "2026-07-03",
+    highlights: [
+      "Export your résumé as PDF, DOCX, or plain text.",
+      "Bold, italics, links, and lists now show up in the live preview.",
+      "The editor covers the full section set — summary, experience, education, skills, certifications, and languages.",
+    ],
+  },
+];
+
+export const LATEST_CHANGELOG_VERSION = CHANGELOG[0]?.version ?? "";

--- a/src/lib/store/changelog-store.ts
+++ b/src/lib/store/changelog-store.ts
@@ -1,0 +1,17 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface ChangelogStoreState {
+  lastSeenVersion: string;
+  markSeen: (version: string) => void;
+}
+
+export const useChangelogStore = create<ChangelogStoreState>()(
+  persist(
+    (set) => ({
+      lastSeenVersion: "",
+      markSeen: (version) => set({ lastSeenVersion: version }),
+    }),
+    { name: "lanjut:changelog-seen" },
+  ),
+);

--- a/src/lib/store/index.ts
+++ b/src/lib/store/index.ts
@@ -1,3 +1,4 @@
+export { useChangelogStore } from "./changelog-store";
 export { useIssueReportStore } from "./issue-report-store";
 export {
   flushOpenResumePersist,


### PR DESCRIPTION
Adds a "What's new" entry point to the platform navbar: a sparkles icon button next to the theme toggle (visible on mobile too) that opens a right-side sheet listing release notes per version — version chip, date, a "Latest" badge on the newest entry, and bulleted highlights.

The notes come from a curated entries file (`src/lib/changelog.ts`) written in plain user language, not from the release-please `CHANGELOG.md` — the generated changelog is commit-subject-voiced developer record, which is the wrong register for end users. The file is seeded with 0.2.0, 0.3.0, and the pending 0.4.0; 0.3.1 is deliberately skipped since an OG-image fix isn't user-visible. Adding an entry becomes part of the release ritual (documented in the file), and versions with nothing user-facing can be skipped.

A persisted last-seen version (`useChangelogStore`, same pattern as the tour store) drives a small dot on the trigger whenever the newest entry hasn't been seen; opening the sheet marks it seen. Everything ships in the bundle — no runtime calls to the GitHub API, in keeping with local-first. For the technically curious, the sheet footer links once to the GitHub releases page; individual PR links stay out of the user-facing view.

Testing: `tsc --noEmit` and Biome pass. The unseen dot shows on first visit, opening the sheet renders all three releases and persists the seen version, and the dot stays cleared after a reload.