### PR TITLE
feat: reorder skills and languages by drag and drop

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.4.0",
     "@mobily/ts-belt": "4.0.0-rc.5",
     "@opennextjs/cloudflare": "^1.20.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,15 @@ importers:
       '@base-ui/react':
         specifier: ^1.6.0
         version: 1.6.0(@date-fns/tz@1.5.0)(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
       '@hookform/resolvers':
         specifier: ^5.4.0
         version: 5.4.0(react-hook-form@7.80.0(react@19.2.4))
@@ -810,6 +819,28 @@ packages:
 
   '@date-fns/tz@1.5.0':
     resolution: {integrity: sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@dotenvx/dotenvx@1.31.0':
     resolution: {integrity: sha512-GeDxvtjiRuoyWVU9nQneId879zIyNdL05bS7RKiqMkfBSKpHMWHLoRyRqjYWLaXmX/llKO1hTlqHDmatkQAjPA==}
@@ -5838,6 +5869,31 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.9
 
   '@date-fns/tz@1.5.0': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
 
   '@dotenvx/dotenvx@1.31.0':
     dependencies:

--- a/src/components/editor/editor-sections/ed-section-languages/ed-section-languages-form-item.tsx
+++ b/src/components/editor/editor-sections/ed-section-languages/ed-section-languages-form-item.tsx
@@ -1,5 +1,6 @@
 import { Trash } from "lucide-react";
 import { type Control, Controller } from "react-hook-form";
+import { SortableItem } from "@/components/shared/sortable-list";
 import { Button } from "@/components/ui/button";
 import { Field, FieldError } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
@@ -21,6 +22,7 @@ const LANGUAGE_LEVELS = [
 ] as const;
 
 interface EditorSectionLanguagesFormItemProps {
+  id: string;
   index: number;
   control: Control<LanguagesFormValues>;
   onRemoveField: (index: number) => void;
@@ -30,16 +32,51 @@ export function EditorSectionLanguagesFormItem(
   props: EditorSectionLanguagesFormItemProps,
 ) {
   return (
-    <div className="flex flex-col md:flex-row md:items-center gap-2">
-      <div className="flex items-center gap-2">
+    <SortableItem id={props.id} handleLabel="Reorder language">
+      <div className="flex flex-col md:flex-row md:items-center gap-2">
+        <div className="flex items-center gap-2">
+          <Controller
+            control={props.control}
+            name={`languages.${props.index}.name`}
+            render={({ field, fieldState }) => (
+              <Field className="flex-1">
+                <Input placeholder="English" {...field} id={field.name} />
+                <FieldError errors={[fieldState.error]} />
+              </Field>
+            )}
+          />
+
+          <Button
+            type="button"
+            variant="outline"
+            size="icon-sm"
+            className="md:hidden"
+            onClick={() => props.onRemoveField(props.index)}
+          >
+            <Trash className="size-3.5 stroke-destructive" />
+            <span className="sr-only">Remove language</span>
+          </Button>
+        </div>
+
         <Controller
           control={props.control}
-          name={`languages.${props.index}.name`}
-          render={({ field, fieldState }) => (
-            <Field className="flex-1">
-              <Input placeholder="English" {...field} id={field.name} />
-              <FieldError errors={[fieldState.error]} />
-            </Field>
+          name={`languages.${props.index}.level`}
+          render={({ field }) => (
+            <Select
+              value={field.value || null}
+              onValueChange={(value) => field.onChange(value)}
+            >
+              <SelectTrigger className="w-[87.888%] md:w-40">
+                <SelectValue placeholder="Proficiency" />
+              </SelectTrigger>
+              <SelectContent>
+                {LANGUAGE_LEVELS.map((level) => (
+                  <SelectItem key={level} value={level}>
+                    {level}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           )}
         />
 
@@ -47,46 +84,13 @@ export function EditorSectionLanguagesFormItem(
           type="button"
           variant="outline"
           size="icon-sm"
-          className="md:hidden"
+          className="max-md:hidden"
           onClick={() => props.onRemoveField(props.index)}
         >
           <Trash className="size-3.5 stroke-destructive" />
           <span className="sr-only">Remove language</span>
         </Button>
       </div>
-
-      <Controller
-        control={props.control}
-        name={`languages.${props.index}.level`}
-        render={({ field }) => (
-          <Select
-            value={field.value || null}
-            onValueChange={(value) => field.onChange(value)}
-          >
-            <SelectTrigger className="w-[87.888%] md:w-40">
-              <SelectValue placeholder="Proficiency" />
-            </SelectTrigger>
-            <SelectContent>
-              {LANGUAGE_LEVELS.map((level) => (
-                <SelectItem key={level} value={level}>
-                  {level}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        )}
-      />
-
-      <Button
-        type="button"
-        variant="outline"
-        size="icon-sm"
-        className="max-md:hidden"
-        onClick={() => props.onRemoveField(props.index)}
-      >
-        <Trash className="size-3.5 stroke-destructive" />
-        <span className="sr-only">Remove language</span>
-      </Button>
-    </div>
+    </SortableItem>
   );
 }

--- a/src/components/editor/editor-sections/ed-section-languages/ed-section-languages-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-languages/ed-section-languages-form.tsx
@@ -3,6 +3,7 @@
 import { Plus } from "lucide-react";
 import { useEffect } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
+import { SortableList } from "@/components/shared/sortable-list";
 import { Button } from "@/components/ui/button";
 import {
   FieldDescription,
@@ -30,7 +31,7 @@ export function EditorSectionLanguagesForm() {
   const form = useForm<LanguagesFormValues>({
     defaultValues: open ? toLanguagesValues(open) : { languages: [] },
   });
-  const { fields, prepend, remove } = useFieldArray({
+  const { fields, prepend, remove, move } = useFieldArray({
     control: form.control,
     name: "languages",
   });
@@ -41,6 +42,11 @@ export function EditorSectionLanguagesForm() {
     });
     return () => subscription.unsubscribe();
   }, [form, updateOpen]);
+
+  function handleReorder(from: number, to: number) {
+    move(from, to);
+    updateOpen((draft) => applyLanguagesValues(draft, form.getValues()));
+  }
 
   if (!open) return null;
 
@@ -60,16 +66,22 @@ export function EditorSectionLanguagesForm() {
           <Plus /> Add Language
         </Button>
 
-        <FieldGroup className="gap-2">
-          {fields.map((field, index) => (
-            <EditorSectionLanguagesFormItem
-              key={field.id}
-              control={form.control}
-              index={index}
-              onRemoveField={remove}
-            />
-          ))}
-        </FieldGroup>
+        <SortableList
+          items={fields.map((field) => field.id)}
+          onReorder={handleReorder}
+        >
+          <FieldGroup className="gap-2">
+            {fields.map((field, index) => (
+              <EditorSectionLanguagesFormItem
+                key={field.id}
+                id={field.id}
+                control={form.control}
+                index={index}
+                onRemoveField={remove}
+              />
+            ))}
+          </FieldGroup>
+        </SortableList>
       </FieldSet>
     </form>
   );

--- a/src/components/editor/editor-sections/ed-section-skills/ed-section-skills-form-item.tsx
+++ b/src/components/editor/editor-sections/ed-section-skills/ed-section-skills-form-item.tsx
@@ -1,5 +1,6 @@
 import { Trash } from "lucide-react";
 import { type Control, Controller } from "react-hook-form";
+import { SortableItem } from "@/components/shared/sortable-list";
 import { Button } from "@/components/ui/button";
 import { Field, FieldError } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
@@ -20,6 +21,7 @@ const PROFICIENCY_LEVELS = [
 ] as const;
 
 interface EditorSectionSkillsFormItemProps {
+  id: string;
   index: number;
   control: Control<SkillsFormValues>;
   onRemoveField: (index: number) => void;
@@ -29,16 +31,51 @@ export function EditorSectionSkillsFormItem(
   props: EditorSectionSkillsFormItemProps,
 ) {
   return (
-    <div className="flex flex-col md:flex-row md:items-center gap-2">
-      <div className="flex items-center gap-2">
+    <SortableItem id={props.id} handleLabel="Reorder skill">
+      <div className="flex flex-col md:flex-row md:items-center gap-2">
+        <div className="flex items-center gap-2">
+          <Controller
+            control={props.control}
+            name={`skills.${props.index}.name`}
+            render={({ field, fieldState }) => (
+              <Field className="flex-1">
+                <Input placeholder="TypeScript" {...field} id={field.name} />
+                <FieldError errors={[fieldState.error]} />
+              </Field>
+            )}
+          />
+
+          <Button
+            type="button"
+            variant="outline"
+            size="icon-sm"
+            className="md:hidden"
+            onClick={() => props.onRemoveField(props.index)}
+          >
+            <Trash className="size-3.5 stroke-destructive" />
+            <span className="sr-only">Remove skill</span>
+          </Button>
+        </div>
+
         <Controller
           control={props.control}
-          name={`skills.${props.index}.name`}
-          render={({ field, fieldState }) => (
-            <Field className="flex-1">
-              <Input placeholder="TypeScript" {...field} id={field.name} />
-              <FieldError errors={[fieldState.error]} />
-            </Field>
+          name={`skills.${props.index}.level`}
+          render={({ field }) => (
+            <Select
+              value={field.value || null}
+              onValueChange={(value) => field.onChange(value)}
+            >
+              <SelectTrigger className="w-[87.888%] md:w-36">
+                <SelectValue placeholder="Proficiency" />
+              </SelectTrigger>
+              <SelectContent>
+                {PROFICIENCY_LEVELS.map((level) => (
+                  <SelectItem key={level} value={level}>
+                    {level}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           )}
         />
 
@@ -46,46 +83,13 @@ export function EditorSectionSkillsFormItem(
           type="button"
           variant="outline"
           size="icon-sm"
-          className="md:hidden"
+          className="max-md:hidden"
           onClick={() => props.onRemoveField(props.index)}
         >
           <Trash className="size-3.5 stroke-destructive" />
           <span className="sr-only">Remove skill</span>
         </Button>
       </div>
-
-      <Controller
-        control={props.control}
-        name={`skills.${props.index}.level`}
-        render={({ field }) => (
-          <Select
-            value={field.value || null}
-            onValueChange={(value) => field.onChange(value)}
-          >
-            <SelectTrigger className="w-[87.888%] md:w-36">
-              <SelectValue placeholder="Proficiency" />
-            </SelectTrigger>
-            <SelectContent>
-              {PROFICIENCY_LEVELS.map((level) => (
-                <SelectItem key={level} value={level}>
-                  {level}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        )}
-      />
-
-      <Button
-        type="button"
-        variant="outline"
-        size="icon-sm"
-        className="max-md:hidden"
-        onClick={() => props.onRemoveField(props.index)}
-      >
-        <Trash className="size-3.5 stroke-destructive" />
-        <span className="sr-only">Remove skill</span>
-      </Button>
-    </div>
+    </SortableItem>
   );
 }

--- a/src/components/editor/editor-sections/ed-section-skills/ed-section-skills-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-skills/ed-section-skills-form.tsx
@@ -3,6 +3,7 @@
 import { Plus } from "lucide-react";
 import { useEffect } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
+import { SortableList } from "@/components/shared/sortable-list";
 import { Button } from "@/components/ui/button";
 import {
   FieldDescription,
@@ -30,7 +31,7 @@ export function EditorSectionSkillsForm() {
   const form = useForm<SkillsFormValues>({
     defaultValues: open ? toSkillsValues(open) : { skills: [] },
   });
-  const { fields, prepend, remove } = useFieldArray({
+  const { fields, prepend, remove, move } = useFieldArray({
     control: form.control,
     name: "skills",
   });
@@ -41,6 +42,11 @@ export function EditorSectionSkillsForm() {
     });
     return () => subscription.unsubscribe();
   }, [form, updateOpen]);
+
+  function handleReorder(from: number, to: number) {
+    move(from, to);
+    updateOpen((draft) => applySkillsValues(draft, form.getValues()));
+  }
 
   return (
     <form>
@@ -58,16 +64,22 @@ export function EditorSectionSkillsForm() {
           <Plus /> Add Skill
         </Button>
 
-        <FieldGroup className="gap-2">
-          {fields.map((field, index) => (
-            <EditorSectionSkillsFormItem
-              key={field.id}
-              control={form.control}
-              index={index}
-              onRemoveField={remove}
-            />
-          ))}
-        </FieldGroup>
+        <SortableList
+          items={fields.map((field) => field.id)}
+          onReorder={handleReorder}
+        >
+          <FieldGroup className="gap-2">
+            {fields.map((field, index) => (
+              <EditorSectionSkillsFormItem
+                key={field.id}
+                id={field.id}
+                control={form.control}
+                index={index}
+                onRemoveField={remove}
+              />
+            ))}
+          </FieldGroup>
+        </SortableList>
       </FieldSet>
     </form>
   );

--- a/src/components/shared/sortable-list.tsx
+++ b/src/components/shared/sortable-list.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVertical } from "lucide-react";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+interface SortableListProps {
+  items: string[];
+  onReorder: (from: number, to: number) => void;
+  children: ReactNode;
+}
+
+export function SortableList(props: SortableListProps) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const from = props.items.indexOf(String(active.id));
+    const to = props.items.indexOf(String(over.id));
+    if (from === -1 || to === -1) return;
+    props.onReorder(from, to);
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext
+        items={props.items}
+        strategy={verticalListSortingStrategy}
+      >
+        {props.children}
+      </SortableContext>
+    </DndContext>
+  );
+}
+
+interface SortableItemProps {
+  id: string;
+  handleLabel: string;
+  children: ReactNode;
+}
+
+export function SortableItem(props: SortableItemProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: props.id });
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={cn(
+        "flex items-start gap-2 md:items-center",
+        isDragging && "relative z-10 opacity-60",
+      )}
+    >
+      <button
+        type="button"
+        className="mt-1.5 flex size-8 shrink-0 touch-none items-center justify-center rounded-md text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring md:mt-0 cursor-grab active:cursor-grabbing"
+        aria-label={props.handleLabel}
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="size-4" />
+      </button>
+      <div className="flex-1">{props.children}</div>
+    </div>
+  );
+}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -11,6 +11,13 @@ export interface ChangelogEntry {
  */
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "0.6.0",
+    date: "2026-07-08",
+    highlights: [
+      "Reorder your skills and languages: grab the handle next to an entry and drag it into place, or use the keyboard to move it. The new order flows straight into the preview and every export.",
+    ],
+  },
+  {
     version: "0.5.0",
     date: "2026-07-06",
     highlights: [


### PR DESCRIPTION
Closes #59.

Adds drag-and-drop and keyboard reordering to the Skills and Languages editor lists. A new shared `SortableList`/`SortableItem` primitive (`src/components/shared/sortable-list.tsx`) wraps dnd-kit: it owns the `DndContext`, sensors, and `SortableContext`, exposes an `onReorder(from, to)` callback, and renders a leading grip handle on each row. Each form supplies its field-array ids and calls `useFieldArray.move` in `onReorder`, then writes the reordered values to the store through the existing `applySkillsValues` / `applyLanguagesValues` adapters. Reordering only permutes the section's `entries` array, so there is no schema, migration, or storage change; entry order already drives the preview and every export.

Sensors cover pointer (with an 8px activation constraint so mobile scrolling survives), keyboard (Space to pick up, arrows to move, Space to drop), and dnd-kit's default screen-reader announcements. Whole-row dragging is not possible since rows contain a text input and a select, so the grip is a dedicated handle. Adding a new item still prepends it to the top, directly under the Add button.

The primitive is deliberately general so the other list sections (Experience, Education, Certifications, Organizations) can adopt it in a follow-up; this PR wires only Skills and Languages, matching the issue.

Verified by creating a seeded résumé and driving the editor: reordered Skills by both keyboard and mouse drag and confirmed the live preview reordered to match, reordered Languages by keyboard, and confirmed a newly added skill still appears at the top with the existing order preserved.