### PR TITLE
style: copywriting refinements across the app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Any feature request that adds structural freedom (tables, columns, floating elem
 - No resume content is sent to any server, API route, or open-next function. Confirm this on every PR touching data flow.
 - Document shape is versioned by the in-document `schemaVersion` plus a forward-only, read-time migration ladder (`src/lib/resume/migrations.ts`). Ship the shape change, the `CURRENT_SCHEMA_VERSION` bump, and the ladder rung in the same PR. Full reference: `docs/schema-migrations.md`.
 - The IndexedDB `DB_VERSION` is separate and governs object stores/indexes only. Never bump it for a field-shape change; never reshape documents inside the idb `upgrade` callback.
-- Migration steps must be bail-safe: when a document does not match the expected shape, keep the original data and no-op — never blank or replace what cannot be parsed.
+- Migration steps must be bail-safe: when a document does not match the expected shape, keep the original data and no-op; never blank or replace what cannot be parsed.
 - Raw pre-migration documents are snapshotted to the `backups` object store before migration. Documents that fail migration are surfaced as unreadable in the UI and are never deleted or overwritten.
 
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Customization applies to how the resume looks. It does not extend to layouts tha
 
 ## Features
 
-- Six résumé templates, all sharing one linear document structure — only styling differs
+- Six résumé templates, all sharing one linear document structure; only styling differs
 - Template gallery with search, sort, and live seed-data previews
 - Résumé library with live first-page thumbnails, rename, and delete
 - Print-accurate A4 preview with automatic pagination
@@ -94,9 +94,9 @@ Changes to the export path are gated by `pnpm validate:exports`, which regenerat
 
 ## Contributing
 
-Bug reports and feature requests go through the issue forms — note the scope rules there: presentation is customizable, structure is not, and accounts/server storage are non-goals.
+Bug reports and feature requests go through the issue forms; note the scope rules there: presentation is customizable, structure is not, and accounts/server storage are non-goals.
 
-Commit messages follow Conventional Commits via commitlint and commitizen. Run `pnpm commit` instead of `git commit` to use the prompt. Pre-commit hooks (husky + lint-staged) run lint and format checks before any commit is accepted. PR titles follow the same convention with a fully lowercase subject — they become the squash-merge commit.
+Commit messages follow Conventional Commits via commitlint and commitizen. Run `pnpm commit` instead of `git commit` to use the prompt. Pre-commit hooks (husky + lint-staged) run lint and format checks before any commit is accepted. PR titles follow the same convention with a fully lowercase subject; they become the squash-merge commit.
 
 See `AGENTS.md` for architecture rules and code conventions before submitting a PR.
 

--- a/docs/export-validation.md
+++ b/docs/export-validation.md
@@ -11,12 +11,12 @@ pnpm validate:exports
 ```
 
 `scripts/validate-exports.tsx` regenerates all three exports from the seed résumé and
-extracts their text with real parsers — `unpdf` for the PDF, `jszip` for the `.docx`
+extracts their text with real parsers: `unpdf` for the PDF, `jszip` for the `.docx`
 XML, and the serializer output for `.txt`. It then asserts:
 
-- **Reading order** — `Summary → Experience → Education → Certificates → Skills →
+- **Reading order**: `Summary → Experience → Education → Certificates → Skills →
   Languages` appears in that order in every format.
-- **Field mapping** — name, headline, email, website, each employer, education,
+- **Field mapping**: name, headline, email, website, each employer, education,
   certificate, a representative skill, and a language are all present in the extracted
   text.
 
@@ -36,7 +36,7 @@ land in the right slots. Do this at least once per meaningful export change:
 - [ ] Open the PDF in a viewer and confirm text is **selectable** (not an image) and
       copies out in reading order.
 - [ ] Run the PDF and `.docx` through an open-source résumé parser (e.g. Affinda's free
-      tool, or `pyresparser`) — confirm **name, email, phone, work history, education,
+      tool, or `pyresparser`); confirm **name, email, phone, work history, education,
       and skills** map to the correct fields.
 - [ ] If available, upload to a real ATS sandbox (Greenhouse / Workday test posting) and
       confirm the parsed application is complete and correctly ordered.
@@ -49,15 +49,15 @@ Decisions made to satisfy them:
 
 - **Website is exported as a full `https://` URL**, not a bare domain. Parsers only
   recognize a link when it has a scheme (`https://…`), a `www.` prefix, or a path
-  slash — `johndoe.dev` alone is not detected.
+  slash; `johndoe.dev` alone is not detected.
 - **Contact icons are drawn as vector SVG**, so they never appear in the extracted
   text and can't interfere with field detection.
 - **`letterSpacing` is banned in PDF template styles.** react-pdf positions
-  letter-spaced glyphs individually, so extractors read `J o h n D o e` — word
+  letter-spaced glyphs individually, so extractors read `J o h n D o e`; word
   boundaries are destroyed and fields stop matching. `textTransform: "uppercase"`
   is fine (whole words survive; the gate matches fields case-insensitively). The
-  DOM preview may still use CSS `tracking-*` — it is never text-extracted.
+  DOM preview may still use CSS `tracking-*`; it is never text-extracted.
 - **Location** relies on the parser. OpenResume, for one, only matches US-style
   `City, ST` with a **two-letter** state (regex `[A-Z][a-zA-Z\s]+, [A-Z]{2}`); a full
   "City, Province, Country" won't be detected as a location. This is a parser
-  limitation, not an export defect — entering a 2-letter state code makes it parse.
+  limitation, not an export defect; entering a 2-letter state code makes it parse.

--- a/docs/schema-migrations.md
+++ b/docs/schema-migrations.md
@@ -20,7 +20,7 @@ existing data.
 
 `src/lib/resume/migrations.ts` holds one forward-only step per version, keyed by
 the version it migrates *from* (`LADDER[N]: vN → vN+1`). `runMigrations` walks a
-document up the ladder at **read time, in memory** — the raw document on disk is
+document up the ladder at **read time, in memory**; the raw document on disk is
 untouched until the user's next edit persists the migrated shape.
 
 Rules for every step:
@@ -32,7 +32,7 @@ Rules for every step:
   build), the step must leave the existing data untouched and degrade to a
   no-op. It must never blank fields or replace entries it can't parse. The
   first write after a migration persists the migrated document over the
