### PR TITLE
chore: add contributor infrastructure and dco enforcement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Every path requires a maintainer review until the maintainer group grows.
+* @rimzzlabs

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,8 +15,10 @@ Closes #
 
 ## Checklist
 
+- [ ] Every commit is signed off (`git commit -s`), certifying the [DCO](https://developercertificate.org/); the DCO check rejects unsigned commits (see [CONTRIBUTING.md](../CONTRIBUTING.md)).
 - [ ] The PR title follows the commitlint convention (`feat: ...` / `fix: ...`, subject fully lowercase — it becomes the squash-merge commit).
-- [ ] Lint and format pass locally (`biome check`); commits were made without `--no-verify`.
+- [ ] Lint and checks pass locally (`pnpm lint`, `pnpm validate:exports`); commits were made without `--no-verify`.
+- [ ] The linked issue is referenced above, or this change is small enough not to need one.
 - [ ] No résumé content is sent to any server, API route, or open-next function (confirm on every PR touching data flow).
 - [ ] Changes keep the structural layer intact: presentation-only styling, no tables/columns/floating elements in the document model.
 - [ ] If the export path changed: text extraction order verified (e.g. `pdftotext`) and output checked against at least one real ATS parser.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm lint
+
+      - run: pnpm validate:exports
+
+      # Same production build the release workflow runs, so open-next
+      # incompatibilities surface on the PR instead of at deploy time.
+      - run: pnpm exec opennextjs-cloudflare build

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,49 @@
+name: DCO
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  DCO:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Verify every commit is signed off by its author
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          failed=0
+          for sha in $(git rev-list --no-merges "$BASE_SHA..$HEAD_SHA"); do
+            author_name=$(git log -1 --format='%an' "$sha")
+            author_email=$(git log -1 --format='%ae' "$sha")
+            case "$author_name" in
+              *"[bot]")
+                echo "skip  $(git log -1 --format='%h %s' "$sha") (bot commit)"
+                continue
+                ;;
+            esac
+            if git log -1 --format='%(trailers:key=Signed-off-by,valueonly)' "$sha" | grep -qiF "<$author_email>"; then
+              echo "ok    $(git log -1 --format='%h %s' "$sha")"
+            else
+              echo "FAIL  $(git log -1 --format='%h %s' "$sha")"
+              echo "      missing trailer: Signed-off-by: $author_name <$author_email>"
+              failed=1
+            fi
+          done
+          if [ "$failed" -ne 0 ]; then
+            echo ""
+            echo "Every commit must carry a Signed-off-by trailer matching its author (Developer Certificate of Origin)."
+            echo "Sign off new commits with: git commit -s"
+            echo "Fix this branch with:      git rebase --signoff \$(git merge-base HEAD origin/main) && git push --force-with-lease"
+            echo "See CONTRIBUTING.md for details."
+            exit 1
+          fi

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+rimzzlabs@proton.me.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,105 @@
+# Contributing to Lanjut
+
+Thanks for helping build a free, open-source, local-first résumé builder. This document covers the mechanics of getting a change merged. For the product and architecture rules (the two-layer model, what is in and out of scope), read [AGENTS.md](AGENTS.md) first; PRs that add structural freedom to the résumé document (tables, columns, floating elements) will be declined regardless of implementation quality.
+
+## Local setup
+
+Prerequisites:
+
+- Node.js 24 or newer
+- pnpm 10 (the repo pins `pnpm@10.30.1` via the `packageManager` field, so `corepack enable` gives you the right version automatically)
+
+```sh
+git clone git@github.com:rimzzlabs/lanjut.git
+cd lanjut
+pnpm install
+pnpm dev
+```
+
+The app runs at `http://localhost:3000`. There is no backend to configure: résumé data lives in your browser's IndexedDB and never leaves it. Keep it that way; no PR may send résumé content to a server, API route, or open-next function.
+
+Useful scripts:
+
+| Script | What it does |
+| --- | --- |
+| `pnpm dev` | Start the dev server |
+| `pnpm lint` | Biome lint and format check |
+| `pnpm format` | Apply Biome formatting |
+| `pnpm validate:exports` | Validate the export pipeline |
+| `pnpm build` | Next.js production build |
+| `pnpm preview` | Build and preview the Cloudflare production bundle via open-next |
+| `pnpm commit` | Guided Commitizen commit prompt |
+
+## Branches
+
+Branch off `main` and name the branch `type/short-kebab-description`, where `type` matches the commit type of the main change:
+
+```
+feat/docx-export
+fix/sidebar-scroll-containment
+docs/schema-migration-guide
+chore/bump-tiptap
+```
+
+## Commits
+
+Every commit must satisfy two rules.
+
+**1. Conventional Commits format.** Messages follow the [Conventional Commits](https://www.conventionalcommits.org/) spec, enforced by commitlint (`@commitlint/config-conventional`). Run `pnpm commit` for a guided Commitizen prompt, or write it yourself: `type(scope): subject` with a fully lowercase subject. Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.
+
+**2. DCO sign-off.** Every commit must carry a `Signed-off-by` trailer matching the commit author. Add it with the `-s` flag:
+
+```sh
+git commit -s -m "fix: contain editor sidebar scrolling"
+```
+
+Signing off certifies the [Developer Certificate of Origin](https://developercertificate.org/): you wrote the change, or otherwise have the right to submit it under this project's license (AGPL-3.0-only). There is no CLA; the sign-off is the whole agreement. The DCO check on every pull request rejects unsigned commits.
+
+If you used `pnpm commit` and it did not add the trailer, amend afterwards with `git commit --amend -s --no-edit`. If a whole branch is missing sign-offs, fix it in one go:
+
+```sh
+git rebase --signoff main
+git push --force-with-lease
+```
+
+Husky's pre-commit hook runs lint-staged (Biome) on staged files. Do not bypass hooks with `--no-verify`.
+
+## Before opening a PR
+
+There is no automated test suite yet, so the required bar is:
+
+- `pnpm lint` passes
+- `pnpm validate:exports` passes
+- `pnpm build` succeeds
+
+CI runs all of these plus the Cloudflare production build (`opennextjs-cloudflare build`) on every PR, and all checks must be green before merge.
+
+Two areas carry extra verification duties (see [AGENTS.md](AGENTS.md) for the full requirements):
+
+- Changes to the export path: confirm PDF text-extraction order (for example with `pdftotext`) and run the output through at least one real ATS parser.
+- Changes to the résumé document shape: bump `CURRENT_SCHEMA_VERSION` and add a migration rung in the same PR (`docs/schema-migrations.md`).
+
+## Pull requests
+
+- PRs are squash-merged, and the PR title becomes the commit subject on `main`. It must therefore follow the same commitlint convention, fully lowercase; a CI check enforces this. release-please parses these subjects to build releases, so a mislabeled title mislabels the release.
+- Fill in the PR template, including the checklist.
+- One approving review from a code owner is required before merge.
+- Link the issue the PR addresses if one exists. For substantial changes, open an issue first so the approach can be discussed before you invest the work.
+
+## Releases and versioning
+
+Releases are fully automated by [release-please](https://github.com/googleapis/release-please). Do not hand-edit:
+
+- `CHANGELOG.md`
+- `version` in `package.json`
+- `.release-please-manifest.json`
+
+The bot derives version bumps and changelog entries from the conventional commit subjects landing on `main`, and opens a release PR that maintainers merge to tag and deploy. Your only responsibility is a correctly formatted PR title.
+
+## Code of conduct and security
+
+All participation is covered by the [Code of Conduct](CODE_OF_CONDUCT.md). To report a security vulnerability, follow [SECURITY.md](SECURITY.md); please do not open a public issue for it.
+
+## License
+
+Lanjut is licensed under [AGPL-3.0-only](LICENSE). By contributing, you agree that your contributions are licensed under the same terms, as certified by your DCO sign-off.

--- a/LICENSE
+++ b/LICENSE
@@ -629,8 +629,8 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
+    Lanjut: a free, open-source, local-first, ATS-safe resume builder.
+    Copyright (c) 2026 Lanjut Contributors
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published

--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ Changes to the export path are gated by `pnpm validate:exports`, which regenerat
 
 Bug reports and feature requests go through the issue forms; note the scope rules there: presentation is customizable, structure is not, and accounts/server storage are non-goals.
 
-Commit messages follow Conventional Commits via commitlint and commitizen. Run `pnpm commit` instead of `git commit` to use the prompt. Pre-commit hooks (husky + lint-staged) run lint and format checks before any commit is accepted. PR titles follow the same convention with a fully lowercase subject; they become the squash-merge commit.
+Commit messages follow Conventional Commits via commitlint and commitizen, and every commit must be signed off (`git commit -s`) under the Developer Certificate of Origin. Run `pnpm commit` instead of `git commit` to use the prompt. Pre-commit hooks (husky + lint-staged) run lint and format checks before any commit is accepted. PR titles follow the same convention with a fully lowercase subject; they become the squash-merge commit.
 
-See `AGENTS.md` for architecture rules and code conventions before submitting a PR.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow (setup, branches, commits, DCO, releases) and `AGENTS.md` for architecture rules and code conventions before submitting a PR.
 
 ## License
 
-[AGPL-3.0-only](LICENSE). Copyright © 2026 Rizki Citra.
+[AGPL-3.0-only](LICENSE). Copyright © 2026 Lanjut Contributors.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+Lanjut is local-first: résumé content is stored only in the user's browser
+(IndexedDB) and is never sent to a server. That narrows the attack surface but
+does not eliminate it. Vulnerabilities we care about include, for example:
+
+- Script injection through résumé content (the editor renders rich text and
+  imported data into the preview and exports)
+- Any code path that would exfiltrate résumé data off the device, including
+  through the export pipeline or third-party requests
+- Supply-chain issues in dependencies that ship to the client
+
+## Reporting a vulnerability
+
+Please report vulnerabilities privately. Do not open a public issue or pull
+request for a security problem.
+
+Preferred channel: GitHub private vulnerability reporting, at
+<https://github.com/rimzzlabs/lanjut/security/advisories/new>.
+
+Alternatively, email rimzzlabs@proton.me with a subject line starting with
+`[SECURITY]`.
+
+In your report, include:
+
+- A description of the issue and the affected code path or component
+- Steps to reproduce, or a proof of concept
+- Your assessment of the impact (what data or users are at risk)
+
+## What to expect
+
+- Acknowledgment of your report within 72 hours
+- An assessment and, if confirmed, a remediation plan within 14 days
+- Credit in the release notes for the fix, unless you prefer to stay anonymous
+
+Please give us a reasonable window to ship a fix before any public disclosure.
+
+## Supported versions
+
+Lanjut is a continuously deployed web application; only the latest deployed
+version (the tip of `main`) is supported. If you self-host a fork, please
+verify the issue reproduces on the current release before reporting.


### PR DESCRIPTION
Sets the repo up for external contributors.

- New DCO workflow fails any PR containing commits without a Signed-off-by trailer matching the commit author; bot commits (release-please) are skipped so release PRs are unaffected. DCO instead of a CLA keeps friction low for an AGPL project this size.
- New CI workflow runs Biome lint, export validation, and the Cloudflare production build on every PR; previously these only ran at deploy time, so open-next incompatibilities surfaced after merge.
- CONTRIBUTING.md covers local setup with pnpm, branch naming, the Commitizen/commitlint commit format, the sign-off requirement with recovery commands, pre-PR checks, and how release-please owns CHANGELOG.md and version numbers so contributors never hand-edit them.
- CODE_OF_CONDUCT.md adopts Contributor Covenant 2.1 verbatim. SECURITY.md documents private vulnerability disclosure through GitHub security advisories with an email fallback. CODEOWNERS requires maintainer review on all paths.
- The PR template gains DCO sign-off and linked-issue checklist items. The LICENSE appendix placeholder and README copyright line now read "Lanjut Contributors", since DCO-signed external commits accumulate copyright holders.

Branch protection on main now requires the DCO check, CI, the PR title check, and one code-owner review; that was applied in repo settings and is not part of this diff.

Testing: the DCO check's trailer matching was verified against real commits from the repo history, and this PR exercises all three required checks on itself; its own commit is signed off.