### PR TITLE
feat: add a layout tab to switch templates from the editor

### DIFF
--- a/src/components/editor/editor-layout/ed-layout-template-item.tsx
+++ b/src/components/editor/editor-layout/ed-layout-template-item.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Radio as RadioPrimitive } from "@base-ui/react/radio";
+import { CheckIcon } from "lucide-react";
+import type { TemplateSummary } from "@/lib/templates";
+import type { ResumePreview } from "../resume-preview";
+import { ResumeThumbnail } from "../resume-thumbnail";
+
+interface EditorLayoutTemplateItemProps {
+  template: TemplateSummary;
+  preview: ResumePreview;
+}
+
+export function EditorLayoutTemplateItem(props: EditorLayoutTemplateItemProps) {
+  return (
+    <RadioPrimitive.Root
+      value={props.template.id}
+      aria-label={`Use ${props.template.name} template`}
+      className="group/template flex cursor-pointer flex-col overflow-hidden rounded-xl border text-left outline-none transition-colors hover:border-ring/50 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 data-checked:border-primary data-checked:ring-1 data-checked:ring-primary"
+    >
+      <div
+        aria-hidden
+        className="pointer-events-none relative aspect-square overflow-hidden border-b bg-muted/40 bg-[radial-gradient(color-mix(in_oklab,var(--color-foreground)_7%,transparent)_1px,transparent_1px)] bg-size-[0.625rem_0.625rem]"
+      >
+        <div className="absolute inset-x-2 top-2 overflow-hidden rounded-lg bg-white shadow-md ring-1 ring-black/5">
+          <ResumeThumbnail
+            resume={props.preview}
+            template={props.template.id}
+          />
+        </div>
+      </div>
+
+      <p className="text-xs text-muted-foreground px-3 py-2">
+        <span className="line-clamp-2">{props.template.description}</span>
+      </p>
+
+      <p className="flex items-center gap-1.5 px-3 pb-2 pt-1 text-sm font-medium">
+        {props.template.name}
+        <CheckIcon className="ml-auto size-3.5 text-primary opacity-0 transition-opacity group-data-checked/template:opacity-100" />
+      </p>
+    </RadioPrimitive.Root>
+  );
+}

