### PR TITLE
feat: allow creating a blank resume from the create dialog

### DIFF
--- a/src/components/editor/editor-layout/ed-layout-template-list.tsx
+++ b/src/components/editor/editor-layout/ed-layout-template-list.tsx
@@ -3,18 +3,34 @@
 import { useMemo } from "react";
 import { RadioGroup } from "@/components/ui/radio-group";
 import { Skeleton } from "@/components/ui/skeleton";
+import { SEED_RESUME } from "@/lib/resume";
 import { useResumeStore } from "@/lib/store";
 import { resolveTemplateId, TEMPLATES } from "@/lib/templates";
+import { buildResumeBlocks } from "../resume-blocks";
 import { resumeToPreview } from "../resume-to-preview";
 import { EditorLayoutTemplateItem } from "./ed-layout-template-item";
 
 const SKELETONS = [1, 2, 3, 4, 5, 6];
 
+const SEED_PREVIEW = resumeToPreview(SEED_RESUME);
+
+/**
+ * A document whose preview renders nothing beyond the header block would make
+ * every template tile look identically blank, so fall back to the seed fixture
+ * to keep the tiles comparable.
+ */
+function toTilePreview(preview: ReturnType<typeof resumeToPreview>) {
+  return buildResumeBlocks(preview).length > 1 ? preview : SEED_PREVIEW;
+}
+
 export function EditorLayoutTemplateList() {
   const open = useResumeStore((state) => state.open);
   const updateOpen = useResumeStore((state) => state.updateOpen);
 
-  const preview = useMemo(() => (open ? resumeToPreview(open) : null), [open]);
+  const preview = useMemo(
+    () => (open ? toTilePreview(resumeToPreview(open)) : null),
+    [open],
+  );
 
   if (!open || !preview) {
     return (

--- a/src/components/editor/editor-sections/ed-section-certifications/ed-section-certifications-form-item.tsx
+++ b/src/components/editor/editor-sections/ed-section-certifications/ed-section-certifications-form-item.tsx
@@ -16,7 +16,6 @@ import type { CertificationsFormValues } from "../resume-form-adapter";
 
 interface EditorSectionCertificationsFormItemProps {
   index: number;
-  deletable: boolean;
   control: Control<CertificationsFormValues>;
   onRemoveField: (index: number) => void;
 }
@@ -46,17 +45,15 @@ export function EditorSectionCertificationsFormItem(
                   {...field}
                   id={field.name}
                 />
-                {props.deletable && (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon-sm"
-                    onClick={onRemove}
-                  >
-                    <Trash className="size-3.5 stroke-destructive" />
-                    <span className="sr-only">Remove</span>
-                  </Button>
-                )}
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon-sm"
+                  onClick={onRemove}
+                >
+                  <Trash className="size-3.5 stroke-destructive" />
+                  <span className="sr-only">Remove</span>
+                </Button>
               </div>
               <FieldError errors={[fieldState.error]} />
             </Field>

--- a/src/components/editor/editor-sections/ed-section-certifications/ed-section-certifications-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-certifications/ed-section-certifications-form.tsx
@@ -65,7 +65,6 @@ export function EditorSectionCertificationsForm() {
             <EditorSectionCertificationsFormItem
               key={field.id}
               control={form.control}
-              deletable={fields.length > 1}
               index={index}
               onRemoveField={remove}
             />

--- a/src/components/editor/editor-sections/ed-section-education/ed-section-education-form-item.tsx
+++ b/src/components/editor/editor-sections/ed-section-education/ed-section-education-form-item.tsx
@@ -17,7 +17,6 @@ import type { EducationFormValues } from "../resume-form-adapter";
 
 interface EditorSectionEducationFormItemProps {
   index: number;
-  deletable: boolean;
   control: Control<EducationFormValues>;
   onRemoveField: (index: number) => void;
 }
@@ -47,17 +46,15 @@ export function EditorSectionEducationFormItem(
                   {...field}
                   id={field.name}
                 />
-                {props.deletable && (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon-sm"
-                    onClick={onRemove}
-                  >
-                    <Trash className="size-3.5 stroke-destructive" />
-                    <span className="sr-only">Remove</span>
-                  </Button>
-                )}
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon-sm"
+                  onClick={onRemove}
+                >
+                  <Trash className="size-3.5 stroke-destructive" />
+                  <span className="sr-only">Remove</span>
+                </Button>
               </div>
               <FieldError errors={[fieldState.error]} />
             </Field>

--- a/src/components/editor/editor-sections/ed-section-education/ed-section-education-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-education/ed-section-education-form.tsx
@@ -73,7 +73,6 @@ export function EditorSectionEducationForm() {
             <EditorSectionEducationFormItem
               key={field.id}
               control={form.control}
-              deletable={fields.length > 1}
               index={index}
               onRemoveField={remove}
             />

--- a/src/components/editor/editor-sections/ed-section-experience/ed-section-experience-form-item.tsx
+++ b/src/components/editor/editor-sections/ed-section-experience/ed-section-experience-form-item.tsx
@@ -18,7 +18,6 @@ import type { ExperienceFormValues } from "../resume-form-adapter";
 
 interface EditorSectionExperienceFormItemProps {
   index: number;
-  deletable: boolean;
   control: Control<ExperienceFormValues>;
   onRemoveField: (index: number) => void;
 }
@@ -45,17 +44,15 @@ export function EditorSectionExperienceFormItem(
               <FieldLabel htmlFor={field.name}>Job Title</FieldLabel>
               <div className="flex items-center gap-2">
                 <Input placeholder="UX Engineer" {...field} id={field.name} />
-                {props.deletable && (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon-sm"
-                    onClick={onRemove}
-                  >
-                    <Trash className="size-3.5 stroke-destructive" />
-                    <span className="sr-only">Remove</span>
-                  </Button>
-                )}
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon-sm"
+                  onClick={onRemove}
+                >
+                  <Trash className="size-3.5 stroke-destructive" />
+                  <span className="sr-only">Remove</span>
+                </Button>
               </div>
               <FieldError errors={[fieldState.error]} />
             </Field>

--- a/src/components/editor/editor-sections/ed-section-experience/ed-section-experience-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-experience/ed-section-experience-form.tsx
@@ -77,7 +77,6 @@ export function EditorSectionExperienceForm() {
             <EditorSectionExperienceFormItem
               key={field.id}
               control={form.control}
-              deletable={fields.length > 1}
               index={index}
               onRemoveField={remove}
             />

--- a/src/components/editor/editor-sections/ed-section-languages/ed-section-languages-form-item.tsx
+++ b/src/components/editor/editor-sections/ed-section-languages/ed-section-languages-form-item.tsx
@@ -22,7 +22,6 @@ const LANGUAGE_LEVELS = [
 
 interface EditorSectionLanguagesFormItemProps {
   index: number;
-  deletable: boolean;
   control: Control<LanguagesFormValues>;
   onRemoveField: (index: number) => void;
 }
@@ -44,18 +43,16 @@ export function EditorSectionLanguagesFormItem(
           )}
         />
 
-        {props.deletable && (
-          <Button
-            type="button"
-            variant="outline"
-            size="icon-sm"
-            className="md:hidden"
-            onClick={() => props.onRemoveField(props.index)}
-          >
-            <Trash className="size-3.5 stroke-destructive" />
-            <span className="sr-only">Remove language</span>
-          </Button>
-        )}
+        <Button
+          type="button"
+          variant="outline"
+          size="icon-sm"
+          className="md:hidden"
+          onClick={() => props.onRemoveField(props.index)}
+        >
+          <Trash className="size-3.5 stroke-destructive" />
+          <span className="sr-only">Remove language</span>
+        </Button>
       </div>
 
       <Controller
@@ -80,18 +77,16 @@ export function EditorSectionLanguagesFormItem(
         )}
       />
 
-      {props.deletable && (
-        <Button
-          type="button"
-          variant="outline"
-          size="icon-sm"
-          className="max-md:hidden"
-          onClick={() => props.onRemoveField(props.index)}
-        >
-          <Trash className="size-3.5 stroke-destructive" />
-          <span className="sr-only">Remove language</span>
-        </Button>
-      )}
+      <Button
+        type="button"
+        variant="outline"
+        size="icon-sm"
+        className="max-md:hidden"
+        onClick={() => props.onRemoveField(props.index)}
+      >
+        <Trash className="size-3.5 stroke-destructive" />
+        <span className="sr-only">Remove language</span>
+      </Button>
     </div>
   );
 }

--- a/src/components/editor/editor-sections/ed-section-languages/ed-section-languages-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-languages/ed-section-languages-form.tsx
@@ -65,7 +65,6 @@ export function EditorSectionLanguagesForm() {
             <EditorSectionLanguagesFormItem
               key={field.id}
               control={form.control}
-              deletable={fields.length > 1}
               index={index}
               onRemoveField={remove}
             />

--- a/src/components/editor/editor-sections/ed-section-organizations/ed-section-organizations-form-item.tsx
+++ b/src/components/editor/editor-sections/ed-section-organizations/ed-section-organizations-form-item.tsx
@@ -17,7 +17,6 @@ import type { OrganizationsFormValues } from "../resume-form-adapter";
 
 interface EditorSectionOrganizationsFormItemProps {
   index: number;
-  deletable: boolean;
   control: Control<OrganizationsFormValues>;
   onRemoveField: (index: number) => void;
 }
@@ -48,17 +47,15 @@ export function EditorSectionOrganizationsFormItem(
                   {...field}
                   id={field.name}
                 />
-                {props.deletable && (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon-sm"
-                    onClick={onRemove}
-                  >
-                    <Trash className="size-3.5 stroke-destructive" />
-                    <span className="sr-only">Remove</span>
-                  </Button>
-                )}
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon-sm"
+                  onClick={onRemove}
+                >
+                  <Trash className="size-3.5 stroke-destructive" />
+                  <span className="sr-only">Remove</span>
+                </Button>
               </div>
               <FieldError errors={[fieldState.error]} />
             </Field>

--- a/src/components/editor/editor-sections/ed-section-organizations/ed-section-organizations-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-organizations/ed-section-organizations-form.tsx
@@ -76,7 +76,6 @@ export function EditorSectionOrganizationsForm() {
             <EditorSectionOrganizationsFormItem
               key={field.id}
               control={form.control}
-              deletable={fields.length > 1}
               index={index}
               onRemoveField={remove}
             />

--- a/src/components/editor/editor-sections/ed-section-skills/ed-section-skills-form-item.tsx
+++ b/src/components/editor/editor-sections/ed-section-skills/ed-section-skills-form-item.tsx
@@ -21,7 +21,6 @@ const PROFICIENCY_LEVELS = [
 
 interface EditorSectionSkillsFormItemProps {
   index: number;
-  deletable: boolean;
   control: Control<SkillsFormValues>;
   onRemoveField: (index: number) => void;
 }
@@ -43,18 +42,16 @@ export function EditorSectionSkillsFormItem(
           )}
         />
 
-        {props.deletable && (
-          <Button
-            type="button"
-            variant="outline"
-            size="icon-sm"
-            className="md:hidden"
-            onClick={() => props.onRemoveField(props.index)}
-          >
-            <Trash className="size-3.5 stroke-destructive" />
-            <span className="sr-only">Remove skill</span>
-          </Button>
-        )}
+        <Button
+          type="button"
+          variant="outline"
+          size="icon-sm"
+          className="md:hidden"
+          onClick={() => props.onRemoveField(props.index)}
+        >
+          <Trash className="size-3.5 stroke-destructive" />
+          <span className="sr-only">Remove skill</span>
+        </Button>
       </div>
 
       <Controller
@@ -79,18 +76,16 @@ export function EditorSectionSkillsFormItem(
         )}
       />
 
-      {props.deletable && (
-        <Button
-          type="button"
-          variant="outline"
-          size="icon-sm"
-          className="max-md:hidden"
-          onClick={() => props.onRemoveField(props.index)}
-        >
-          <Trash className="size-3.5 stroke-destructive" />
-          <span className="sr-only">Remove skill</span>
-        </Button>
-      )}
+      <Button
+        type="button"
+        variant="outline"
+        size="icon-sm"
+        className="max-md:hidden"
+        onClick={() => props.onRemoveField(props.index)}
+      >
+        <Trash className="size-3.5 stroke-destructive" />
+        <span className="sr-only">Remove skill</span>
+      </Button>
     </div>
   );
 }

--- a/src/components/editor/editor-sections/ed-section-skills/ed-section-skills-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-skills/ed-section-skills-form.tsx
@@ -63,7 +63,6 @@ export function EditorSectionSkillsForm() {
             <EditorSectionSkillsFormItem
               key={field.id}
               control={form.control}
-              deletable={fields.length > 1}
               index={index}
               onRemoveField={remove}
             />

--- a/src/components/editor/editor-sections/resume-form-adapter.ts
+++ b/src/components/editor/editor-sections/resume-form-adapter.ts
@@ -162,8 +162,14 @@ export function applySummaryValues(
   draft: Resume,
   values: SummaryFormValues,
 ): void {
-  const entry = sectionOfType(draft, "summary")?.entries[0];
-  if (entry) entry.fields.body = rich(values.summary);
+  const section = sectionOfType(draft, "summary");
+  if (!section) return;
+  const entry = section.entries[0];
+  if (entry) {
+    entry.fields.body = rich(values.summary);
+    return;
+  }
+  section.entries = [{ id: nanoid(), fields: { body: rich(values.summary) } }];
 }
 
 // --- Experience (repeating section entries) --------------------------------

--- a/src/components/platform/platform-resume-create-dialog.tsx
+++ b/src/components/platform/platform-resume-create-dialog.tsx
@@ -7,8 +7,8 @@ import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import {
   RESUME_TITLE_MAX_LENGTH,
-  type ResumeTitleForm,
-  resumeTitleSchema,
+  type ResumeCreateForm,
+  resumeCreateSchema,
 } from "@/lib/forms/resume";
 import { useResumeStore } from "@/lib/store";
 import { DEFAULT_TEMPLATE_ID, resolveTemplateId } from "@/lib/templates";
@@ -22,6 +22,7 @@ import {
   ResponsiveDialogTitle,
 } from "../shared/responsive-dialog";
 import { Button } from "../ui/button";
+import { Checkbox } from "../ui/checkbox";
 import {
   Field,
   FieldDescription,
@@ -53,15 +54,18 @@ export function PlatformResumeCreateDialog(
   const [templateId, setTemplateId] = useState(() =>
     resolveTemplateId(props.templateId ?? DEFAULT_TEMPLATE_ID),
   );
-  const form = useForm<ResumeTitleForm>({
-    resolver: standardSchemaResolver(resumeTitleSchema),
-    defaultValues: { title: props.initialTitle ?? "" },
+  const form = useForm<ResumeCreateForm>({
+    resolver: standardSchemaResolver(resumeCreateSchema),
+    defaultValues: { title: props.initialTitle ?? "", prefill: true },
     mode: "onChange",
   });
 
   const onSubmit = form.handleSubmit(async (values) => {
-    const resume = await createResume(values.title, templateId);
-    form.reset({ title: "" });
+    const resume = await createResume(values.title, {
+      templateId,
+      prefill: values.prefill,
+    });
+    form.reset({ title: "", prefill: true });
     props.onOpenChange(false);
     router.push(`/platform/editor/${resume.id}`);
   });
@@ -104,6 +108,28 @@ export function PlatformResumeCreateDialog(
                   </FieldDescription>
 
                   <FieldError errors={[fieldState.error]} />
+                </Field>
+              )}
+            />
+
+            <Controller
+              control={form.control}
+              name="prefill"
+              render={({ field }) => (
+                <Field orientation="horizontal">
+                  <Checkbox
+                    id="create-resume-prefill"
+                    name={field.name}
+                    checked={field.value}
+                    onCheckedChange={(checked) =>
+                      field.onChange(checked === true)
+                    }
+                    onBlur={field.onBlur}
+                    ref={field.ref}
+                  />
+                  <FieldLabel htmlFor="create-resume-prefill">
+                    Pre-fill with example content
+                  </FieldLabel>
                 </Field>
               )}
             />

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -11,6 +11,15 @@ export interface ChangelogEntry {
  */
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "0.5.0",
+    date: "2026-07-06",
+    highlights: [
+      "Switch templates without leaving the editor: the new Layout tab shows your résumé rendered in every template, and one click applies your pick.",
+      'Start from scratch when you want to: untick "Pre-fill with example content" in the create dialog to begin with a blank document instead of the example résumé.',
+      "Sections can now be emptied completely: every entry has a delete button, and removing the last one simply drops the section from the preview until you add another.",
+    ],
+  },
+  {
     version: "0.4.0",
     date: "2026-07-05",
     highlights: [

--- a/src/lib/forms/resume.ts
+++ b/src/lib/forms/resume.ts
@@ -22,3 +22,10 @@ export const resumeTitleSchema = z.object({
 });
 
 export type ResumeTitleForm = z.infer<typeof resumeTitleSchema>;
+
+/** The create dialog adds the pre-fill opt-out on top of the shared title field. */
+export const resumeCreateSchema = resumeTitleSchema.extend({
+  prefill: z.boolean(),
+});
+
+export type ResumeCreateForm = z.infer<typeof resumeCreateSchema>;

--- a/src/lib/resume/factory.ts
+++ b/src/lib/resume/factory.ts
@@ -51,7 +51,7 @@ export function createEmptySection(type: SectionType): Section {
     id: nanoid(),
     type,
     title: schema.defaultTitle,
-    entries: [createEmptyEntry(type)],
+    entries: [],
   };
 }
 
@@ -60,9 +60,9 @@ export function createEmptyHeader(): Header {
 }
 
 /**
- * A blank structural document: Header plus one empty Entry per core Section.
- * The primary create path seeds the Seed fixture instead (see seed.ts); this is
- * the deferred "blank resume" option.
+ * A blank structural document: Header plus every core Section with zero
+ * entries. Backs the create dialog's opt-out from pre-filling; the default
+ * create path seeds the Seed fixture instead (see seed.ts).
  */
 export function createEmptyResume(title: string): Resume {
   const now = new Date().toISOString();

--- a/src/lib/store/resume-store.ts
+++ b/src/lib/store/resume-store.ts
@@ -9,6 +9,7 @@ import {
 } from "@/lib/db";
 import {
   cloneResumeAsNew,
+  createEmptyResume,
   type Resume,
   type ResumeIndexEntry,
   SEED_RESUME,
@@ -22,6 +23,12 @@ import {
 type IndexStatus = "idle" | "loading" | "ready" | "error";
 type OpenStatus = "idle" | "loading" | "ready" | "missing";
 
+interface CreateResumeOptions {
+  templateId?: string;
+  /** Seed the document with the example content; false starts blank. */
+  prefill?: boolean;
+}
+
 interface ResumeStoreState {
   /** The lightweight Library list, newest first. Not the full document bodies. */
   index: readonly ResumeIndexEntry[];
@@ -33,7 +40,10 @@ interface ResumeStoreState {
   openStatus: OpenStatus;
 
   hydrateIndex: () => Promise<void>;
-  createResume: (title: string, templateId?: string) => Promise<Resume>;
+  createResume: (
+    title: string,
+    options?: CreateResumeOptions,
+  ) => Promise<Resume>;
   renameResume: (id: string, title: string) => Promise<void>;
   duplicateResume: (id: string) => Promise<Resume | undefined>;
   removeResume: (id: string) => Promise<void>;
@@ -83,9 +93,12 @@ export const useResumeStore = create<ResumeStoreState>()((set, get) => ({
     }
   },
 
-  async createResume(title, templateId) {
-    const resume = cloneResumeAsNew(SEED_RESUME, S.trim(title));
-    if (templateId) resume.templateId = templateId;
+  async createResume(title, options) {
+    const resume =
+      options?.prefill === false
+        ? createEmptyResume(S.trim(title))
+        : cloneResumeAsNew(SEED_RESUME, S.trim(title));
+    if (options?.templateId) resume.templateId = options.templateId;
     await putResume(resume);
     await setLastOpenedResumeId(resume.id);
     set((state) => ({


### PR DESCRIPTION
The create dialog now shows a "Pre-fill with example content" checkbox directly under the label field, ticked by default and validated through the form schema (`resumeCreateSchema` extends the shared title schema with `prefill`). Leaving it ticked keeps today's behavior of cloning the seed fixture; unticking it creates a truly blank document via `createEmptyResume`, whose sections now start with zero entries. The store's `createResume` takes an options object (`templateId`, `prefill`) instead of a bare template id.

Blank documents change what the section forms must tolerate, so the field arrays now support empty state: the `deletable` gating that forced every list to keep at least one entry is removed, every entry shows its delete button, and a list deleted to zero leaves just the section's add button, with the section dropping out of the preview. The summary adapter creates its entry on first write, since a blank document has no summary entry to update and typing would otherwise be silently dropped.

One editor follow-up: the layout tab's template tiles fall back to the seed preview whenever the document renders nothing beyond the header, so the six templates stay visually comparable instead of showing near-identical blank pages.

Tested by driving both create paths: the checkbox defaults to ticked and the default path still produces the seeded document; unticking produces a blank editor where the experience section opens with zero entries, an added entry can be removed back to zero, and typed summary text reaches the preview. On a seeded resume, all skills can be deleted down to zero and the section disappears from the preview. Blank documents show fully populated template tiles in the layout tab, and adding a single summary line switches the tiles to the document's own content.