-  original — a lossy step destroys data permanently at that moment.
+  original; a lossy step destroys data permanently at that moment.
 - **Shipped atomically.** The field-shape change, the `CURRENT_SCHEMA_VERSION`
   bump, and the ladder rung land in the same PR. A shipped gap in the ladder
   makes every older document unreadable.
@@ -46,7 +46,7 @@ writing a downgraded document over a newer one.
 
 Before the repository (`src/lib/db/resume.ts`) migrates a document, it snapshots
 the raw pre-migration form into the `backups` object store, keyed by
-`${resumeId}@v${schemaVersion}` — one snapshot per document per ladder crossing.
+`${resumeId}@v${schemaVersion}`, one snapshot per document per ladder crossing.
 This happens on read, before the migrated shape has any chance of being
 persisted, so a buggy ladder step is always recoverable.
 
@@ -61,7 +61,7 @@ Migration failures are isolated per document and **nothing is ever deleted**:
 - `listResumeIndex` migrates each document in its own try/catch. Unreadable
   documents are counted (`unreadableCount`), not dropped from disk, and one bad
   document cannot empty the whole Library.
-- The Library shows a notice ("saved by a newer version — refresh to update")
+- The Library shows a notice ("saved by a newer version, refresh to update")
   when `unreadableCount > 0`, and the empty state is suppressed so the user is
   never told they have no résumés while unreadable ones exist.
 - Opening an unreadable document resolves to the `missing` state instead of a

--- a/src/components/editor/docx/resume-to-docx.ts
+++ b/src/components/editor/docx/resume-to-docx.ts
@@ -141,7 +141,7 @@ function gridParagraphs(
         children: [
           new TextRun({ text: item.name, bold: true }),
           ...(item.proficiency
-            ? [new TextRun({ text: ` — ${item.proficiency}`, color: MUTED })]
+            ? [new TextRun({ text: ` - ${item.proficiency}`, color: MUTED })]
             : []),
         ],
       }),

--- a/src/components/editor/download-resume.ts
+++ b/src/components/editor/download-resume.ts
@@ -8,7 +8,7 @@ export const EXPORT_FORMATS: ExportFormat[] = ["pdf", "docx", "txt"];
 
 /**
  * Exports `resume` in the chosen format and triggers the browser download.
- * Everything renders client-side — no résumé content leaves the device. The
+ * Everything renders client-side; no résumé content leaves the device. The
  * per-format modules are loaded lazily so the heavy PDF/docx libraries stay
  * out of the main bundle.
  */

--- a/src/components/editor/editor-resume-not-found.tsx
+++ b/src/components/editor/editor-resume-not-found.tsx
@@ -8,7 +8,7 @@ import { useResumeStore } from "@/lib/store";
 
 /**
  * The editor's missing-résumé state. When the route id doesn't resolve, the
- * library index is searched for the closest id within edit tolerance — a
+ * library index is searched for the closest id within edit tolerance, a
  * "did you mean" for mangled or truncated links. Deleted résumés (no near id)
  * fall back to the plain message.
  */

