### PR TITLE
feat: add an organization experience section

### DIFF
--- a/src/components/editor/editor-sections.ts
+++ b/src/components/editor/editor-sections.ts
@@ -6,12 +6,14 @@ import {
   GraduationCap,
   Languages,
   type LucideIcon,
+  Users,
   Zap,
 } from "lucide-react";
 
 export type EditorSectionId =
   | "personal-details"
   | "experience"
+  | "organizations"
   | "education"
   | "skills"
   | "languages"
@@ -40,6 +42,12 @@ export const EDITOR_SECTIONS: EditorSectionDescriptor[] = [
     required: true,
   },
   { id: "experience", label: "Experience", icon: Briefcase, required: false },
+  {
+    id: "organizations",
+    label: "Organizations",
+    icon: Users,
+    required: false,
+  },
   { id: "education", label: "Education", icon: GraduationCap, required: false },
   { id: "skills", label: "Skills", icon: Zap, required: false },
   { id: "languages", label: "Languages", icon: Languages, required: false },

--- a/src/components/editor/editor-sections/ed-section-list.tsx
+++ b/src/components/editor/editor-sections/ed-section-list.tsx
@@ -7,11 +7,12 @@ import { EditorSectionCertifications } from "./ed-section-certifications/ed-sect
 import { EditorSectionEducation } from "./ed-section-education/ed-section-education";
 import { EditorSectionExperience } from "./ed-section-experience/ed-section-experience";
 import { EditorSectionLanguages } from "./ed-section-languages/ed-section-languages";
+import { EditorSectionOrganizations } from "./ed-section-organizations/ed-section-organizations";
 import { EditorSectionPersonal } from "./ed-section-personal/ed-section-personal";
 import { EditorSectionSkills } from "./ed-section-skills/ed-section-skills";
 import { EditorSectionSummary } from "./ed-section-summary/ed-section-summary";
 
-const SKELETONS = [1, 2, 3, 4, 5, 6];
+const SKELETONS = [1, 2, 3, 4, 5, 6, 7];
 
 export function EditorSectionList() {
   const openStatus = useResumeStore((state) => state.openStatus);
@@ -46,6 +47,7 @@ export function EditorSectionList() {
       <EditorSectionPersonal />
       <EditorSectionSummary />
       <EditorSectionExperience />
+      <EditorSectionOrganizations />
       <EditorSectionEducation />
       <EditorSectionCertifications />
       <EditorSectionSkills />

--- a/src/components/editor/editor-sections/ed-section-organizations/ed-section-organizations-form-item.tsx
+++ b/src/components/editor/editor-sections/ed-section-organizations/ed-section-organizations-form-item.tsx
@@ -1,0 +1,112 @@
+import { Trash } from "lucide-react";
+import { type Control, Controller } from "react-hook-form";
+import { Button } from "@/components/ui/button";
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+  FieldLegend,
+  FieldSet,
+} from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { PROSE_FEATURES } from "@/lib/resume/schema-registry";
+import { RichTextEditor } from "../../rich-text/rich-text-editor";
+import { DateRangeFields } from "../date-range-fields";
+import type { OrganizationsFormValues } from "../resume-form-adapter";
+
+interface EditorSectionOrganizationsFormItemProps {
+  index: number;
+  deletable: boolean;
+  control: Control<OrganizationsFormValues>;
+  onRemoveField: (index: number) => void;
+}
+
+export function EditorSectionOrganizationsFormItem(
+  props: EditorSectionOrganizationsFormItemProps,
+) {
+  const onRemove = () => {
+    props.onRemoveField(props.index);
+  };
+
+  return (
+    <FieldSet className="not-last-of-type:pb-4 not-last-of-type:border-b">
+      <FieldLegend className="sr-only" variant="label">
+        Organization {props.index + 1}
+      </FieldLegend>
+
+      <FieldGroup className="gap-3">
+        <Controller
+          control={props.control}
+          name={`organizations.${props.index}.role`}
+          render={({ field, fieldState }) => (
+            <Field>
+              <FieldLabel htmlFor={field.name}>Role</FieldLabel>
+              <div className="flex items-center gap-2">
+                <Input
+                  placeholder="Head of Public Relations"
+                  {...field}
+                  id={field.name}
+                />
+                {props.deletable && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon-sm"
+                    onClick={onRemove}
+                  >
+                    <Trash className="size-3.5 stroke-destructive" />
+                    <span className="sr-only">Remove</span>
+                  </Button>
+                )}
+              </div>
+              <FieldError errors={[fieldState.error]} />
+            </Field>
+          )}
+        />
+
+        <Controller
+          control={props.control}
+          name={`organizations.${props.index}.organization`}
+          render={({ field, fieldState }) => (
+            <Field>
+              <FieldLabel htmlFor={field.name}>Organization</FieldLabel>
+              <Input
+                placeholder="Student Executive Board"
+                {...field}
+                id={field.name}
+              />
+              <FieldError errors={[fieldState.error]} />
+            </Field>
+          )}
+        />
+
+        <DateRangeFields
+          control={props.control}
+          startName={`organizations.${props.index}.startDate`}
+          endName={`organizations.${props.index}.endDate`}
+          presentLabel="I'm currently active here"
+        />
+
+        <Controller
+          control={props.control}
+          name={`organizations.${props.index}.description`}
+          render={({ field, fieldState }) => (
+            <Field>
+              <FieldLabel htmlFor={field.name}>Summary</FieldLabel>
+              <RichTextEditor
+                id={field.name}
+                value={field.value}
+                features={PROSE_FEATURES}
+                placeholder="Organized events that...."
+                onChange={field.onChange}
+                onBlur={field.onBlur}
+              />
+              <FieldError errors={[fieldState.error]} />
+            </Field>
+          )}
+        />
+      </FieldGroup>
+    </FieldSet>
+  );
+}