--- a/src/components/editor/editor-layout/ed-layout-template-list.tsx
+++ b/src/components/editor/editor-layout/ed-layout-template-list.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useMemo } from "react";
+import { RadioGroup } from "@/components/ui/radio-group";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useResumeStore } from "@/lib/store";
+import { resolveTemplateId, TEMPLATES } from "@/lib/templates";
+import { resumeToPreview } from "../resume-to-preview";
+import { EditorLayoutTemplateItem } from "./ed-layout-template-item";
+
+const SKELETONS = [1, 2, 3, 4, 5, 6];
+
+export function EditorLayoutTemplateList() {
+  const open = useResumeStore((state) => state.open);
+  const updateOpen = useResumeStore((state) => state.updateOpen);
+
+  const preview = useMemo(() => (open ? resumeToPreview(open) : null), [open]);
+
+  if (!open || !preview) {
+    return (
+      <div className="grid grid-cols-2 gap-3 px-4">
+        {SKELETONS.map((s) => (
+          <Skeleton key={s} className="aspect-3/4 rounded-xl" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <RadioGroup
+      value={resolveTemplateId(open.templateId)}
+      onValueChange={(value) => {
+        updateOpen((draft) => {
+          draft.templateId = value as string;
+        });
+      }}
+      className="grid grid-cols-2 gap-3 px-4"
+    >
+      {TEMPLATES.map((template) => (
+        <EditorLayoutTemplateItem
+          key={template.id}
+          template={template}
+          preview={preview}
+        />
+      ))}
+    </RadioGroup>
+  );
+}

--- a/src/components/editor/editor-panels.tsx
+++ b/src/components/editor/editor-panels.tsx
@@ -12,13 +12,15 @@ import { ScrollArea } from "../ui/scroll-area";
 import { EditorSheet } from "./editor-sheet";
 import { EditorSidebar } from "./editor-sidebar";
 
+const PANELS_CONTAINER = "h-[calc(100svh-3rem-1px)] min-h-0 overflow-hidden";
+
 export function EditorPanels(props: { children: ReactNode }) {
   useEditorResume();
   const isDesktop = useMediaQuery(MEDIA_XL);
 
   if (isDesktop) {
     return (
-      <div className="h-[calc(100vh-4rem)] flex-1 overflow-hidden">
+      <div className={PANELS_CONTAINER}>
         <ResizablePanelGroup>
           <ResizablePanel defaultSize="68%" minSize="40%" maxSize="72%">
             <EditorPreviewScroll>{props.children}</EditorPreviewScroll>
@@ -33,7 +35,7 @@ export function EditorPanels(props: { children: ReactNode }) {
   }
 
   return (
-    <div className="h-[calc(100vh-4rem)] flex-1 overflow-hidden">
+    <div className={PANELS_CONTAINER}>
       <EditorPreviewScroll>{props.children}</EditorPreviewScroll>
       {isDesktop === false && <EditorSheet />}
     </div>
@@ -42,7 +44,7 @@ export function EditorPanels(props: { children: ReactNode }) {
 
 function EditorPreviewScroll(props: { children: ReactNode }) {
   return (
-    <ScrollArea id="tour-editor-preview" className="h-[calc(100vh-3.5rem)]">
+    <ScrollArea id="tour-editor-preview" className="h-full">
       <div className="bg-muted px-6 py-10 min-h-screen">{props.children}</div>
     </ScrollArea>
   );

--- a/src/components/editor/editor-sheet.tsx
+++ b/src/components/editor/editor-sheet.tsx
@@ -2,7 +2,6 @@
 
 import { PenLine } from "lucide-react";
 import { Button } from "../ui/button";
-import { ScrollArea } from "../ui/scroll-area";
 import {
   Sheet,
   SheetContent,
@@ -36,9 +35,9 @@ export function EditorSheet() {
           <SheetTitle>Editor</SheetTitle>
           <SheetDescription>Resume Editor</SheetDescription>
         </SheetHeader>
-        <ScrollArea className="min-h-0 flex-1">
+        <div className="min-h-0 flex-1">
           <EditorSidebarContent />
-        </ScrollArea>
+        </div>
       </SheetContent>
     </Sheet>
   );

--- a/src/components/editor/editor-sidebar-content.tsx
+++ b/src/components/editor/editor-sidebar-content.tsx
@@ -1,15 +1,48 @@
 "use client";
 
+import { parseAsString, useQueryState } from "nuqs";
+import { ScrollArea } from "../ui/scroll-area";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
+import { EditorLayoutTemplateList } from "./editor-layout/ed-layout-template-list";
 import { EditorSectionList } from "./editor-sections/ed-section-list";
 
+const TABS = [
+  { value: "editor", label: "Editor" },
+  { value: "layout", label: "Layout" },
+  // { value: "latex", label: "LaTex", disabled: true },
+];
+
 export function EditorSidebarContent() {
+  const [tab, setTab] = useQueryState(
+    "editor-tab",
+    parseAsString.withDefault(TABS[0].value),
+  );
+
+  const onTabChange = (next: string) => setTab(next);
+
   return (
-    <div className="flex flex-col py-6">
-      <h2 className="pb-1 text-2xl font-bold tracking-tight px-4">Editor</h2>
-      <h3 className="pb-2 text-lg font-semibold tracking-tight px-4">
-        The Essentials
-      </h3>
-      <EditorSectionList />
+    <div className="flex h-full flex-col py-6">
+      <Tabs className="min-h-0 flex-1" value={tab} onValueChange={onTabChange}>
+        <div className="shrink-0 px-4">
+          <TabsList>
+            {TABS.map((t) => (
+              <TabsTrigger key={t.value} value={t.value}>
+                {t.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </div>
+
+        <ScrollArea id="tour-editor-sections" className="min-h-0 flex-1">
+          <TabsContent value="editor">
+            <EditorSectionList />
+          </TabsContent>
+
+          <TabsContent value="layout" className="py-4">
+            <EditorLayoutTemplateList />
+          </TabsContent>
+        </ScrollArea>
+      </Tabs>
     </div>
   );
 }

--- a/src/components/editor/editor-sidebar.tsx
+++ b/src/components/editor/editor-sidebar.tsx
@@ -1,24 +1,19 @@
 "use client";
 
 import { ResizablePanel } from "../ui/resizable";
-import { ScrollArea } from "../ui/scroll-area";
 import { useSidebar } from "../ui/sidebar";
 import { EditorSidebarContent } from "./editor-sidebar-content";
 
 export function EditorSidebar() {
   const { open } = useSidebar();
+
   return (
     <ResizablePanel
       defaultSize={open ? "36%" : "38%"}
       minSize={open ? "28%" : "30%"}
       maxSize="40%"
     >
-      <ScrollArea
-        id="tour-editor-sections"
-        className="max-h-[calc(100vh-3.5rem)]"
-      >
-        <EditorSidebarContent />
-      </ScrollArea>
+      <EditorSidebarContent />
     </ResizablePanel>
   );
 }


### PR DESCRIPTION
The editor sidebar's layout tab is now real: a two-column radio grid of template tiles, each one a miniature render of the open resume in that template, with the active template ringed and checked. Picking a tile sets `templateId` through the store's `updateOpen`, so it flows through the existing debounced IndexedDB persist; presentation only, the document schema is untouched.

Getting there also fixes the editor scroll layout. The panels container previously combined `flex-1` with a wrong viewport calc (the navbar is 3rem, not 4rem), and the flex item's implicit `min-height: auto` let tall sidebar content stretch the whole page. The container now takes a single fixed viewport-derived height, the preview and sidebar fill their panels with `h-full`, and the tab content scrolls in its own scroll area under pinned triggers. The mobile edit sheet drops its outer scroll wrapper for the same reason, so the triggers stay pinned there too.

Tested by creating a resume and driving the editor: the page itself no longer scrolls at any point, the Editor/Layout triggers stay fixed while section forms and the template grid scroll beneath them, switching to Tebal restyles the live preview immediately, and the choice survives a reload. The guided tour still highlights the preview and the sections area correctly, and the edit sheet on smaller screens behaves the same way.