### PR TITLE
fix: keep saved resumes safe across schema migrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,10 @@ Any feature request that adds structural freedom (tables, columns, floating elem
 
 - zustand holds working state, synced to IndexedDB on change (debounced).
 - No resume content is sent to any server, API route, or open-next function. Confirm this on every PR touching data flow.
-- Schema for a resume document: versioned. Add a schema version field. Write a migration path before changing field shapes, do not silently break old saved resumes.
+- Document shape is versioned by the in-document `schemaVersion` plus a forward-only, read-time migration ladder (`src/lib/resume/migrations.ts`). Ship the shape change, the `CURRENT_SCHEMA_VERSION` bump, and the ladder rung in the same PR. Full reference: `docs/schema-migrations.md`.
+- The IndexedDB `DB_VERSION` is separate and governs object stores/indexes only. Never bump it for a field-shape change; never reshape documents inside the idb `upgrade` callback.
+- Migration steps must be bail-safe: when a document does not match the expected shape, keep the original data and no-op — never blank or replace what cannot be parsed.
+- Raw pre-migration documents are snapshotted to the `backups` object store before migration. Documents that fail migration are surfaced as unreadable in the UI and are never deleted or overwritten.
 
 
 ## Reordering

--- a/docs/schema-migrations.md
+++ b/docs/schema-migrations.md
@@ -1,0 +1,70 @@
+# Schema versioning and migrations
+
+How résumé documents survive schema changes without losing user data. This is
+the canonical reference for the two version numbers, the migration ladder, the
+pre-migration backup store, and what the UI does when a document can't be read.
+
+## Two versions, two jobs
+
+| Version | Lives in | Governs | Bump when |
+| --- | --- | --- | --- |
+| `DB_VERSION` (`src/lib/db/schema.ts`) | The IndexedDB database | Object stores and indexes only | Adding or changing a store or index |
+| `schemaVersion` (`src/lib/resume/types.ts`, `CURRENT_SCHEMA_VERSION`) | Each persisted document | The field shape of a résumé | Any persisted field-shape change |
+
+Never bump `DB_VERSION` for a field-shape change, and never reshape documents
+inside idb's `upgrade` callback. The `upgrade` callback only creates stores
+guarded by `objectStoreNames.contains`, so opening the database can never drop
+existing data.
+
+## The migration ladder
+
+`src/lib/resume/migrations.ts` holds one forward-only step per version, keyed by
+the version it migrates *from* (`LADDER[N]: vN → vN+1`). `runMigrations` walks a
+document up the ladder at **read time, in memory** — the raw document on disk is
+untouched until the user's next edit persists the migrated shape.
+
+Rules for every step:
+
+- **Pure.** A JSON→JSON function over a plain document. No IndexedDB access, no
+  app state.
+- **Bail-safe.** If the document doesn't match the shape the step expects
+  (e.g. a mis-stamped `schemaVersion`, or a doc written by an in-progress dev
+  build), the step must leave the existing data untouched and degrade to a
+  no-op. It must never blank fields or replace entries it can't parse. The
+  first write after a migration persists the migrated document over the
+  original — a lossy step destroys data permanently at that moment.
+- **Shipped atomically.** The field-shape change, the `CURRENT_SCHEMA_VERSION`
+  bump, and the ladder rung land in the same PR. A shipped gap in the ladder
+  makes every older document unreadable.
+
+Documents with a `schemaVersion` **newer** than the running app (a stale cached
+bundle or a long-lived old tab after a deploy) fail migration with an error.
+That is deliberate: there is no forward compatibility, and guessing would risk
+writing a downgraded document over a newer one.
+
+## Pre-migration backups
+
+Before the repository (`src/lib/db/resume.ts`) migrates a document, it snapshots
+the raw pre-migration form into the `backups` object store, keyed by
+`${resumeId}@v${schemaVersion}` — one snapshot per document per ladder crossing.
+This happens on read, before the migrated shape has any chance of being
+persisted, so a buggy ladder step is always recoverable.
+
+To recover: DevTools → Application → IndexedDB → `lanjut` → `backups`, copy the
+`doc` value for the affected id/version, and restore it into the `resumes`
+store (the app will re-migrate it on the next read).
+
+## Failure handling in the UI
+
+Migration failures are isolated per document and **nothing is ever deleted**:
+
+- `listResumeIndex` migrates each document in its own try/catch. Unreadable
+  documents are counted (`unreadableCount`), not dropped from disk, and one bad
+  document cannot empty the whole Library.
+- The Library shows a notice ("saved by a newer version — refresh to update")
+  when `unreadableCount > 0`, and the empty state is suppressed so the user is
+  never told they have no résumés while unreadable ones exist.
+- Opening an unreadable document resolves to the `missing` state instead of a
+  stuck loading state.
+- A total index failure (storage itself unreadable) sets `indexStatus` to
+  `error` and renders an explicit error message instead of an endless skeleton.

--- a/src/app/platform/page.tsx
+++ b/src/app/platform/page.tsx
@@ -4,6 +4,7 @@ import { PlatformEmptyState } from "@/components/platform/platform-empty-state";
 import { PlatformLibraryTour } from "@/components/platform/platform-library-tour";
 import { PlatformResumeGrid } from "@/components/platform/platform-resume-grid/platform-resume-grid";
 import { PlatformResumeToolbar } from "@/components/platform/platform-resume-toolbar";
+import { PlatformResumeUnreadableNotice } from "@/components/platform/platform-resume-unreadable-notice";
 
 export const metadata: Metadata = {
   title: "Dashboard",
@@ -14,6 +15,7 @@ export default function PlatformPage() {
     <div className="flex flex-col gap-4 p-4">
       <Suspense>
         <PlatformResumeToolbar />
+        <PlatformResumeUnreadableNotice />
         <PlatformResumeGrid />
         <PlatformLibraryTour />
       </Suspense>

--- a/src/components/platform/platform-empty-state.tsx
+++ b/src/components/platform/platform-empty-state.tsx
@@ -18,9 +18,13 @@ import { PlatformResumeCreateDialog } from "./platform-resume-create-dialog";
 export function PlatformEmptyState() {
   const index = useResumeStore((state) => state.index);
   const indexStatus = useResumeStore((state) => state.indexStatus);
+  const unreadableCount = useResumeStore((state) => state.unreadableCount);
   const [open, setOpen] = useState(false);
 
-  if (indexStatus !== "ready" || index.length > 0) return null;
+  // With unreadable documents present, "No résumés yet" would be a lie.
+  if (indexStatus !== "ready" || index.length > 0 || unreadableCount > 0) {
+    return null;
+  }
 
   return (
     <div className="min-h-[calc(100vh-16rem)] grid place-items-center">

--- a/src/components/platform/platform-resume-action-download.tsx
+++ b/src/components/platform/platform-resume-action-download.tsx
@@ -30,7 +30,7 @@ export function PlatformResumeActionDownload(
   async function handleDownload(format: ExportFormat, fileName: string) {
     setGenerating(true);
     try {
-      const document = await getResume(props.resume.id);
+      const document = await getResume(props.resume.id).catch(() => undefined);
       if (!document) {
         setMissing(true);
         return;

--- a/src/components/platform/platform-resume-grid/platform-resume-grid-error.tsx
+++ b/src/components/platform/platform-resume-grid/platform-resume-grid-error.tsx
@@ -1,0 +1,15 @@
+import { TriangleAlert } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+
+export function PlatformResumeGridError() {
+  return (
+    <Alert variant="destructive">
+      <TriangleAlert />
+      <AlertTitle>Couldn&rsquo;t load your résumés</AlertTitle>
+      <AlertDescription>
+        Nothing was deleted — the library just failed to load from this
+        browser&rsquo;s storage. Refresh the page to try again.
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/src/components/platform/platform-resume-grid/platform-resume-grid.tsx
+++ b/src/components/platform/platform-resume-grid/platform-resume-grid.tsx
@@ -5,6 +5,7 @@ import { useResumeSearchQuery } from "@/hooks/use-resume-search";
 import { filterResumeIndex } from "@/lib/resume";
 import { useResumeStore } from "@/lib/store";
 import { PlatformResumeGridEmptySearch } from "./platform-resume-grid-empty-search";
+import { PlatformResumeGridError } from "./platform-resume-grid-error";
 import { PlatformResumeGridItem } from "./platform-resume-grid-item";
 import { PlatformResumeGridItemNew } from "./platform-resume-grid-item-new";
 import { PlatformResumeGridSkeleton } from "./platform-resume-grid-skeleton";
@@ -15,6 +16,7 @@ export function PlatformResumeGrid() {
   const indexStatus = useResumeStore((state) => state.indexStatus);
   const [query] = useResumeSearchQuery();
 
+  if (indexStatus === "error") return <PlatformResumeGridError />;
   if (indexStatus !== "ready") return <PlatformResumeGridSkeleton />;
   if (index.length === 0) return null;
 

--- a/src/components/platform/platform-resume-unreadable-notice.tsx
+++ b/src/components/platform/platform-resume-unreadable-notice.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { TriangleAlert } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { useResumeStore } from "@/lib/store";
+
+export function PlatformResumeUnreadableNotice() {
+  const unreadableCount = useResumeStore((state) => state.unreadableCount);
+
+  if (unreadableCount === 0) return null;
+
+  const subject =
+    unreadableCount === 1 ? "1 résumé was" : `${unreadableCount} résumés were`;
+
+  return (
+    <Alert>
+      <TriangleAlert />
+      <AlertTitle>Some résumés need a newer version of the app</AlertTitle>
+      <AlertDescription>
+        {subject} saved by a newer version of Lanjut than the one this tab is
+        running. They are still stored safely on this device — refresh the page
+        to update the app and see them again.
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/src/hooks/use-resume-document.ts
+++ b/src/hooks/use-resume-document.ts
@@ -16,9 +16,11 @@ export function useResumeDocument(id: string, updatedAt: string) {
   // biome-ignore lint/correctness/useExhaustiveDependencies: `updatedAt` is a deliberate re-fetch trigger — the id alone doesn't change when the document is edited.
   useEffect(() => {
     let cancelled = false;
-    void getResume(id).then((document) => {
-      if (!cancelled) setResume(document ?? null);
-    });
+    void getResume(id)
+      .catch(() => undefined)
+      .then((document) => {
+        if (!cancelled) setResume(document ?? null);
+      });
     return () => {
       cancelled = true;
     };

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -14,6 +14,7 @@ export const CHANGELOG: ChangelogEntry[] = [
     version: "0.4.0",
     date: "2026-07-05",
     highlights: [
+      "Your saved résumés are safer during app updates: a backup copy is kept on your device before any data-format upgrade, and a résumé the app can't read yet is flagged with a notice instead of disappearing.",
       "A guided tour now walks you through the dashboard, the templates, and the editor on your first visit.",
       "The landing page walks through how Lanjut works, ending with a one-click way to start a new résumé.",
       "Found a bug or missing a feature? Report it from the sidebar — we prefill the GitHub issue for you.",

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -4,6 +4,12 @@ export {
   getResume,
   listResumeIndex,
   putResume,
+  type ResumeIndexResult,
   setLastOpenedResumeId,
 } from "./resume";
-export { getDb, type LanjutDB, META_KEYS } from "./schema";
+export {
+  getDb,
+  type LanjutDB,
+  META_KEYS,
+  type ResumeBackup,
+} from "./schema";

--- a/src/lib/db/resume.ts
+++ b/src/lib/db/resume.ts
@@ -1,7 +1,39 @@
-import { A, pipe } from "@mobily/ts-belt";
+import { A, G, pipe } from "@mobily/ts-belt";
 import type { Resume, ResumeIndexEntry } from "@/lib/resume";
-import { runMigrations } from "@/lib/resume";
+import { needsMigration, readSchemaVersion, runMigrations } from "@/lib/resume";
 import { getDb, META_KEYS } from "./schema";
+
+export interface ResumeIndexResult {
+  entries: readonly ResumeIndexEntry[];
+  /**
+   * Documents that failed migration — typically written by a newer app build
+   * than the one currently running. They stay untouched in the store.
+   */
+  unreadableCount: number;
+}
+
+type Db = Awaited<ReturnType<typeof getDb>>;
+
+/**
+ * Snapshot the raw pre-migration document before the migrated shape has any
+ * chance of being persisted over it, so a buggy ladder step is recoverable.
+ * Idempotent per (id, version): re-reads overwrite the same key.
+ */
+async function backupRawResume(db: Db, raw: unknown): Promise<void> {
+  const id = (raw as { id?: unknown }).id;
+  if (!G.isString(id)) return;
+  const version = readSchemaVersion(raw);
+  await db.put(
+    "backups",
+    {
+      resumeId: id,
+      schemaVersion: version,
+      backedUpAt: new Date().toISOString(),
+      doc: raw,
+    },
+    `${id}@v${version}`,
+  );
+}
 
 /**
  * Persist a whole Resume document. Resolves once the write transaction has
@@ -13,11 +45,17 @@ export async function putResume(resume: Resume): Promise<void> {
   await db.put("resumes", resume);
 }
 
-/** Read one Resume, stepped up through the migration ladder before returning. */
+/**
+ * Read one Resume, stepped up through the migration ladder before returning.
+ * Backs up the raw document first when a migration will run. Throws when the
+ * document cannot be migrated (e.g. written by a newer app build).
+ */
 export async function getResume(id: string): Promise<Resume | undefined> {
   const db = await getDb();
   const raw = await db.get("resumes", id);
-  return raw ? runMigrations(raw) : undefined;
+  if (!raw) return undefined;
+  if (needsMigration(raw)) await backupRawResume(db, raw);
+  return runMigrations(raw);
 }
 
 export async function deleteResume(id: string): Promise<void> {
@@ -28,24 +66,40 @@ export async function deleteResume(id: string): Promise<void> {
 /**
  * The lightweight Library projection (id, title, updatedAt), newest first. Reads
  * full bodies to migrate them, but returns only index fields — the full body of a
- * non-open Resume is not kept in memory.
+ * non-open Resume is not kept in memory. Migration failures are isolated per
+ * document and counted, never deleted: one unreadable document must not make the
+ * whole Library look empty.
  */
-export async function listResumeIndex(): Promise<readonly ResumeIndexEntry[]> {
+export async function listResumeIndex(): Promise<ResumeIndexResult> {
   const db = await getDb();
-  const all = await db.getAllFromIndex("resumes", "by-updatedAt");
-  return pipe(
-    all,
-    A.map((raw) => {
+  // getAll, not the by-updatedAt index: a document missing the indexed key would
+  // be silently absent from an index scan, which reads as data loss.
+  const all = await db.getAll("resumes");
+
+  const entries: ResumeIndexEntry[] = [];
+  let unreadableCount = 0;
+  for (const raw of all) {
+    try {
+      if (needsMigration(raw)) await backupRawResume(db, raw);
       const resume = runMigrations(raw);
-      return {
+      entries.push({
         id: resume.id,
         title: resume.title,
         updatedAt: resume.updatedAt,
-      };
-    }),
-    A.sortBy((entry) => entry.updatedAt),
-    A.reverse,
-  );
+      });
+    } catch {
+      unreadableCount += 1;
+    }
+  }
+
+  return {
+    entries: pipe(
+      entries,
+      A.sortBy((entry) => entry.updatedAt),
+      A.reverse,
+    ),
+    unreadableCount,
+  };
 }
 
 export async function getLastOpenedResumeId(): Promise<string | null> {

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -6,15 +6,32 @@ const DB_NAME = "lanjut";
 /**
  * IndexedDB structural version. Governs object stores and indexes ONLY — document
  * field-shape changes are versioned separately by the in-document schemaVersion
- * and its migration ladder (see ADR-0002). Bump this only when adding/changing a
- * store or index, never for a field-shape change.
+ * and its migration ladder (see docs/schema-migrations.md). Bump this only when
+ * adding/changing a store or index, never for a field-shape change.
+ *
+ * v2: adds the `backups` store for raw pre-migration document snapshots.
  */
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 
 /** Keys used in the single-value `app` meta store. */
 export const META_KEYS = {
   lastOpenedResumeId: "lastOpenedResumeId",
 } as const;
+
+/**
+ * A raw pre-migration snapshot of a résumé document, written before the first
+ * read that steps it up the ladder — so a buggy or lossy migration is always
+ * recoverable. Keyed by `${resumeId}@v${schemaVersion}`: one snapshot per
+ * document per ladder crossing.
+ */
+export interface ResumeBackup {
+  resumeId: string;
+  schemaVersion: number;
+  /** ISO 8601. */
+  backedUpAt: string;
+  /** The document exactly as it was persisted, before any migration ran. */
+  doc: unknown;
+}
 
 export interface LanjutDB extends DBSchema {
   resumes: {
@@ -26,6 +43,10 @@ export interface LanjutDB extends DBSchema {
   app: {
     key: string;
     value: string;
+  };
+  backups: {
+    key: string;
+    value: ResumeBackup;
   };
 }
 
@@ -50,6 +71,9 @@ export function getDb(): Promise<IDBPDatabase<LanjutDB>> {
         }
         if (!db.objectStoreNames.contains("app")) {
           db.createObjectStore("app");
+        }
+        if (!db.objectStoreNames.contains("backups")) {
+          db.createObjectStore("backups");
         }
       },
     });

--- a/src/lib/resume/index.ts
+++ b/src/lib/resume/index.ts
@@ -6,7 +6,7 @@ export {
   createEmptySection,
   emptyRichTextValue,
 } from "./factory";
-export { needsMigration, runMigrations } from "./migrations";
+export { needsMigration, readSchemaVersion, runMigrations } from "./migrations";
 export {
   type FieldSchema,
   getSectionSchema,

--- a/src/lib/resume/migrations.ts
+++ b/src/lib/resume/migrations.ts
@@ -8,7 +8,10 @@ type ResumeDoc = Record<string, unknown>;
 /**
  * A forward-only migration from version N to N+1, keyed by N. Each step is a pure
  * JSON→JSON function over a plain document, testable with fixtures — never runs
- * inside idb's onupgradeneeded (that governs store structure only; see ADR-0002).
+ * inside idb's onupgradeneeded (that governs store structure only; see
+ * docs/schema-migrations.md). Steps must bail out (keep the original data) when a
+ * document does not match the shape they expect — a mis-stamped schemaVersion
+ * must degrade to a no-op, never to blanked or replaced fields.
  */
 type Migration = (doc: ResumeDoc) => ResumeDoc;
 
@@ -58,8 +61,15 @@ const migrateV1toV2: Migration = (doc) => {
   const header = next.header as
     | { fields?: Record<string, unknown> }
     | undefined;
-  if (header) {
-    const hf = header.fields ?? {};
+  // "in" checks guard against a doc already in v2 shape but stamped v1:
+  // remapping from absent v1 keys would blank every field.
+  if (
+    header?.fields &&
+    ("fullName" in header.fields ||
+      "headline" in header.fields ||
+      "location" in header.fields)
+  ) {
+    const hf = header.fields;
     const { firstName, lastName } = splitName(fieldValue(hf.fullName));
     const { city, province, country } = splitLocation(fieldValue(hf.location));
     header.fields = {
@@ -83,6 +93,7 @@ const migrateV1toV2: Migration = (doc) => {
       }
       for (const entry of section.entries as Array<Record<string, unknown>>) {
         const ef = (entry.fields ?? {}) as Record<string, unknown>;
+        if (!("role" in ef) && !("highlights" in ef)) continue;
         entry.fields = {
           title: plainField(fieldValue(ef.role)),
           company: plainField(fieldValue(ef.company)),
@@ -128,8 +139,14 @@ const migrateV2toV3: Migration = (doc) => {
   for (const section of sections as Array<Record<string, unknown>>) {
     if (section.type !== "skills") continue;
     const entries = Array.isArray(section.entries) ? section.entries : [];
-    const body = (entries[0] as { fields?: { body?: { value?: unknown } } })
-      ?.fields?.body?.value;
+    const first = entries[0] as
+      | { fields?: Record<string, unknown> }
+      | undefined;
+    // Entries without a `body` field are not the v2 single-body shape (likely a
+    // mis-stamped doc already at v3+) — replacing them would destroy real skills.
+    if (first?.fields && !("body" in first.fields)) continue;
+    const body = (first?.fields?.body as { value?: unknown } | undefined)
+      ?.value;
 
     const names: string[] = [];
     if (
@@ -230,8 +247,10 @@ const LADDER: Record<number, Migration> = {
   4: migrateV4toV5,
 };
 
-function readVersion(doc: ResumeDoc): number {
-  return G.isNumber(doc.schemaVersion) ? doc.schemaVersion : 0;
+/** The persisted schemaVersion of a raw document; 0 when absent or malformed. */
+export function readSchemaVersion(raw: unknown): number {
+  const doc = raw as ResumeDoc | null | undefined;
+  return G.isNumber(doc?.schemaVersion) ? doc.schemaVersion : 0;
 }
 
 /**
@@ -241,7 +260,7 @@ function readVersion(doc: ResumeDoc): number {
  */
 export function runMigrations(raw: unknown): Resume {
   let doc = raw as ResumeDoc;
-  let version = readVersion(doc);
+  let version = readSchemaVersion(doc);
 
   if (version > CURRENT_SCHEMA_VERSION) {
     throw new Error(
@@ -264,5 +283,5 @@ export function runMigrations(raw: unknown): Resume {
 
 /** Whether a persisted document is below the current version and will be migrated. */
 export function needsMigration(raw: unknown): boolean {
-  return readVersion(raw as ResumeDoc) < CURRENT_SCHEMA_VERSION;
+  return readSchemaVersion(raw) < CURRENT_SCHEMA_VERSION;
 }

--- a/src/lib/resume/schema-registry.ts
+++ b/src/lib/resume/schema-registry.ts
@@ -94,7 +94,7 @@ export const HEADER_SCHEMA: FieldSchema[] = [
 ];
 
 /**
- * The closed, code-defined set of Section types (ADR-0001). Users add, reorder,
+ * The closed, code-defined set of Section types. Users add, reorder,
  * relabel, and fill Sections but can never define new Field structures. Adding a
  * type is a deliberate code change so parseability is answered before it ships.
  */

--- a/src/lib/store/persistence.ts
+++ b/src/lib/store/persistence.ts
@@ -20,7 +20,7 @@ async function persistOpenNow(): Promise<void> {
 }
 
 /**
- * The single debounced whole-document write (ADR-0003). Edits to the open Resume
+ * The single debounced whole-document write. Edits to the open Resume
  * schedule this; it collapses a burst of edits into one IndexedDB put ~500ms
  * after the last change. Leading is off so the first keystroke doesn't write.
  */

--- a/src/lib/store/resume-store.ts
+++ b/src/lib/store/resume-store.ts
@@ -19,13 +19,15 @@ import {
   setOpenResumeGetter,
 } from "./persistence";
 
-type IndexStatus = "idle" | "loading" | "ready";
+type IndexStatus = "idle" | "loading" | "ready" | "error";
 type OpenStatus = "idle" | "loading" | "ready" | "missing";
 
 interface ResumeStoreState {
   /** The lightweight Library list, newest first. Not the full document bodies. */
   index: readonly ResumeIndexEntry[];
   indexStatus: IndexStatus;
+  /** Documents that failed migration (see ResumeIndexResult). Still on disk. */
+  unreadableCount: number;
   /** The single fully-hydrated open document, or null when none is open. */
   open: Resume | null;
   openStatus: OpenStatus;
@@ -63,13 +65,22 @@ function syncIndexEntry(
 export const useResumeStore = create<ResumeStoreState>()((set, get) => ({
   index: [],
   indexStatus: "idle",
+  unreadableCount: 0,
   open: null,
   openStatus: "idle",
 
   async hydrateIndex() {
     set({ indexStatus: "loading" });
-    const index = await listResumeIndex();
-    set({ index, indexStatus: "ready" });
+    try {
+      const result = await listResumeIndex();
+      set({
+        index: result.entries,
+        unreadableCount: result.unreadableCount,
+        indexStatus: "ready",
+      });
+    } catch {
+      set({ indexStatus: "error" });
+    }
   },
 
   async createResume(title, templateId) {
@@ -127,7 +138,9 @@ export const useResumeStore = create<ResumeStoreState>()((set, get) => ({
     if (get().open?.id === id) return;
     await flushOpenResumePersist();
     set({ openStatus: "loading" });
-    const resume = await getResume(id);
+    // A document that fails migration reads as missing rather than leaving the
+    // editor stuck on "loading"; the raw document stays untouched on disk.
+    const resume = await getResume(id).catch(() => undefined);
     if (!resume) {
       set({ open: null, openStatus: "missing" });
       return;


### PR DESCRIPTION
A résumé library could look wiped around a release that changes the document schema: one unreadable document failed the whole library read, and a document whose stored shape didn't match its stamped `schemaVersion` had its fields blanked by the migration ladder and then permanently overwritten on the next edit. This PR closes every loss path found:

- Library reads migrate each document in isolation. An unreadable document (typically one written by a newer app build than a stale tab is running) is counted and left untouched instead of emptying the whole list; a notice explains the résumés are still on the device and a refresh brings them back. The "no résumés yet" empty state is suppressed while unreadable documents exist.
- Migration steps are now bail-safe: a document that doesn't match the shape a step expects is left as-is rather than having header/experience fields blanked or skills entries replaced.
- Before any document is migrated, its raw pre-migration form is snapshotted to a new `backups` object store (`DB_VERSION` 2, additive upgrade only), keyed by `id@vN`, so even a buggy future ladder step is recoverable from the device.
- A storage-level failure renders an explicit error instead of an endless loading skeleton, and opening an unreadable document resolves to the missing state instead of hanging.
- The library list is read via `getAll` instead of the `by-updatedAt` index, so a document missing that key can no longer silently vanish.

Documentation refresh: new `docs/schema-migrations.md` is the canonical reference for the two-version model (IndexedDB `DB_VERSION` vs in-document `schemaVersion`), ladder rules, and backup recovery; the AGENTS.md data section is updated to match; dead ADR-000x references are removed from code comments. Adds a 0.4.0 what's-new highlight for the change.

All resume data stays in IndexedDB on-device; no resume content is sent to any server, API route, or open-next function.

Testing: the guards and quarantine behavior were derived from the read/write paths above; the upgrade flow has not yet been exercised against a browser holding an old-version database, so a manual pass with a seeded old-shape document is worthwhile before release.