--- a/src/components/editor/editor-sections/ed-section-organizations/ed-section-organizations-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-organizations/ed-section-organizations-form.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { Plus } from "lucide-react";
+import { useEffect } from "react";
+import { useFieldArray, useForm } from "react-hook-form";
+import { Button } from "@/components/ui/button";
+import {
+  FieldDescription,
+  FieldGroup,
+  FieldLegend,
+  FieldSet,
+} from "@/components/ui/field";
+import { emptyRichTextValue } from "@/lib/resume";
+import { useResumeStore } from "@/lib/store";
+import {
+  applyOrganizationsValues,
+  type OrganizationItemValues,
+  type OrganizationsFormValues,
+  toOrganizationsValues,
+} from "../resume-form-adapter";
+import { EditorSectionOrganizationsFormItem } from "./ed-section-organizations-form-item";
+
+function emptyOrganization(): OrganizationItemValues {
+  return {
+    role: "",
+    organization: "",
+    startDate: "",
+    endDate: "",
+    description: emptyRichTextValue(),
+  };
+}
+
+export function EditorSectionOrganizationsForm() {
+  const open = useResumeStore((state) => state.open);
+  const updateOpen = useResumeStore((state) => state.updateOpen);
+
+  const form = useForm<OrganizationsFormValues>({
+    defaultValues: open ? toOrganizationsValues(open) : { organizations: [] },
+  });
+  const { fields, prepend, remove } = useFieldArray({
+    control: form.control,
+    name: "organizations",
+  });
+
+  // The field array owns the list; every form change (including add/remove)
+  // rebuilds the store entries. Subscribing to the form and writing to the
+  // store is a valid external-system sync; the store debounces the IndexedDB
+  // write. Reading getValues() inside the callback avoids stale-value timing.
+  useEffect(() => {
+    const subscription = form.watch(() => {
+      updateOpen((draft) => applyOrganizationsValues(draft, form.getValues()));
+    });
+    return () => subscription.unsubscribe();
+  }, [form, updateOpen]);
+
+  if (!open) return null;
+
+  return (
+    <form>
+      <FieldSet className="gap-3">
+        <FieldLegend className="sr-only">Organization Experience</FieldLegend>
+        <FieldDescription className="sr-only">
+          Describe your volunteer, student, and community roles
+        </FieldDescription>
+        <Button
+          type="button"
+          onClick={() => prepend(emptyOrganization())}
+          variant="outline"
+          className="w-full"
+        >
+          <Plus /> Add Organization Experience
+        </Button>
+
+        <FieldGroup className="gap-4">
+          {fields.map((field, index) => (
+            <EditorSectionOrganizationsFormItem
+              key={field.id}
+              control={form.control}
+              deletable={fields.length > 1}
+              index={index}
+              onRemoveField={remove}
+            />
+          ))}
+        </FieldGroup>
+      </FieldSet>
+    </form>
+  );
+}

