### PR TITLE
feat: show a ghost placeholder for blank resume cards

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -241,6 +241,7 @@
       "errorTitle": "Couldn't load your résumés",
       "errorDescription": "Nothing was deleted. The library just failed to load from this browser's storage. Refresh the page to try again.",
       "open": "Open {title}",
+      "emptyDocument": "Blank résumé, nothing added yet",
       "edited": "Edited",
       "menu": "Menu",
       "rename": "Rename",

--- a/messages/id.json
+++ b/messages/id.json
@@ -241,6 +241,7 @@
       "errorTitle": "Gagal memuat resume kamu",
       "errorDescription": "Tenang, nggak ada yang kehapus. Pustakanya cuma gagal dimuat dari penyimpanan browser ini. Segarin halaman buat coba lagi.",
       "open": "Buka {title}",
+      "emptyDocument": "Resume kosong, belum ada isinya",
       "edited": "Diedit",
       "menu": "Menu",
       "rename": "Ganti nama",

--- a/src/components/editor/resume-to-preview.ts
+++ b/src/components/editor/resume-to-preview.ts
@@ -84,6 +84,26 @@ function toHeaderView(resume: Resume): HeaderView {
 }
 
 /**
+ * True when a preview carries no user content: an untouched document that would
+ * render as a blank sheet. Callers surface a placeholder instead of the empty page.
+ */
+export function isResumePreviewEmpty(preview: ResumePreview): boolean {
+  const { header } = preview;
+  return (
+    !header.fullName &&
+    !header.headline &&
+    header.contacts.length === 0 &&
+    preview.summary.length === 0 &&
+    preview.experience.length === 0 &&
+    preview.organizations.length === 0 &&
+    preview.education.length === 0 &&
+    preview.certificates.length === 0 &&
+    preview.skills.length === 0 &&
+    preview.languages.length === 0
+  );
+}
+
+/**
  * Projects the persisted `Resume` onto the `ResumePreview` view-model the "Awal"
  * template renders. This is the single Resume → presentation seam: preview
  * components never read the storage schema directly.

--- a/src/components/platform/platform-resume-grid/platform-resume-grid-item-empty.tsx
+++ b/src/components/platform/platform-resume-grid/platform-resume-grid-item-empty.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { cn } from "@/lib/utils";
+
+function GhostLine(props: { className: string }) {
+  return (
+    <div className={cn("h-1.5 rounded-full bg-neutral-200", props.className)} />
+  );
+}
+
+function GhostHeading(props: { className: string }) {
+  return (
+    <div className="flex items-center gap-2">
+      <div className={cn("h-2 rounded-full bg-neutral-300", props.className)} />
+      <div className="h-px flex-1 bg-neutral-200" />
+    </div>
+  );
+}
+
+function GhostBullet(props: { className: string }) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <div className="size-1 shrink-0 rounded-full bg-neutral-300" />
+      <GhostLine className={props.className} />
+    </div>
+  );
+}
+
+export function PlatformResumeGridItemEmpty() {
+  const t = useTranslations("platform.grid");
+
+  return (
+    <div className="aspect-210/297 w-full overflow-hidden bg-white">
+      <span className="sr-only">{t("emptyDocument")}</span>
+
+      <div
+        aria-hidden
+        className="flex h-full flex-col justify-between px-[9%] py-[11%]"
+      >
+        <div className="flex items-start justify-between gap-[8%]">
+          <div className="w-1/2 space-y-2.5">
+            <div className="flex items-center gap-1">
+              <div className="h-2.5 w-[85%] rounded-full bg-neutral-300" />
+              <div className="h-4 w-0.5 shrink-0 animate-caret-blink bg-primary motion-reduce:animate-none" />
+            </div>
+            <GhostLine className="w-[60%]" />
+          </div>
+          <div className="flex w-[38%] flex-col items-end gap-1.5">
+            <GhostLine className="h-1 w-[75%]" />
+            <GhostLine className="h-1 w-[90%]" />
+            <GhostLine className="h-1 w-[65%]" />
+          </div>
+        </div>
+
+        <div className="space-y-2.5">
+          <GhostHeading className="w-[28%]" />
+          <div className="space-y-1.5">
+            <GhostLine className="w-full" />
+            <GhostLine className="w-[94%]" />
+            <GhostLine className="w-[68%]" />
+          </div>
+        </div>
+
+        <div className="space-y-2.5">
+          <GhostHeading className="w-[34%]" />
+          <div className="flex items-center justify-between gap-4">
+            <GhostLine className="w-[42%]" />
+            <GhostLine className="w-[20%]" />
+          </div>
+          <div className="space-y-1.5">
+            <GhostBullet className="w-[92%]" />
+            <GhostBullet className="w-[74%]" />
+          </div>
+        </div>
+
+        <div className="space-y-2.5">
+          <GhostHeading className="w-[24%]" />
+          <div className="flex flex-wrap gap-1.5">
+            <div className="h-3 w-12 rounded bg-neutral-200" />
+            <div className="h-3 w-16 rounded bg-neutral-200" />
+            <div className="h-3 w-10 rounded bg-neutral-200" />
+            <div className="h-3 w-14 rounded bg-neutral-200" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/platform/platform-resume-grid/platform-resume-grid-item-thumbnail.tsx
+++ b/src/components/platform/platform-resume-grid/platform-resume-grid-item-thumbnail.tsx
@@ -2,12 +2,16 @@
 
 import { useMemo } from "react";
 import { ResumeThumbnail } from "@/components/editor/resume-thumbnail";
-import { resumeToPreview } from "@/components/editor/resume-to-preview";
+import {
+  isResumePreviewEmpty,
+  resumeToPreview,
+} from "@/components/editor/resume-to-preview";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useResumeDocument } from "@/hooks/use-resume-document";
 import type { ResumeIndexEntry } from "@/lib/resume";
 import { resolveTemplateId } from "@/lib/templates";
 import { PlatformPaperFrame } from "../platform-paper-frame";
+import { PlatformResumeGridItemEmpty } from "./platform-resume-grid-item-empty";
 
 interface PlatformResumeGridItemThumbnailProps {
   resume: ResumeIndexEntry;
@@ -22,16 +26,28 @@ export function PlatformResumeGridItemThumbnail({
     [document],
   );
 
+  if (!document || !preview) {
+    return (
+      <PlatformPaperFrame>
+        <Skeleton className="aspect-210/297 w-full rounded-none" />
+      </PlatformPaperFrame>
+    );
+  }
+
+  if (isResumePreviewEmpty(preview)) {
+    return (
+      <PlatformPaperFrame>
+        <PlatformResumeGridItemEmpty />
+      </PlatformPaperFrame>
+    );
+  }
+
   return (
     <PlatformPaperFrame>
-      {document && preview ? (
-        <ResumeThumbnail
-          resume={preview}
-          template={resolveTemplateId(document.templateId)}
-        />
-      ) : (
-        <Skeleton className="aspect-210/297 w-full rounded-none" />
-      )}
+      <ResumeThumbnail
+        resume={preview}
+        template={resolveTemplateId(document.templateId)}
+      />
     </PlatformPaperFrame>
   );
 }


### PR DESCRIPTION
A blank résumé rendered as an empty white sheet in the library, indistinguishable from a failed render or a still-loading skeleton. This gives an untouched document a deliberate placeholder instead.

The thumbnail now projects the document to the preview view-model and, when there is no content at all (no name, headline, contacts, or any section entries), draws a pale ghost of a résumé spread across the full sheet: header, summary, experience, and skills laid out in faint neutral strokes, with a teal caret blinking at the name line as a "ready to write" cue. A partially-started document keeps its real thumbnail. The paper is always white, so the ghost uses fixed neutral tones rather than theme colors, and the caret holds steady under reduced-motion. The visual is aria-hidden with an sr-only label so screen readers still announce the card as an empty résumé.

Emptiness is decided by a new `isResumePreviewEmpty` helper on the preview seam, so the check reads the presentation view-model and never touches the storage schema directly.

Verified the blank card shows the ghost with the blinking caret, a filled document still renders its normal thumbnail, and the loading state remains the skeleton. English and Indonesian both carry the accessibility label.