### PR TITLE
fix: contain editor sidebar scrolling within its own panel

### DIFF
--- a/src/components/editor/editor-layout/ed-layout-template-list.tsx
+++ b/src/components/editor/editor-layout/ed-layout-template-list.tsx
@@ -43,22 +43,24 @@ export function EditorLayoutTemplateList() {
   }
 
   return (
-    <RadioGroup
-      value={resolveTemplateId(open.templateId)}
-      onValueChange={(value) => {
-        updateOpen((draft) => {
-          draft.templateId = value as string;
-        });
-      }}
-      className="grid grid-cols-2 gap-3 px-4"
-    >
-      {TEMPLATES.map((template) => (
-        <EditorLayoutTemplateItem
-          key={template.id}
-          template={template}
-          preview={preview}
-        />
-      ))}
-    </RadioGroup>
+    <div className="pb-4 lg:pb-6">
+      <RadioGroup
+        value={resolveTemplateId(open.templateId)}
+        onValueChange={(value) => {
+          updateOpen((draft) => {
+            draft.templateId = value as string;
+          });
+        }}
+        className="grid grid-cols-2 gap-3 px-4"
+      >
+        {TEMPLATES.map((template) => (
+          <EditorLayoutTemplateItem
+            key={template.id}
+            template={template}
+            preview={preview}
+          />
+        ))}
+      </RadioGroup>
+    </div>
   );
 }

--- a/src/components/editor/editor-panels.tsx
+++ b/src/components/editor/editor-panels.tsx
@@ -21,7 +21,7 @@ export function EditorPanels(props: { children: ReactNode }) {
   if (isDesktop) {
     return (
       <div className={PANELS_CONTAINER}>
-        <ResizablePanelGroup>
+        <ResizablePanelGroup style={{ overflow: "hidden" }}>
           <ResizablePanel defaultSize="68%" minSize="40%" maxSize="72%">
             <EditorPreviewScroll>{props.children}</EditorPreviewScroll>
           </ResizablePanel>

--- a/src/components/editor/editor-sheet.tsx
+++ b/src/components/editor/editor-sheet.tsx
@@ -35,7 +35,7 @@ export function EditorSheet() {
           <SheetTitle>Editor</SheetTitle>
           <SheetDescription>Resume Editor</SheetDescription>
         </SheetHeader>
-        <div className="min-h-0 flex-1">
+        <div className="flex-1">
           <EditorSidebarContent />
         </div>
       </SheetContent>

--- a/src/components/editor/editor-sidebar-content.tsx
+++ b/src/components/editor/editor-sidebar-content.tsx
@@ -21,8 +21,8 @@ export function EditorSidebarContent() {
   const onTabChange = (next: string) => setTab(next);
 
   return (
-    <div className="flex h-full flex-col py-6">
-      <Tabs className="min-h-0 flex-1" value={tab} onValueChange={onTabChange}>
+    <div className="flex flex-col py-6">
+      <Tabs value={tab} onValueChange={onTabChange}>
         <div className="shrink-0 px-4">
           <TabsList>
             {TABS.map((t) => (
@@ -33,15 +33,23 @@ export function EditorSidebarContent() {
           </TabsList>
         </div>
 
-        <ScrollArea id="tour-editor-sections" className="min-h-0 flex-1">
-          <TabsContent value="editor">
+        <TabsContent value="editor">
+          <ScrollArea
+            id="tour-editor-sections"
+            className="h-[calc(100vh-4.126rem)] xl:h-[calc(100vh-7rem)]"
+          >
             <EditorSectionList />
-          </TabsContent>
+          </ScrollArea>
+        </TabsContent>
 
-          <TabsContent value="layout" className="py-4">
+        <TabsContent value="layout">
+          <ScrollArea
+            id="tour-editor-sections"
+            className="h-[calc(100vh-4.126rem)] xl:h-[calc(100vh-7rem)]"
+          >
             <EditorLayoutTemplateList />
-          </TabsContent>
-        </ScrollArea>
+          </ScrollArea>
+        </TabsContent>
       </Tabs>
     </div>
   );

--- a/src/components/editor/editor-sidebar.tsx
+++ b/src/components/editor/editor-sidebar.tsx
@@ -12,6 +12,7 @@ export function EditorSidebar() {
       defaultSize={open ? "36%" : "38%"}
       minSize={open ? "28%" : "30%"}
       maxSize="40%"
+      style={{ maxHeight: "auto", height: "auto", overflow: "hidden" }}
     >
       <EditorSidebarContent />
     </ResizablePanel>


### PR DESCRIPTION
The editor sidebar's scroll region was tied to the panel flex height, which left the section list scrolling awkwardly and leaving dead space in the resizable layout. This moves the `ScrollArea` inside each tab's content and gives it an explicit bounded height (`calc(100vh-4.126rem)`, `calc(100vh-7rem)` at xl), so the section list and the layout template list each scroll within their own region. The resizable panel group and sidebar panel get explicit overflow handling so the scroll stays contained, and the layout template list picks up bottom padding so its last row isn't flush against the edge.

Verified in the editor: the section list scrolls within the sidebar without spilling into the preview panel, both the Editor and Layout tabs scroll independently, and the mobile sheet still renders the same content.