--- a/src/components/editor/editor-sections/ed-section-organizations/ed-section-organizations.tsx
+++ b/src/components/editor/editor-sections/ed-section-organizations/ed-section-organizations.tsx
@@ -1,0 +1,21 @@
+import { Users } from "lucide-react";
+import {
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { EditorSectionOrganizationsForm } from "./ed-section-organizations-form";
+
+export function EditorSectionOrganizations() {
+  return (
+    <AccordionItem>
+      <AccordionTrigger className="items-center gap-3">
+        <Users className="size-4" /> Organization Experience
+      </AccordionTrigger>
+
+      <AccordionContent>
+        <EditorSectionOrganizationsForm />
+      </AccordionContent>
+    </AccordionItem>
+  );
+}

--- a/src/components/editor/editor-sections/resume-form-adapter.ts
+++ b/src/components/editor/editor-sections/resume-form-adapter.ts
@@ -32,6 +32,18 @@ export interface ExperienceFormValues {
   experiences: ExperienceItemValues[];
 }
 
+export interface OrganizationItemValues {
+  role: string;
+  organization: string;
+  startDate: string;
+  endDate: string;
+  description: JSONContent;
+}
+
+export interface OrganizationsFormValues {
+  organizations: OrganizationItemValues[];
+}
+
 export interface EducationItemValues {
   institution: string;
   degree: string;
@@ -185,6 +197,42 @@ export function applyExperienceValues(
       title: plain(item.title),
       company: plain(item.company),
       website: plain(item.website),
+      startDate: plain(item.startDate),
+      endDate: plain(item.endDate),
+      description: rich(item.description),
+    },
+  }));
+}
+
+// --- Organizations (repeating section entries) ------------------------------
+
+export function organizationEntries(resume: Resume): Entry[] {
+  return sectionOfType(resume, "organizations")?.entries ?? [];
+}
+
+export function toOrganizationsValues(resume: Resume): OrganizationsFormValues {
+  return {
+    organizations: organizationEntries(resume).map((entry) => ({
+      role: plainValue(entry.fields.role),
+      organization: plainValue(entry.fields.organization),
+      startDate: plainValue(entry.fields.startDate),
+      endDate: plainValue(entry.fields.endDate),
+      description: richValue(entry.fields.description),
+    })),
+  };
+}
+
+export function applyOrganizationsValues(
+  draft: Resume,
+  values: OrganizationsFormValues,
+): void {
+  const section = sectionOfType(draft, "organizations");
+  if (!section) return;
+  section.entries = values.organizations.map((item, index) => ({
+    id: entryId(section, index),
+    fields: {
+      role: plain(item.role),
+      organization: plain(item.organization),
       startDate: plain(item.startDate),
       endDate: plain(item.endDate),
       description: rich(item.description),

--- a/src/components/editor/resume-blocks.ts
+++ b/src/components/editor/resume-blocks.ts
@@ -125,6 +125,24 @@ export function buildResumeBlocks(resume: ResumePreview): ResumeBlock[] {
     );
   }
 
+  // Organization entries reuse the "experience" block kind: they render
+  // identically in every template and export, only the section heading differs.
+  const organizations = resume.organizations.filter(hasExperience);
+  if (organizations.length > 0) {
+    blocks.push(
+      heading("organizations-heading", "Organizations"),
+      ...organizations.map(
+        (item, index): ResumeBlock => ({
+          id: item.id,
+          kind: "experience",
+          item,
+          gapBefore: entryGap(index),
+          keepWithNext: false,
+        }),
+      ),
+    );
+  }
+
   const education = resume.education.filter(hasEducation);
   if (education.length > 0) {
     blocks.push(

--- a/src/components/editor/resume-preview.ts
+++ b/src/components/editor/resume-preview.ts
@@ -69,6 +69,13 @@ export interface ResumePreview {
   header: HeaderView;
   summary: RichBlock[];
   experience: ExperienceItemView[];
+  /**
+   * Organization entries (volunteer, student, community roles) are
+   * presentationally identical to experience entries, so they reuse
+   * `ExperienceItemView` (`company` holds the organization name) and every
+   * renderer's experience path.
+   */
+  organizations: ExperienceItemView[];
   education: EducationItemView[];
   certificates: CertificateItemView[];
   skills: SkillItemView[];

--- a/src/components/editor/resume-to-preview.ts
+++ b/src/components/editor/resume-to-preview.ts
@@ -104,6 +104,16 @@ export function resumeToPreview(resume: Resume): ResumePreview {
         };
       })
       .sort(byRecency),
+    organizations: (sectionOfType(resume, "organizations")?.entries ?? [])
+      .map((entry) => ({
+        id: entry.id,
+        role: plain(entry.fields.role),
+        company: plain(entry.fields.organization),
+        startDate: plain(entry.fields.startDate),
+        endDate: plain(entry.fields.endDate),
+        description: richBlocks(entry.fields.description),
+      }))
+      .sort(byRecency),
     education: (sectionOfType(resume, "education")?.entries ?? [])
       .map((entry) => ({
         id: entry.id,

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -11,16 +11,10 @@ export interface ChangelogEntry {
  */
 export const CHANGELOG: ChangelogEntry[] = [
   {
-    version: "0.5.0",
-    date: "2026-07-05",
-    highlights: [
-      "New Organization Experience section: showcase volunteer, student, and community roles with dates and highlights, just like work experience. It shows up in every template and export, and your existing résumés get it automatically.",
-    ],
-  },
-  {
     version: "0.4.0",
     date: "2026-07-05",
     highlights: [
+      "New Organization Experience section: showcase volunteer, student, and community roles with dates and highlights, just like work experience. It shows up in every template and export, and your existing résumés get it automatically.",
       "Your saved résumés are safer during app updates: a backup copy is kept on your device before any data-format upgrade, and a résumé the app can't read yet is flagged with a notice instead of disappearing.",
       "A guided tour now walks you through the dashboard, the templates, and the editor on your first visit.",
       "The landing page walks through how Lanjut works, ending with a one-click way to start a new résumé.",

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -11,6 +11,13 @@ export interface ChangelogEntry {
  */
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "0.5.0",
+    date: "2026-07-05",
+    highlights: [
+      "New Organization Experience section: showcase volunteer, student, and community roles with dates and highlights, just like work experience. It shows up in every template and export, and your existing résumés get it automatically.",
+    ],
+  },
+  {
     version: "0.4.0",
     date: "2026-07-05",
     highlights: [

--- a/src/lib/resume/factory.ts
+++ b/src/lib/resume/factory.ts
@@ -75,6 +75,7 @@ export function createEmptyResume(title: string): Resume {
     sections: [
       createEmptySection("summary"),
       createEmptySection("experience"),
+      createEmptySection("organizations"),
       createEmptySection("education"),
       createEmptySection("skills"),
       createEmptySection("certifications"),

--- a/src/lib/resume/migrations.ts
+++ b/src/lib/resume/migrations.ts
@@ -238,6 +238,44 @@ const migrateV4toV5: Migration = (doc) => {
 };
 
 /**
+ * v5→v6: adds the Organizations section (volunteer, student, and community
+ * roles). Existing documents gain it (with one empty entry) if it is not
+ * already present, so the new editor form has somewhere to write.
+ */
+const migrateV5toV6: Migration = (doc) => {
+  const next = structuredClone(doc);
+  const sections = Array.isArray(next.sections)
+    ? (next.sections as Array<Record<string, unknown>>)
+    : [];
+
+  if (!sections.some((s) => s.type === "organizations")) {
+    sections.push({
+      id: nanoid(),
+      type: "organizations",
+      title: "Organizations",
+      entries: [
+        {
+          id: nanoid(),
+          fields: {
+            role: plainField(""),
+            organization: plainField(""),
+            startDate: plainField(""),
+            endDate: plainField(""),
+            description: {
+              kind: "richtext",
+              value: { type: "doc", content: [{ type: "paragraph" }] },
+            },
+          },
+        },
+      ],
+    });
+  }
+
+  next.sections = sections;
+  return next;
+};
+
+/**
  * The migration ladder. Each key N is a forward-only step from version N to N+1.
  */
 const LADDER: Record<number, Migration> = {
@@ -245,6 +283,7 @@ const LADDER: Record<number, Migration> = {
   2: migrateV2toV3,
   3: migrateV3toV4,
   4: migrateV4toV5,
+  5: migrateV5toV6,
 };
 
 /** The persisted schemaVersion of a raw document; 0 when absent or malformed. */

--- a/src/lib/resume/schema-registry.ts
+++ b/src/lib/resume/schema-registry.ts
@@ -155,6 +155,43 @@ export const SECTION_REGISTRY: Record<SectionType, SectionSchema> = {
       },
     ],
   },
+  organizations: {
+    type: "organizations",
+    defaultTitle: "Organizations",
+    singleton: false,
+    fields: [
+      {
+        key: "role",
+        label: "Role",
+        kind: "plain",
+        placeholder: "Head of Public Relations",
+      },
+      {
+        key: "organization",
+        label: "Organization",
+        kind: "plain",
+        placeholder: "Student Executive Board",
+      },
+      {
+        key: "startDate",
+        label: "Start date",
+        kind: "plain",
+        placeholder: "Jan 2023",
+      },
+      {
+        key: "endDate",
+        label: "End date",
+        kind: "plain",
+        placeholder: "Present",
+      },
+      {
+        key: "description",
+        label: "Description",
+        kind: "richtext",
+        features: PROSE_FEATURES,
+      },
+    ],
+  },
   education: {
     type: "education",
     defaultTitle: "Education",

--- a/src/lib/resume/seed.ts
+++ b/src/lib/resume/seed.ts
@@ -233,6 +233,56 @@ export const SEED_RESUME: Resume = {
       ],
     },
     {
+      id: "seed-organizations",
+      type: "organizations",
+      title: "Organizations",
+      entries: [
+        {
+          id: "seed-organizations-1",
+          fields: {
+            role: plain("Organizer"),
+            organization: plain("React SF Meetup"),
+            startDate: plain("Jan 2021"),
+            endDate: plain("Present"),
+            description: prose(
+              ul(
+                li(
+                  t("Curate monthly talks for a "),
+                  b("1,800-member"),
+                  t(
+                    " community and coordinate speakers, venues, and sponsors.",
+                  ),
+                ),
+                li(
+                  t(
+                    "Launched a lightning-talk track that has given 30+ first-time speakers a stage.",
+                  ),
+                ),
+              ),
+            ),
+          },
+        },
+        {
+          id: "seed-organizations-2",
+          fields: {
+            role: plain("President"),
+            organization: plain("Web Development Club, State University"),
+            startDate: plain("2016"),
+            endDate: plain("2018"),
+            description: prose(
+              ul(
+                li(
+                  t("Grew the club from 30 to "),
+                  b("120 members"),
+                  t(" and ran weekly hands-on workshops."),
+                ),
+              ),
+            ),
+          },
+        },
+      ],
+    },
+    {
       id: "seed-education",
       type: "education",
       title: "Education",

--- a/src/lib/resume/types.ts
+++ b/src/lib/resume/types.ts
@@ -5,7 +5,7 @@ import type { JSONContent } from "@tiptap/core";
  * governs object-store/index structure only. Bumped whenever a persisted field
  * shape changes; every bump gets a forward-only step in the migration ladder.
  */
-export const CURRENT_SCHEMA_VERSION = 5;
+export const CURRENT_SCHEMA_VERSION = 6;
 
 export type FieldKind = "plain" | "richtext";
 
@@ -38,6 +38,7 @@ export interface Entry {
 export type SectionType =
   | "summary"
   | "experience"
+  | "organizations"
   | "education"
   | "skills"
   | "certifications"


### PR DESCRIPTION
Adds organization experience (volunteer, student, and community roles) as a first-class section, a frequent request from users whose campus and community leadership carries as much weight as their work history.

- New `organizations` section type in the registry: role, organization, start/end dates, and a rich text description with the standard restricted feature set. New resumes include it by default, between Experience and Education.
- Schema version bumps to 6 with a ladder rung that appends an empty Organizations section to existing documents (same precedent as the v3 to v4 step that introduced certifications and languages). The step bails out if the section already exists.
- New "Organization Experience" editor panel mirroring the experience form, including the date range picker with an "I'm currently active here" checkbox.
- Organization entries are presentationally identical to experience entries, so the block builder emits them under an "Organizations" heading reusing the experience block kind. Every template, the PDF documents, and the docx/txt exports pick them up with no renderer changes, keeping rendering identical across templates by construction.
- The seed resume gains two organization entries so the showcase and parser-gate document exercise the section.

No resume content touches any server; the section persists through the existing zustand to IndexedDB flow.

Testing: type checks, lint, and a production build pass. Export reading order is unchanged since organization entries flow through the already-validated experience rendering path; recommend one manual look at a PDF export with an organization entry filled in before merging.