### PR TITLE
chore: group release-please notes into readable sections

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,19 @@
   "bump-minor-pre-major": false,
   "bump-patch-for-minor-pre-major": false,
   "include-component-in-tag": false,
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "perf", "section": "Performance" },
+    { "type": "refactor", "section": "Refactors" },
+    { "type": "revert", "section": "Reverts" },
+    { "type": "docs", "section": "Documentation" },
+    { "type": "style", "section": "Styles", "hidden": true },
+    { "type": "chore", "section": "Chores", "hidden": true },
+    { "type": "test", "section": "Tests", "hidden": true },
+    { "type": "build", "section": "Build", "hidden": true },
+    { "type": "ci", "section": "CI", "hidden": true }
+  ],
   "packages": {
     ".": {}
   }


### PR DESCRIPTION
Configures release-please to generate grouped, dev-readable release notes instead of the sparse default. Commits are now grouped under named sections in both the GitHub Release body and CHANGELOG.md.

Shown sections: Features, Bug Fixes, Performance, Refactors, Reverts, Documentation. The style/chore/test/build/ci types stay hidden from the notes but still count toward the semver version bump, so nothing is lost from version reasoning. Section content is driven by the existing commitlint/commitizen conventional commit format (type drives the section, scope becomes the bold prefix).

No workflow change needed; release.yml already runs release-please-action@v5.

Verified the release-please option names (changelog-sections, hidden) against the current release-please docs and confirmed the config is schema-valid. The output renders on the next release PR release-please opens against main.