--- a/src/components/editor/editor-resume-preview.tsx
+++ b/src/components/editor/editor-resume-preview.tsx
@@ -74,7 +74,7 @@ function PreviewEnter(props: { children: ReactNode }) {
 
 /**
  * ResumeDocument paints unpaginated on mount, then reflows once its measurement
- * effects fire — a visible flicker if it happens mid-entrance. A blank sheet
+ * effects fire, a visible flicker if it happens mid-entrance. A blank sheet
  * (matching ResumePage's paper style) rides the slide instead, and the real
  * content fades in over it only after the entrance has settled.
  */

--- a/src/components/editor/editor-sections.ts
+++ b/src/components/editor/editor-sections.ts
@@ -30,7 +30,7 @@ export interface EditorSectionDescriptor {
  * The editor's section navigation, in reading order. Personal Details maps to the
  * privileged `Header` (always first, never hidden); the rest map to reorderable
  * sections. This is the sidebar's view contract, decoupled from the persisted
- * `Resume` model — an adapter will project real sections onto these descriptors.
+ * `Resume` model; an adapter will project real sections onto these descriptors.
  */
 export const EDITOR_SECTIONS: EditorSectionDescriptor[] = [
   {

--- a/src/components/editor/editor-sections/ed-section-list.tsx
+++ b/src/components/editor/editor-sections/ed-section-list.tsx
@@ -39,7 +39,7 @@ export function EditorSectionList() {
     );
   }
 
-  // Keyed by the open résumé so a load/switch remounts the forms — this is how
+  // Keyed by the open résumé so a load/switch remounts the forms; this is how
   // the uncontrolled rich-text editors pick up the loaded document.
   return (
     <Accordion key={open.id} multiple className="border-none">

--- a/src/components/editor/editor-sections/resume-form-adapter.ts
+++ b/src/components/editor/editor-sections/resume-form-adapter.ts
@@ -99,7 +99,7 @@ function sectionOfType(
 /**
  * Keep entry ids stable across form-driven rebuilds by reusing the existing
  * entry's id at the same index. Regenerating ids on every keystroke invalidates
- * everything keyed by them downstream — most visibly the preview's measured
+ * everything keyed by them downstream, most visibly the preview's measured
  * block heights, which collapsed pagination to a single page.
  */
 function entryId(section: Section, index: number): string {

--- a/src/components/editor/pdf/awal-pdf-document.tsx
+++ b/src/components/editor/pdf/awal-pdf-document.tsx
@@ -175,7 +175,7 @@ function PdfBlock(props: { block: ResumeBlock }) {
 /**
  * The "Awal" résumé as a react-pdf document. It renders the same linear
  * `buildResumeBlocks` sequence the on-screen preview uses, so PDF content,
- * ordering, sorting, and empty-section gating stay identical — and the text is
+ * ordering, sorting, and empty-section gating stay identical, and the text is
  * real (extractable), never rasterized. react-pdf handles page breaks; a
  * heading's `minPresenceAhead` keeps it from being orphaned at a page foot.
  */

--- a/src/components/editor/pdf/download-resume-pdf.tsx
+++ b/src/components/editor/pdf/download-resume-pdf.tsx
@@ -7,7 +7,7 @@ import { TEMPLATE_PDF_DOCUMENTS } from "./template-pdf-document";
 
 /**
  * Generates the résumé's template as a PDF entirely in the browser and triggers
- * a download as `<fileName>.pdf`. No résumé content leaves the device —
+ * a download as `<fileName>.pdf`. No résumé content leaves the device;
  * react-pdf renders to a Blob client-side. Loaded lazily by the download button
  * so react-pdf stays out of the main bundle.
  */

--- a/src/components/editor/pdf/pdf-fonts.ts
+++ b/src/components/editor/pdf/pdf-fonts.ts
@@ -5,7 +5,7 @@ let registered = false;
 /**
  * Registers the font families the PDF templates use, matching the on-screen
  * preview: Inter (sans, all templates) and Lora (serif accents in Ketat/Luasa).
- * Idempotent — safe to call before every render. Hyphenation is disabled so
+ * Idempotent, safe to call before every render. Hyphenation is disabled so
  * react-pdf never injects soft hyphens that would corrupt text extraction
  * (pdftotext / ATS parsers must see whole words in reading order).
  */

--- a/src/components/editor/pdf/pdf-rich-text.tsx
+++ b/src/components/editor/pdf/pdf-rich-text.tsx
@@ -64,7 +64,7 @@ export function PdfRichText(props: PdfRichTextProps) {
               {block.items.map((runs, itemIndex) => (
                 // biome-ignore lint/suspicious/noArrayIndexKey: see renderer note above
                 <View key={itemIndex} style={styles.listItem}>
-                  {/* Only "•" — the bundled font subsets lack fancier list
+                  {/* Only "•"; the bundled font subsets lack fancier list
                       glyphs (e.g. U+25AA), which render as garbage. */}
                   <Text style={styles.bullet}>
                     {block.ordered ? `${itemIndex + 1}.` : "•"}

--- a/src/components/editor/resume-blocks.ts
+++ b/src/components/editor/resume-blocks.ts
@@ -84,7 +84,7 @@ function hasLanguage(item: LanguageItemView): boolean {
 }
 
 /**
- * Builds the linear block sequence, omitting any section — heading included —
+ * Builds the linear block sequence, omitting any section (heading included)
  * that has no meaningful content, so a sparse résumé shows only what the user
  * filled in. Empty repeated entries are dropped before a section is weighed.
  */

--- a/src/components/editor/resume-document.tsx
+++ b/src/components/editor/resume-document.tsx
@@ -21,11 +21,11 @@ const PAGE_GAP_PX = 24;
  * Renders a résumé as exact A4 pages, reflowing content across pages as it grows.
  * Pagination is presentation-only: blocks are measured off-screen at the printable
  * width, then packed into page-height buckets without reordering (linear reading
- * order — and therefore parse/export order — is preserved).
+ * order, and therefore parse/export order, is preserved).
  *
  * The rendered stack is scaled to fit the available width (never upscaled past
  * 100%) so the fixed A4 page shrinks as the surrounding panel narrows. Scaling is
- * a CSS transform on the whole stack — it changes nothing about text order.
+ * a CSS transform on the whole stack; it changes nothing about text order.
  */
 export function ResumeDocument(props: ResumeDocumentProps) {
   const blocks = useMemo(() => buildResumeBlocks(props.resume), [props.resume]);
@@ -35,7 +35,7 @@ export function ResumeDocument(props: ResumeDocumentProps) {
   const [heights, setHeights] = useState<Record<string, number>>({});
   const [availableWidth, setAvailableWidth] = useState(0);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: `blocks` and `BlockView` are deliberate re-run triggers — the ResizeObserver only fires when the layer's total size changes, which misses block-id swaps or template restyles that keep the layout size (stale height keys collapse pagination).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `blocks` and `BlockView` are deliberate re-run triggers; the ResizeObserver only fires when the layer's total size changes, which misses block-id swaps or template restyles that keep the layout size (stale height keys collapse pagination).
   useEffect(() => {
     const layer = measureRef.current;
     if (!layer) return;

--- a/src/components/editor/resume-geometry.ts
+++ b/src/components/editor/resume-geometry.ts
@@ -19,8 +19,8 @@ export const A4 = {
   marginPx: mmToPx(14),
 } as const;
 
-/** Printable width of one page — the exact width content is measured at. */
+/** Printable width of one page; the exact width content is measured at. */
 export const CONTENT_WIDTH_PX = A4.widthPx - A4.marginPx * 2;
 
-/** Printable height of one page — the per-page height budget for pagination. */
+/** Printable height of one page; the per-page height budget for pagination. */
 export const CONTENT_HEIGHT_PX = A4.heightPx - A4.marginPx * 2;

--- a/src/components/editor/resume-page.tsx
+++ b/src/components/editor/resume-page.tsx
@@ -22,7 +22,7 @@ const PAPER_STYLE: CSSProperties = {
 
 /**
  * A single, exact A4 page frame. Fixed width and height with `overflow-hidden`
- * so content never spills past the page bounds — the paginator is responsible
+ * so content never spills past the page bounds; the paginator is responsible
  * for placing only what fits (see `paginate`).
  */
 export function ResumePage(props: ResumePageProps) {

--- a/src/components/editor/resume-thumbnail.tsx
+++ b/src/components/editor/resume-thumbnail.tsx
@@ -16,8 +16,8 @@ interface ResumeThumbnailProps {
 /**
  * A miniature, non-interactive render of a résumé's first page, scaled with a
  * CSS transform to fill the container width. Unlike ResumeDocument there is no
- * measurement or pagination pass — blocks flow linearly and the page frame's
- * overflow clipping cuts everything past page one — so it is cheap enough to
+ * measurement or pagination pass (blocks flow linearly and the page frame's
+ * overflow clipping cuts everything past page one) so it is cheap enough to
  * render per card in a grid.
  */
 export function ResumeThumbnail(props: ResumeThumbnailProps) {

--- a/src/components/editor/resume-to-text.ts
+++ b/src/components/editor/resume-to-text.ts
@@ -7,13 +7,13 @@ function dateRange(start: string, end: string): string {
   return `${start} - ${end}`;
 }
 
-/** "Role — Company — Dates", dropping whichever parts are absent. */
+/** "Role - Company - Dates", dropping whichever parts are absent. */
 function metaLine(...parts: string[]): string {
-  return parts.filter(Boolean).join(" — ");
+  return parts.filter(Boolean).join(" - ");
 }
 
 /**
- * Serializes the résumé to plain text in linear reading order — the ATS-safest
+ * Serializes the résumé to plain text in linear reading order, the ATS-safest
  * format. Reuses `buildResumeBlocks` so the content, ordering, sorting, and
  * empty-section gating match the preview and the PDF exactly.
  */

--- a/src/components/editor/rich-content.ts
+++ b/src/components/editor/rich-content.ts
@@ -2,8 +2,8 @@ import type { JSONContent } from "@tiptap/core";
 
 /**
  * A run of inline text carrying the restricted schema's marks (bold, italic,
- * link). This is the export-neutral shape every renderer consumes — the DOM
- * preview, the PDF template, and the text/docx serializers — so marks survive
+ * link). This is the export-neutral shape every renderer consumes (the DOM
+ * preview, the PDF template, and the text/docx serializers) so marks survive
  * into every output instead of collapsing to plain strings.
  */
 export interface InlineRun {
@@ -121,8 +121,8 @@ export function richBlocksToMarkdown(blocks: RichBlock[]): string {
 }
 
 /**
- * Flattens rich blocks to plain-text lines — one per paragraph, and each list
- * item prefixed with "- " — for the .txt export. Marks are dropped (plain text
+ * Flattens rich blocks to plain-text lines (one per paragraph, and each list
+ * item prefixed with "- ") for the .txt export. Marks are dropped (plain text
  * carries no formatting); reading order is preserved.
  */
 export function richBlocksToText(blocks: RichBlock[]): string[] {

--- a/src/components/editor/rich-text/rich-text-editor.tsx
+++ b/src/components/editor/rich-text/rich-text-editor.tsx
@@ -21,7 +21,7 @@ interface RichTextEditorProps {
 /**
  * Restricted rich-text control. Uncontrolled after mount: `value` seeds the
  * initial document once, then edits flow out through `onChange`. The editor's
- * live document is never re-synced from `value` (that would reset the caret) —
+ * live document is never re-synced from `value` (that would reset the caret);
  * to load a different document, remount with a fresh `key`.
  */
 export function RichTextEditor(props: RichTextEditorProps) {

--- a/src/components/editor/rich-text/rich-text-extensions.ts
+++ b/src/components/editor/rich-text/rich-text-extensions.ts
@@ -15,7 +15,7 @@ import type { RichTextFeature } from "@/lib/resume/schema-registry";
  * Builds the restricted TipTap schema for a richtext Field. Document/Paragraph/
  * Text are always present; every other node/mark is opt-in via `features`, so
  * disallowed structure (headings, tables, images) can neither be typed nor
- * survive a paste — the schema simply has no node to represent it.
+ * survive a paste; the schema simply has no node to represent it.
  */
 export function buildRichTextExtensions(
   features: readonly RichTextFeature[],

--- a/src/components/editor/templates/ketat/ketat-block-view.tsx
+++ b/src/components/editor/templates/ketat/ketat-block-view.tsx
@@ -12,7 +12,7 @@ interface KetatBlockViewProps {
   block: ResumeBlock;
 }
 
-/** "Ketat" — a compact serif classic with centered, ruled section headings. */
+/** "Ketat": a compact serif classic with centered, ruled section headings. */
 export function KetatBlockView(props: KetatBlockViewProps) {
   const { block } = props;
   switch (block.kind) {

--- a/src/components/editor/templates/ketik/ketik-block-view.tsx
+++ b/src/components/editor/templates/ketik/ketik-block-view.tsx
@@ -12,7 +12,7 @@ interface KetikBlockViewProps {
   block: ResumeBlock;
 }
 
-/** "Ketik" — typewriter-flavored: monospace name/headings/dates over a sans body. */
+/** "Ketik": typewriter-flavored: monospace name/headings/dates over a sans body. */
 export function KetikBlockView(props: KetikBlockViewProps) {
   const { block } = props;
   switch (block.kind) {

--- a/src/components/editor/templates/klasik/klasik-block-view.tsx
+++ b/src/components/editor/templates/klasik/klasik-block-view.tsx
@@ -12,7 +12,7 @@ interface KlasikBlockViewProps {
   block: ResumeBlock;
 }
 
-/** "Klasik" — a traditional all-serif CV with a centered header and quiet headings. */
+/** "Klasik": a traditional all-serif CV with a centered header and quiet headings. */
 export function KlasikBlockView(props: KlasikBlockViewProps) {
   const { block } = props;
   switch (block.kind) {

--- a/src/components/editor/templates/luasa/luasa-block-view.tsx
+++ b/src/components/editor/templates/luasa/luasa-block-view.tsx
@@ -12,7 +12,7 @@ interface LuasaBlockViewProps {
   block: ResumeBlock;
 }
 
-/** "Luasa" — an airy minimalist layout with slim accent bars and letterspaced headings. */
+/** "Luasa": an airy minimalist layout with slim accent bars and letterspaced headings. */
 export function LuasaBlockView(props: LuasaBlockViewProps) {
   const { block } = props;
   switch (block.kind) {

--- a/src/components/editor/templates/tebal/tebal-block-view.tsx
+++ b/src/components/editor/templates/tebal/tebal-block-view.tsx
@@ -12,7 +12,7 @@ interface TebalBlockViewProps {
   block: ResumeBlock;
 }
 
-/** "Tebal" — a bold modern statement with heavy uppercase headings over thick rules. */
+/** "Tebal": a bold modern statement with heavy uppercase headings over thick rules. */
 export function TebalBlockView(props: TebalBlockViewProps) {
   const { block } = props;
   switch (block.kind) {

--- a/src/components/editor/templates/template-block-view.ts
+++ b/src/components/editor/templates/template-block-view.ts
@@ -12,8 +12,8 @@ export type BlockViewComponent = ComponentType<{ block: ResumeBlock }>;
 
 /**
  * Presentation-layer registry: which block renderer draws each template. All
- * templates consume the same linear `ResumeBlock` sequence — only styling
- * differs — so pagination, exports, and parse order stay identical.
+ * templates consume the same linear `ResumeBlock` sequence (only styling
+ * differs) so pagination, exports, and parse order stay identical.
  */
 export const TEMPLATE_BLOCK_VIEWS: Record<TemplateId, BlockViewComponent> = {
   awal: ResumeBlockView,

--- a/src/components/landing/landing-closure.tsx
+++ b/src/components/landing/landing-closure.tsx
@@ -24,9 +24,9 @@ export function LandingClosure() {
           Lanjut. Resume. Résumé.
         </h2>
         <p className="mx-auto mt-3 max-w-2xl text-sm text-muted-foreground text-balance sm:text-base">
-          The name is the pitch — lanjut means continue. Pick a template or
-          start from a blank page; either way it&apos;s free, open source, and
-          your résumé never leaves your browser.
+          The name is the pitch: lanjut means continue. Pick a template or start
+          from a blank page; either way it&apos;s free, open source, and your
+          résumé never leaves your browser.
         </p>
         <div className="mx-auto mt-8 flex w-full max-w-xs flex-col justify-center gap-3 sm:w-auto sm:max-w-none sm:flex-row sm:gap-4">
           <Button

--- a/src/components/landing/landing-footer.tsx
+++ b/src/components/landing/landing-footer.tsx
@@ -19,7 +19,7 @@ export function LandingFooter() {
             <span className="font-heading text-sm font-semibold">Lanjut</span>
           </div>
           <p className="text-xs text-muted-foreground">
-            Local-first — your résumé never leaves your browser.
+            Local-first: your résumé never leaves your browser.
           </p>
         </div>
 

--- a/src/components/landing/landing-how-it-works.tsx
+++ b/src/components/landing/landing-how-it-works.tsx
@@ -15,13 +15,13 @@ const STEPS: Step[] = [
     kicker: "01 · Template",
     title: "Pick a template",
     description:
-      "Start from a template you like. Each one only changes typography, spacing, and accents — the structure underneath stays ATS-safe.",
+      "Start from a template you like. Each one only changes typography, spacing, and accents; the structure underneath stays ATS-safe.",
   },
   {
     kicker: "02 · Content",
     title: "Type it once",
     description:
-      "Fill structured sections — experience, education, skills. Every change lands in your browser's storage and nowhere else.",
+      "Fill structured sections: experience, education, skills. Every change lands in your browser's storage and nowhere else.",
   },
   {
     kicker: "03 · Export",
@@ -237,7 +237,7 @@ function ArtifactParserOutput() {
           EXPERIENCE
         </motion.p>
         <motion.p variants={terminalLineVariants} className="text-stone-200">
-          Senior Frontend Engineer — Acme Corp
+          Senior Frontend Engineer, Acme Corp
         </motion.p>
         <motion.p variants={terminalLineVariants} className="text-stone-400">
           Mar 2022 – Present

--- a/src/components/landing/landing-preview-editor.tsx
+++ b/src/components/landing/landing-preview-editor.tsx
@@ -19,7 +19,7 @@ export function LandingPreviewEditor() {
         </h2>
         <p className="mx-auto mt-3 max-w-2xl text-sm text-muted-foreground text-balance sm:text-base">
           Build your ATS-safe résumé in a focused editor. No AI slop, no
-          overwhelming features — straight to the point, without wasting your
+          overwhelming features. Straight to the point, without wasting your
           time.
         </p>
       </motion.div>

--- a/src/components/platform/platform-bug-report-dialog.tsx
+++ b/src/components/platform/platform-bug-report-dialog.tsx
@@ -28,7 +28,7 @@ export function PlatformBugReportDialog() {
         <ResponsiveDialogHeader>
           <ResponsiveDialogTitle>Report a bug</ResponsiveDialogTitle>
           <ResponsiveDialogDescription className="text-balance">
-            This opens a prefilled GitHub issue for you to review and submit — a
+            This opens a prefilled GitHub issue for you to review and submit; a
             GitHub account is required, and your browser details are filled in
             for you.
           </ResponsiveDialogDescription>

--- a/src/components/platform/platform-bug-report-form.tsx
+++ b/src/components/platform/platform-bug-report-form.tsx
@@ -110,13 +110,13 @@ export function PlatformBugReportForm(props: PlatformBugReportFormProps) {
               <RichTextEditor
                 id="bug-report-steps"
                 features={PROSE_FEATURES}
-                placeholder="1. Create a résumé — a numbered list works great here"
+                placeholder="1. Create a résumé (a numbered list works great here)"
                 value={field.value}
                 onChange={field.onChange}
                 onBlur={field.onBlur}
               />
               <FieldDescription>
-                Optional here — you can also fill this in on GitHub.
+                Optional here; you can also fill this in on GitHub.
               </FieldDescription>
             </Field>
           )}

--- a/src/components/platform/platform-feature-request-dialog.tsx
+++ b/src/components/platform/platform-feature-request-dialog.tsx
@@ -28,7 +28,7 @@ export function PlatformFeatureRequestDialog() {
         <ResponsiveDialogHeader>
           <ResponsiveDialogTitle>Request a feature</ResponsiveDialogTitle>
           <ResponsiveDialogDescription className="text-balance">
-            This opens a prefilled GitHub issue for you to review and submit — a
+            This opens a prefilled GitHub issue for you to review and submit; a
             GitHub account is required. Note that résumé structure (tables,
             columns, images) is out of scope by design; presentation is fair
             game.

--- a/src/components/platform/platform-library-tour.tsx
+++ b/src/components/platform/platform-library-tour.tsx
@@ -7,7 +7,7 @@ import { TourAutostart } from "../tour/tour-autostart";
 /**
  * Holds the library tour back while the create dialog is deep-linked open
  * (`/platform?create=true`): the user arrived with an explicit goal, so the
- * dialog wins. The tour is deferred, not skipped — mounting TourAutostart on
+ * dialog wins. The tour is deferred, not skipped; mounting TourAutostart on
  * close starts it if the user cancels, and saving routes to the editor where
  * the editor tour takes over.
  */

--- a/src/components/platform/platform-paper-frame.tsx
+++ b/src/components/platform/platform-paper-frame.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 /**
  * The card "desk": a dotted work surface with an A4 sheet resting on it. The
  * sheet is pinned near the top and clipped by the frame, so the paper visibly
- * runs past the bottom edge — the page continues — and lifts on card hover.
+ * runs past the bottom edge (the page continues) and lifts on card hover.
  */
 export function PlatformPaperFrame(props: { children: ReactNode }) {
   return (

--- a/src/components/platform/platform-resume-grid/platform-resume-grid-error.tsx
+++ b/src/components/platform/platform-resume-grid/platform-resume-grid-error.tsx
@@ -7,7 +7,7 @@ export function PlatformResumeGridError() {
       <TriangleAlert />
       <AlertTitle>Couldn&rsquo;t load your résumés</AlertTitle>
       <AlertDescription>
-        Nothing was deleted — the library just failed to load from this
+        Nothing was deleted. The library just failed to load from this
         browser&rsquo;s storage. Refresh the page to try again.
       </AlertDescription>
     </Alert>

--- a/src/components/platform/platform-resume-unreadable-notice.tsx
+++ b/src/components/platform/platform-resume-unreadable-notice.tsx
@@ -18,7 +18,7 @@ export function PlatformResumeUnreadableNotice() {
       <AlertTitle>Some résumés need a newer version of the app</AlertTitle>
       <AlertDescription>
         {subject} saved by a newer version of Lanjut than the one this tab is
-        running. They are still stored safely on this device — refresh the page
+        running. They are still stored safely on this device. Refresh the page
         to update the app and see them again.
       </AlertDescription>
     </Alert>

--- a/src/components/platform/platform-template-radio-group.tsx
+++ b/src/components/platform/platform-template-radio-group.tsx
@@ -19,7 +19,7 @@ interface PlatformTemplateRadioGroupProps {
 /**
  * Template chooser: a radio list of template names beside one live seed-data
  * preview of the selected template. A single legible preview beats a tile per
- * template — at dialog size six mini-renders are unreadable.
+ * template; at dialog size six mini-renders are unreadable.
  */
 export function PlatformTemplateRadioGroup(
   props: PlatformTemplateRadioGroupProps,

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 function Input(props: React.ComponentProps<"input">) {
   // A controlled input (one with `onChange`) must never receive an `undefined`
   // value, or base-ui warns when it later becomes a string (uncontrolled →
-  // controlled) — e.g. react-hook-form's `values` before its first sync.
+  // controlled), e.g. react-hook-form's `values` before its first sync.
   const value = props.onChange && props.value === undefined ? "" : props.value;
   return (
     <InputPrimitive

--- a/src/hooks/use-editor-resume.ts
+++ b/src/hooks/use-editor-resume.ts
@@ -24,7 +24,7 @@ export function useEditorResume() {
     if (id) void openResume(id);
   }, [id, openResume]);
 
-  // On unmount, only flush pending writes — never clear the open document.
+  // On unmount, only flush pending writes; never clear the open document.
   // Clearing it here races with the reopen effect (and React StrictMode's
   // remount): the async clear can land after `openResume` has already skipped an
   // unchanged id, stranding the store empty and the preview stuck loading.

--- a/src/hooks/use-hydrate-resume-library.ts
+++ b/src/hooks/use-hydrate-resume-library.ts
@@ -7,7 +7,7 @@ let started = false;
 
 /**
  * Load the Library index into the store once per app session. Safe to call from
- * several mounted consumers at once — a module-level guard collapses them to a
+ * several mounted consumers at once; a module-level guard collapses them to a
  * single IndexedDB read. Synchronizing with IndexedDB is a valid effect.
  */
 export function useHydrateResumeLibrary() {

--- a/src/hooks/use-resume-document.ts
+++ b/src/hooks/use-resume-document.ts
@@ -13,7 +13,7 @@ import type { Resume } from "@/lib/resume";
 export function useResumeDocument(id: string, updatedAt: string) {
   const [resume, setResume] = useState<Resume | null>(null);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: `updatedAt` is a deliberate re-fetch trigger — the id alone doesn't change when the document is edited.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `updatedAt` is a deliberate re-fetch trigger; the id alone doesn't change when the document is edited.
   useEffect(() => {
     let cancelled = false;
     void getResume(id)

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -6,7 +6,7 @@ export interface ChangelogEntry {
 
 /**
  * User-facing release notes shown in the "What's new" sheet, newest first.
- * Hand-written in plain language — not generated from commits. Add an entry
+ * Hand-written in plain language, not generated from commits. Add an entry
  * here as part of each release PR; skip versions with nothing user-visible.
  */
 export const CHANGELOG: ChangelogEntry[] = [
@@ -17,7 +17,7 @@ export const CHANGELOG: ChangelogEntry[] = [
       "Your saved résumés are safer during app updates: a backup copy is kept on your device before any data-format upgrade, and a résumé the app can't read yet is flagged with a notice instead of disappearing.",
       "A guided tour now walks you through the dashboard, the templates, and the editor on your first visit.",
       "The landing page walks through how Lanjut works, ending with a one-click way to start a new résumé.",
-      "Found a bug or missing a feature? Report it from the sidebar — we prefill the GitHub issue for you.",
+      "Found a bug or missing a feature? Report it from the sidebar; we prefill the GitHub issue for you.",
       "On your phone, dialogs now open as drawers that are easier to reach and swipe away.",
     ],
   },
@@ -37,7 +37,7 @@ export const CHANGELOG: ChangelogEntry[] = [
     highlights: [
       "Export your résumé as PDF, DOCX, or plain text.",
       "Bold, italics, links, and lists now show up in the live preview.",
-      "The editor covers the full section set — summary, experience, education, skills, certifications, and languages.",
+      "The editor covers the full section set: summary, experience, education, skills, certifications, and languages.",
     ],
   },
 ];

--- a/src/lib/db/resume.ts
+++ b/src/lib/db/resume.ts
@@ -6,7 +6,7 @@ import { getDb, META_KEYS } from "./schema";
 export interface ResumeIndexResult {
   entries: readonly ResumeIndexEntry[];
   /**
-   * Documents that failed migration — typically written by a newer app build
+   * Documents that failed migration, typically written by a newer app build
    * than the one currently running. They stay untouched in the store.
    */
   unreadableCount: number;
@@ -65,7 +65,7 @@ export async function deleteResume(id: string): Promise<void> {
 
 /**
  * The lightweight Library projection (id, title, updatedAt), newest first. Reads
- * full bodies to migrate them, but returns only index fields — the full body of a
+ * full bodies to migrate them, but returns only index fields; the full body of a
  * non-open Resume is not kept in memory. Migration failures are isolated per
  * document and counted, never deleted: one unreadable document must not make the
  * whole Library look empty.

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -4,7 +4,7 @@ import type { Resume } from "@/lib/resume";
 const DB_NAME = "lanjut";
 
 /**
- * IndexedDB structural version. Governs object stores and indexes ONLY — document
+ * IndexedDB structural version. Governs object stores and indexes ONLY; document
  * field-shape changes are versioned separately by the in-document schemaVersion
  * and its migration ladder (see docs/schema-migrations.md). Bump this only when
  * adding/changing a store or index, never for a field-shape change.
@@ -20,7 +20,7 @@ export const META_KEYS = {
 
 /**
  * A raw pre-migration snapshot of a résumé document, written before the first
- * read that steps it up the ladder — so a buggy or lossy migration is always
+ * read that steps it up the ladder, so a buggy or lossy migration is always
  * recoverable. Keyed by `${resumeId}@v${schemaVersion}`: one snapshot per
  * document per ladder crossing.
  */
@@ -53,7 +53,7 @@ export interface LanjutDB extends DBSchema {
 let dbPromise: Promise<IDBPDatabase<LanjutDB>> | null = null;
 
 /**
- * Lazily open the singleton database. Guarded against server rendering — this is
+ * Lazily open the singleton database. Guarded against server rendering; this is
  * the only persistence tier and it never leaves the browser.
  */
 export function getDb(): Promise<IDBPDatabase<LanjutDB>> {

--- a/src/lib/github-issue.ts
+++ b/src/lib/github-issue.ts
@@ -36,7 +36,7 @@ export function issueTitle(prefix: string, summaryLine: string): string {
 
 /**
  * GitHub prefills issue-form fields from query params keyed by the field ids
- * in the matching .github/ISSUE_TEMPLATE/*.yml — keep the param names in sync
+ * in the matching .github/ISSUE_TEMPLATE/*.yml; keep the param names in sync
  * with those files. Body fields are markdown strings; GitHub renders the
  * textareas as GFM.
  */

--- a/src/lib/levenshtein.ts
+++ b/src/lib/levenshtein.ts
@@ -1,6 +1,6 @@
 /**
  * The minimal number of single-character edits (insert, delete, substitute) to
- * align `query` against the best-matching substring of `text` — a Levenshtein
+ * align `query` against the best-matching substring of `text`, a Levenshtein
  * distance DP whose first row is left at zero, so a match may begin at any
  * offset in `text`. A return of 0 means `query` occurs verbatim in `text`.
  *

--- a/src/lib/resume/factory.ts
+++ b/src/lib/resume/factory.ts
@@ -60,7 +60,7 @@ export function createEmptyHeader(): Header {
 }
 
 /**
- * A blank structural document — Header plus one empty Entry per core Section.
+ * A blank structural document: Header plus one empty Entry per core Section.
  * The primary create path seeds the Seed fixture instead (see seed.ts); this is
  * the deferred "blank resume" option.
  */

--- a/src/lib/resume/migrations.ts
+++ b/src/lib/resume/migrations.ts
@@ -7,10 +7,10 @@ type ResumeDoc = Record<string, unknown>;
 
 /**
  * A forward-only migration from version N to N+1, keyed by N. Each step is a pure
- * JSON→JSON function over a plain document, testable with fixtures — never runs
+ * JSON→JSON function over a plain document, testable with fixtures; never runs
  * inside idb's onupgradeneeded (that governs store structure only; see
  * docs/schema-migrations.md). Steps must bail out (keep the original data) when a
- * document does not match the shape they expect — a mis-stamped schemaVersion
+ * document does not match the shape they expect: a mis-stamped schemaVersion
  * must degrade to a no-op, never to blanked or replaced fields.
  */
 type Migration = (doc: ResumeDoc) => ResumeDoc;
@@ -143,7 +143,7 @@ const migrateV2toV3: Migration = (doc) => {
       | { fields?: Record<string, unknown> }
       | undefined;
     // Entries without a `body` field are not the v2 single-body shape (likely a
-    // mis-stamped doc already at v3+) — replacing them would destroy real skills.
+    // mis-stamped doc already at v3+); replacing them would destroy real skills.
     if (first?.fields && !("body" in first.fields)) continue;
     const body = (first?.fields?.body as { value?: unknown } | undefined)
       ?.value;

--- a/src/lib/resume/schema-registry.ts
+++ b/src/lib/resume/schema-registry.ts
@@ -1,7 +1,7 @@
 import type { FieldKey, SectionType } from "./types";
 
 /**
- * The allowed TipTap features for a richtext Field — the Restricted schema
+ * The allowed TipTap features for a richtext Field: the Restricted schema
  * allowlist. Base document/paragraph/text are always implied. Both typing and
  * paste are filtered through this list so disallowed structure (tables, headings,
  * images) cannot be represented or pasted in.
@@ -49,7 +49,7 @@ export const PROSE_FEATURES: RichTextFeature[] = [
 
 /**
  * The privileged Header's Field shape. Identity and contact information only.
- * Not part of the Section registry — the Header is not a Section.
+ * Not part of the Section registry; the Header is not a Section.
  */
 export const HEADER_SCHEMA: FieldSchema[] = [
   {

--- a/src/lib/resume/search.ts
+++ b/src/lib/resume/search.ts
@@ -6,7 +6,7 @@ import type { ResumeIndexEntry } from "./types";
 const ERROR_TOLERANCE = 0.4;
 
 /**
- * The closest saved résumé to a requested id that no longer resolves — the
+ * The closest saved résumé to a requested id that no longer resolves, the
  * "did you mean" candidate for mangled or truncated editor links. Distance is
  * measured on ids (the only signal a broken URL carries); anything beyond
  * tolerance returns undefined, so a genuinely deleted résumé suggests nothing.

--- a/src/lib/resume/seed.ts
+++ b/src/lib/resume/seed.ts
@@ -41,7 +41,7 @@ function prose(...blocks: JSONContent[]): Field {
 /**
  * The single code-defined sample Resume. Every newly created Resume is cloned
  * from this fixture, and the export Parser gate reuses it as its test document.
- * The stable ids here are placeholders — cloneResumeAsNew reassigns fresh ids.
+ * The stable ids here are placeholders; cloneResumeAsNew reassigns fresh ids.
  * It doubles as the "Awal" template showcase, so it exercises every section plus
  * bold / italic / link marks.
  */

--- a/src/lib/resume/types.ts
+++ b/src/lib/resume/types.ts
@@ -46,7 +46,7 @@ export type SectionType =
 
 /**
  * A typed, reorderable unit below the Header. `title` is presentation/label data
- * only — relabeling never changes the Section's parse shape or Field schema.
+ * only; relabeling never changes the Section's parse shape or Field schema.
  */
 export interface Section {
   id: string;
@@ -70,7 +70,7 @@ export interface Header {
 export interface Resume {
   id: string;
   schemaVersion: number;
-  /** The résumé's name, e.g. "Frontend Engineer — Acme". Per-job tailoring is core. */
+  /** The résumé's name, e.g. "Frontend Engineer, Acme". Per-job tailoring is core. */
   title: string;
   /**
    * Presentation-layer template rendering this document (e.g. "awal"). Kept a

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -2,7 +2,7 @@
 export const SITE = {
   name: "Lanjut",
   url: "https://lanjut.rimzzlabs.com",
-  title: "Lanjut — Free, local-first ATS résumé builder",
+  title: "Lanjut: Free, local-first ATS résumé builder",
   description:
-    "Lanjut is a free, open-source résumé builder that stays entirely in your browser — no account, nothing uploaded. Style it freely; every export is structured to sail through applicant tracking systems.",
+    "Lanjut is a free, open-source résumé builder that stays entirely in your browser; no account, nothing uploaded. Style it freely; every export is structured to sail through applicant tracking systems.",
 } as const;

--- a/src/lib/store/persistence.ts
+++ b/src/lib/store/persistence.ts
@@ -4,7 +4,7 @@ import type { Resume } from "@/lib/resume";
 
 /**
  * The persist target is read lazily so this module and the store don't import
- * each other circularly — the store registers its getter at init.
+ * each other circularly; the store registers its getter at init.
  */
 type OpenResumeGetter = () => Resume | null;
 
@@ -36,7 +36,7 @@ export function scheduleOpenResumePersist(): void {
 }
 
 /**
- * Flush a pending write immediately — called on resume-switch and page-hide so
+ * Flush a pending write immediately; called on resume-switch and page-hide so
  * the worst-case loss window stays bounded to edits made after the last flush.
  */
 export async function flushOpenResumePersist(): Promise<void> {
@@ -47,7 +47,7 @@ export async function flushOpenResumePersist(): Promise<void> {
 
 /**
  * Register the page-lifecycle flush safety net. Returns a cleanup. Intended to be
- * called once from a client provider effect — synchronizing with the browser's
+ * called once from a client provider effect; synchronizing with the browser's
  * lifecycle is a legitimate external-system effect.
  */
 export function registerResumeFlushListeners(): () => void {

--- a/src/lib/store/sidebar-store.ts
+++ b/src/lib/store/sidebar-store.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
-// Must match MOBILE_BREAKPOINT in hooks/use-mobile.ts — below it the sidebar
+// Must match MOBILE_BREAKPOINT in hooks/use-mobile.ts; below it the sidebar
 // renders as a sheet controlled via `mobileControl`, not `open`.
 const MOBILE_QUERY = "(max-width: 767px)";
 

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -1,6 +1,6 @@
 /**
  * The catalog of résumé templates shown on the Browse Templates page. Presentation
- * metadata only — the rendering for each template lives under
+ * metadata only; the rendering for each template lives under
  * `@/components/editor/templates`.
  */
 export type TemplateId =
@@ -17,7 +17,7 @@ export interface TemplateSummary {
   id: TemplateId;
   name: string;
   description: string;
-  /** ISO 8601 — when the template was added, for "newest" sorting. */
+  /** ISO 8601: when the template was added, for "newest" sorting. */
   addedAt: string;
 }
 

--- a/src/lib/tour.ts
+++ b/src/lib/tour.ts
@@ -55,7 +55,7 @@ export const TOURS: AppTour[] = [
         sidebar: "closed",
         title: "Welcome to Lanjut",
         content:
-          "A free, local-first résumé builder. Everything you write stays in this browser — nothing is ever sent to a server.",
+          "A free, local-first résumé builder. Everything you write stays in this browser; nothing is ever sent to a server.",
       },
       {
         ...TOP_STEP,
@@ -90,7 +90,7 @@ export const TOURS: AppTour[] = [
         side: "right",
         title: "Your résumés",
         content:
-          "Every résumé you create shows up here — pick one to jump into the editor.",
+          "Every résumé you create shows up here; pick one to jump into the editor.",
       },
       {
         ...TOP_STEP,
@@ -113,7 +113,7 @@ export const TOURS: AppTour[] = [
         side: "right",
         title: "Browse templates",
         content:
-          "Templates change presentation only — typography, spacing, accents. The structure stays linear so ATS parsers can always read your résumé.",
+          "Templates change presentation only: typography, spacing, accents. The structure stays linear so ATS parsers can always read your résumé.",
       },
       {
         ...TOP_STEP,


### PR DESCRIPTION
A copywriting pass over the product's prose. User-facing copy (landing sections, the guided tour, dialog descriptions, form hints, site metadata, the what's-new entries) and internal prose (code comments, README, docs) now read with tighter, more consistent sentence structure and punctuation. Wording is preserved throughout; sentences were only re-joined or split where the flow benefited.

Two spots touch output rather than copy: the plain-text export's role/company/dates line and the DOCX language-proficiency label now use a simpler ASCII separator, which is also the safer choice for strict parsers.

No behavior changes otherwise, and no resume data flow is affected. Export validation passes for every template: reading order and all fields (name, contact, employers, education, certificates, skills, languages) still map correctly in PDF, DOCX, and plain text.