### PR TITLE
feat: show an empty state in editor sections with no entries

### DIFF
--- a/src/components/editor/editor-sections/ed-section-certifications/ed-section-certifications-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-certifications/ed-section-certifications-form.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { Plus } from "lucide-react";
+import { Award, Plus } from "lucide-react";
 import { useEffect } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
+import { EmptyState } from "@/components/shared/empty-state";
 import { Button } from "@/components/ui/button";
 import {
   FieldDescription,
@@ -60,16 +61,24 @@ export function EditorSectionCertificationsForm() {
           <Plus /> Add Certification
         </Button>
 
-        <FieldGroup className="gap-4">
-          {fields.map((field, index) => (
-            <EditorSectionCertificationsFormItem
-              key={field.id}
-              control={form.control}
-              index={index}
-              onRemoveField={remove}
-            />
-          ))}
-        </FieldGroup>
+        {fields.length === 0 ? (
+          <EmptyState
+            icon={Award}
+            title="No certifications yet"
+            description="Add licenses and certifications you've earned."
+          />
+        ) : (
+          <FieldGroup className="gap-4">
+            {fields.map((field, index) => (
+              <EditorSectionCertificationsFormItem
+                key={field.id}
+                control={form.control}
+                index={index}
+                onRemoveField={remove}
+              />
+            ))}
+          </FieldGroup>
+        )}
       </FieldSet>
     </form>
   );

--- a/src/components/editor/editor-sections/ed-section-education/ed-section-education-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-education/ed-section-education-form.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { Plus } from "lucide-react";
+import { GraduationCap, Plus } from "lucide-react";
 import { useEffect } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
+import { EmptyState } from "@/components/shared/empty-state";
 import { Button } from "@/components/ui/button";
 import {
   FieldDescription,
@@ -68,16 +69,24 @@ export function EditorSectionEducationForm() {
           <Plus /> Add Education
         </Button>
 
-        <FieldGroup className="gap-4">
-          {fields.map((field, index) => (
-            <EditorSectionEducationFormItem
-              key={field.id}
-              control={form.control}
-              index={index}
-              onRemoveField={remove}
-            />
-          ))}
-        </FieldGroup>
+        {fields.length === 0 ? (
+          <EmptyState
+            icon={GraduationCap}
+            title="No education yet"
+            description="Add your degrees, schools, and courses."
+          />
+        ) : (
+          <FieldGroup className="gap-4">
+            {fields.map((field, index) => (
+              <EditorSectionEducationFormItem
+                key={field.id}
+                control={form.control}
+                index={index}
+                onRemoveField={remove}
+              />
+            ))}
+          </FieldGroup>
+        )}
       </FieldSet>
     </form>
   );

--- a/src/components/editor/editor-sections/ed-section-experience/ed-section-experience-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-experience/ed-section-experience-form.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { Plus } from "lucide-react";
+import { Briefcase, Plus } from "lucide-react";
 import { useEffect } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
+import { EmptyState } from "@/components/shared/empty-state";
 import { Button } from "@/components/ui/button";
 import {
   FieldDescription,
@@ -72,16 +73,24 @@ export function EditorSectionExperienceForm() {
           <Plus /> Add Professional Experience
         </Button>
 
-        <FieldGroup className="gap-4">
-          {fields.map((field, index) => (
-            <EditorSectionExperienceFormItem
-              key={field.id}
-              control={form.control}
-              index={index}
-              onRemoveField={remove}
-            />
-          ))}
-        </FieldGroup>
+        {fields.length === 0 ? (
+          <EmptyState
+            icon={Briefcase}
+            title="No experience yet"
+            description="Add your roles to build out your work history."
+          />
+        ) : (
+          <FieldGroup className="gap-4">
+            {fields.map((field, index) => (
+              <EditorSectionExperienceFormItem
+                key={field.id}
+                control={form.control}
+                index={index}
+                onRemoveField={remove}
+              />
+            ))}
+          </FieldGroup>
+        )}
       </FieldSet>
     </form>
   );

--- a/src/components/editor/editor-sections/ed-section-languages/ed-section-languages-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-languages/ed-section-languages-form.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { Plus } from "lucide-react";
+import { Languages, Plus } from "lucide-react";
 import { useEffect } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
+import { EmptyState } from "@/components/shared/empty-state";
 import { SortableList } from "@/components/shared/sortable-list";
 import { Button } from "@/components/ui/button";
 import {
@@ -66,22 +67,30 @@ export function EditorSectionLanguagesForm() {
           <Plus /> Add Language
         </Button>
 
-        <SortableList
-          items={fields.map((field) => field.id)}
-          onReorder={handleReorder}
-        >
-          <FieldGroup className="gap-2">
-            {fields.map((field, index) => (
-              <EditorSectionLanguagesFormItem
-                key={field.id}
-                id={field.id}
-                control={form.control}
-                index={index}
-                onRemoveField={remove}
-              />
-            ))}
-          </FieldGroup>
-        </SortableList>
+        {fields.length === 0 ? (
+          <EmptyState
+            icon={Languages}
+            title="No languages yet"
+            description="Add the languages you speak and your proficiency."
+          />
+        ) : (
+          <SortableList
+            items={fields.map((field) => field.id)}
+            onReorder={handleReorder}
+          >
+            <FieldGroup className="gap-2">
+              {fields.map((field, index) => (
+                <EditorSectionLanguagesFormItem
+                  key={field.id}
+                  id={field.id}
+                  control={form.control}
+                  index={index}
+                  onRemoveField={remove}
+                />
+              ))}
+            </FieldGroup>
+          </SortableList>
+        )}
       </FieldSet>
     </form>
   );

--- a/src/components/editor/editor-sections/ed-section-organizations/ed-section-organizations-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-organizations/ed-section-organizations-form.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { Plus } from "lucide-react";
+import { Plus, Users } from "lucide-react";
 import { useEffect } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
+import { EmptyState } from "@/components/shared/empty-state";
 import { Button } from "@/components/ui/button";
 import {
   FieldDescription,
@@ -71,16 +72,24 @@ export function EditorSectionOrganizationsForm() {
           <Plus /> Add Organization Experience
         </Button>
 
-        <FieldGroup className="gap-4">
-          {fields.map((field, index) => (
-            <EditorSectionOrganizationsFormItem
-              key={field.id}
-              control={form.control}
-              index={index}
-              onRemoveField={remove}
-            />
-          ))}
-        </FieldGroup>
+        {fields.length === 0 ? (
+          <EmptyState
+            icon={Users}
+            title="No organizations yet"
+            description="Add volunteer, student, or community roles here."
+          />
+        ) : (
+          <FieldGroup className="gap-4">
+            {fields.map((field, index) => (
+              <EditorSectionOrganizationsFormItem
+                key={field.id}
+                control={form.control}
+                index={index}
+                onRemoveField={remove}
+              />
+            ))}
+          </FieldGroup>
+        )}
       </FieldSet>
     </form>
   );

--- a/src/components/editor/editor-sections/ed-section-skills/ed-section-skills-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-skills/ed-section-skills-form.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { Plus } from "lucide-react";
+import { Plus, Zap } from "lucide-react";
 import { useEffect } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
+import { EmptyState } from "@/components/shared/empty-state";
 import { SortableList } from "@/components/shared/sortable-list";
 import { Button } from "@/components/ui/button";
 import {
@@ -64,22 +65,30 @@ export function EditorSectionSkillsForm() {
           <Plus /> Add Skill
         </Button>
 
-        <SortableList
-          items={fields.map((field) => field.id)}
-          onReorder={handleReorder}
-        >
-          <FieldGroup className="gap-2">
-            {fields.map((field, index) => (
-              <EditorSectionSkillsFormItem
-                key={field.id}
-                id={field.id}
-                control={form.control}
-                index={index}
-                onRemoveField={remove}
-              />
-            ))}
-          </FieldGroup>
-        </SortableList>
+        {fields.length === 0 ? (
+          <EmptyState
+            icon={Zap}
+            title="No skills yet"
+            description="Add the tools and technologies you work with."
+          />
+        ) : (
+          <SortableList
+            items={fields.map((field) => field.id)}
+            onReorder={handleReorder}
+          >
+            <FieldGroup className="gap-2">
+              {fields.map((field, index) => (
+                <EditorSectionSkillsFormItem
+                  key={field.id}
+                  id={field.id}
+                  control={form.control}
+                  index={index}
+                  onRemoveField={remove}
+                />
+              ))}
+            </FieldGroup>
+          </SortableList>
+        )}
       </FieldSet>
     </form>
   );

--- a/src/components/shared/empty-state.tsx
+++ b/src/components/shared/empty-state.tsx
@@ -1,0 +1,37 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+
+interface EmptyStateProps {
+  title: string;
+  description: string;
+  icon?: LucideIcon;
+}
+
+export function EmptyState({
+  title,
+  description,
+  icon: Icon,
+}: EmptyStateProps) {
+  return (
+    <Empty className="gap-1.5 rounded-lg border px-4 py-5">
+      <EmptyHeader className="gap-1">
+        {Icon ? (
+          <EmptyMedia
+            variant="icon"
+            className="mb-1 size-8 rounded-lg [&_svg:not([class*='size-'])]:size-4"
+          >
+            <Icon />
+          </EmptyMedia>
+        ) : null}
+        <EmptyTitle className="text-sm font-medium">{title}</EmptyTitle>
+        <EmptyDescription className="text-xs">{description}</EmptyDescription>
+      </EmptyHeader>
+    </Empty>
+  );
+}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -15,6 +15,7 @@ export const CHANGELOG: ChangelogEntry[] = [
     date: "2026-07-08",
     highlights: [
       "Reorder your skills and languages: grab the handle next to an entry and drag it into place, or use the keyboard to move it. The new order flows straight into the preview and every export.",
+      "Empty sections now tell you so: instead of a lone button, each section without entries shows a short prompt for what to add.",
     ],
   },
   {


### PR DESCRIPTION
Sections with no entries previously showed only their Add button, leaving an ambiguous blank. This adds a reusable `EmptyState` component (`src/components/shared/empty-state.tsx`) that composes the existing shadcn `Empty` primitives and takes a `title`, a `description`, and an optional `icon`. It is deliberately compact so it reads as an inline hint sized to the editor panel rather than a full-page empty state.

All six list sections render it when their field array is empty, each with its own section icon and a short prompt: Experience, Organizations, Education, Certifications, Skills, and Languages. Skills and Languages swap it in place of the sortable list when empty, so the existing reorder wiring is untouched. Adding the first entry replaces the prompt with the list; deleting the last entry brings it back.

Verified by creating a blank résumé and stepping through the sections: each empty section shows its prompt, adding a skill replaces it with an editable row and its drag handle, and removing that row restores the prompt.