### PR TITLE
fix: show navbar actions on small screens and round the sheet close button

### DIFF
--- a/src/components/platform/platform-navbar.tsx
+++ b/src/components/platform/platform-navbar.tsx
@@ -14,7 +14,7 @@ export function PlatformNavbar() {
         <SidebarTrigger />
         <PlatformNavbarBreadcrumb />
 
-        <div className="lg:inline-flex items-center gap-2 ml-auto">
+        <div className="inline-flex items-center gap-2 ml-auto">
           <PlatformNavbarChangelog />
           <PlatformNavbarTheme />
           <PlatformNavbarDownload />

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -66,7 +66,7 @@ function SheetContent({
             render={
               <Button
                 variant="ghost"
-                className="absolute top-4 right-4 bg-secondary"
+                className="absolute top-4 right-4 bg-secondary rounded-2xl"
                 size="icon-sm"
               />
             }


### PR DESCRIPTION
Two small UI fixes ahead of the 0.4.0 release:

- The navbar action group (what's new, theme, download) was only laid out as a flex row from the lg breakpoint up, so on smaller screens the buttons fell back to stacked block layout. It is now inline-flex at every size, keeping the actions in a row next to the breadcrumb.
- The sheet's close button picks up the same rounded shape as the rest of the controls instead of the default corner radius.

Testing: lint and type checks pass; the navbar actions sit correctly in a row on narrow viewports and the what's new sheet close button renders rounded.