### PR TITLE
fix: trim hero side padding and shorten the navbar download label

### DIFF
--- a/src/components/landing/landing-hero.tsx
+++ b/src/components/landing/landing-hero.tsx
@@ -31,7 +31,7 @@ export function LandingHero() {
       variants={containerVariants}
       initial="hidden"
       animate="visible"
-      className="w-11/12 mx-auto max-w-5xl flex min-h-svh flex-col items-center justify-center px-4 py-20 text-center md:py-24"
+      className="w-11/12 mx-auto max-w-5xl flex min-h-svh flex-col items-center justify-center py-20 text-center md:py-24"
     >
       <motion.div variants={itemVariants} className="relative mb-4 md:mb-5">
         <span

--- a/src/components/platform/platform-navbar-download.tsx
+++ b/src/components/platform/platform-navbar-download.tsx
@@ -33,7 +33,7 @@ export function PlatformNavbarDownload() {
           />
         }
       >
-        <Download /> Download Résumé
+        <Download /> <span className="sr-only">Download</span> Résumé
       </PopoverTrigger>
       <PopoverContent align="end">
         <PopoverHeader>


### PR DESCRIPTION
Two small UI touch-ups:

- The landing hero container dropped its `px-4`; it already sizes itself with `w-11/12 mx-auto`, so the extra side padding only narrowed the content on small screens.
- The platform navbar's download trigger now reads "Résumé" next to the download icon instead of "Download Résumé"; the icon already communicates the action, and the full "Download Résumé" name is kept for screen readers via an sr-only span.

Presentation-only; no data flow or export behavior is touched.