### PR TITLE
style: recolor landing hero heading gradient

### DIFF
--- a/src/components/landing/landing-hero.tsx
+++ b/src/components/landing/landing-hero.tsx
@@ -46,7 +46,7 @@ export function LandingHero() {
 
       <motion.h1
         variants={itemVariants}
-        className="mb-4 text-4xl leading-[1.08] font-bold tracking-tight sm:text-5xl md:mb-6 md:text-6xl lg:text-7xl bg-linear-to-r from-primary to-violet-800 bg-clip-text text-transparent"
+        className="mb-4 text-4xl leading-[1.08] font-bold tracking-tight sm:text-5xl md:mb-6 md:text-6xl lg:text-7xl bg-linear-to-r from-primary to-sky-800 bg-clip-text text-transparent dark:from-emerald-200 dark:to-cyan-400"
       >
         <span className="sr-only">Lanjut, ATS Resume builder:</span> Land The
         Interview,


### PR DESCRIPTION
Recolors the gradient on the landing hero heading. In light mode the gradient now runs from the primary color to `sky-800` instead of `violet-800`, and a dedicated dark-mode gradient is added running from `emerald-200` to `cyan-400` so the heading reads well against the dark background.