### PR TITLE
feat: add an internship section to the resume editor

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -166,7 +166,7 @@
           "Sections can now be emptied completely: every entry has a delete button, and removing the last one simply drops the section from the preview until you add another."
         ],
         "0_4_0": [
-          "New Organization Experience section: showcase volunteer, student, and community roles with dates and highlights, just like work experience. It shows up in every template and export, and your existing résumés get it automatically.",
+          "New Organization section: showcase volunteer, student, and community roles with dates and highlights, just like work experience. It shows up in every template and export, and your existing résumés get it automatically.",
           "Your saved résumés are safer during app updates: a backup copy is kept on your device before any data-format upgrade, and a résumé the app can't read yet is flagged with a notice instead of disappearing.",
           "A guided tour now walks you through the dashboard, the templates, and the editor on your first visit.",
           "The landing page walks through how Lanjut works, ending with a one-click way to start a new résumé.",
@@ -413,8 +413,27 @@
       "summaryPlaceholder": "Creating real-time application that....",
       "remove": "Remove"
     },
+    "internship": {
+      "accordionTitle": "Internship",
+      "legend": "Internship",
+      "legendDesc": "Add internships you've completed",
+      "add": "Internship",
+      "emptyTitle": "No internships yet",
+      "emptyDescription": "Add internships to show early hands-on experience.",
+      "itemLegend": "Internship {index}",
+      "role": "Role",
+      "rolePlaceholder": "Frontend Engineering Intern",
+      "company": "Company",
+      "companyPlaceholder": "Acme Inc.",
+      "companyWebsite": "Company Website",
+      "companyWebsitePlaceholder": "acme.com",
+      "present": "I'm currently interning here",
+      "summary": "Summary",
+      "summaryPlaceholder": "Built internal tooling that....",
+      "remove": "Remove"
+    },
     "organizations": {
-      "accordionTitle": "Organization Experience",
+      "accordionTitle": "Organization",
       "legend": "Organization Experience",
       "legendDesc": "Describe your volunteer, student, and community roles",
       "add": "Organization Experience",

--- a/messages/id.json
+++ b/messages/id.json
@@ -390,12 +390,12 @@
       "countryPlaceholder": "Indonesia"
     },
     "summary": {
-      "accordionTitle": "Ringkasan Profesional",
+      "accordionTitle": "Ringkasan",
       "label": "Ringkasan Profesional",
       "placeholder": "Saya seorang UX engineer yang antusias. Bikin pengalaman yang menarik secara visual..."
     },
     "experience": {
-      "accordionTitle": "Pengalaman Profesional",
+      "accordionTitle": "Pengalaman Kerja",
       "legend": "Pengalaman Profesional",
       "legendDesc": "Ceritain pengalaman kamu sebelumnya",
       "add": "Pengalaman Profesional",
@@ -413,8 +413,27 @@
       "summaryPlaceholder": "Membuat aplikasi real-time yang....",
       "remove": "Hapus"
     },
+    "internship": {
+      "accordionTitle": "Magang",
+      "legend": "Magang",
+      "legendDesc": "Tambahin pengalaman magang kamu",
+      "add": "Magang",
+      "emptyTitle": "Belum ada magang",
+      "emptyDescription": "Tambahin magang buat nunjukin pengalaman awal kamu.",
+      "itemLegend": "Magang {index}",
+      "role": "Posisi",
+      "rolePlaceholder": "Frontend Engineering Intern",
+      "company": "Perusahaan",
+      "companyPlaceholder": "Acme Inc.",
+      "companyWebsite": "Situs web perusahaan",
+      "companyWebsitePlaceholder": "acme.com",
+      "present": "Masih magang di sini sekarang",
+      "summary": "Ringkasan",
+      "summaryPlaceholder": "Membuat internal tooling yang....",
+      "remove": "Hapus"
+    },
     "organizations": {
-      "accordionTitle": "Pengalaman Organisasi",
+      "accordionTitle": "Organisasi",
       "legend": "Pengalaman Organisasi",
       "legendDesc": "Ceritain peran sukarelawan, mahasiswa, dan komunitas kamu",
       "add": "Pengalaman Organisasi",

--- a/src/components/editor/editor-sections.ts
+++ b/src/components/editor/editor-sections.ts
@@ -1,6 +1,7 @@
 import {
   AlignLeft,
   Award,
+  Backpack,
   Briefcase,
   CircleUserRound,
   GraduationCap,
@@ -13,6 +14,7 @@ import {
 export type EditorSectionId =
   | "personal-details"
   | "experience"
+  | "internship"
   | "organizations"
   | "education"
   | "skills"
@@ -42,6 +44,7 @@ export const EDITOR_SECTIONS: EditorSectionDescriptor[] = [
     required: true,
   },
   { id: "experience", label: "Experience", icon: Briefcase, required: false },
+  { id: "internship", label: "Internship", icon: Backpack, required: false },
   {
     id: "organizations",
     label: "Organizations",

--- a/src/components/editor/editor-sections/ed-section-internship/ed-section-internship-form-item.tsx
+++ b/src/components/editor/editor-sections/ed-section-internship/ed-section-internship-form-item.tsx
@@ -1,0 +1,134 @@
+import { Trash } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { type Control, Controller } from "react-hook-form";
+import { UrlInput } from "@/components/shared/url-input";
+import { Button } from "@/components/ui/button";
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+  FieldLegend,
+  FieldSet,
+} from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { PROSE_FEATURES } from "@/lib/resume/schema-registry";
+import { RichTextEditor } from "../../rich-text/rich-text-editor";
+import { DateRangeFields } from "../date-range-fields";
+import type { InternshipFormValues } from "../resume-form-adapter";
+
+interface EditorSectionInternshipFormItemProps {
+  index: number;
+  control: Control<InternshipFormValues>;
+  onRemoveField: (index: number) => void;
+}
+
+export function EditorSectionInternshipFormItem(
+  props: EditorSectionInternshipFormItemProps,
+) {
+  const t = useTranslations("editor.internship");
+  const onRemove = () => {
+    props.onRemoveField(props.index);
+  };
+
+  return (
+    <FieldSet className="not-last-of-type:pb-4 not-last-of-type:border-b">
+      <FieldLegend className="sr-only" variant="label">
+        {t("itemLegend", { index: props.index + 1 })}
+      </FieldLegend>
+
+      <FieldGroup className="gap-3">
+        <Controller
+          control={props.control}
+          name={`internships.${props.index}.title`}
+          render={({ field, fieldState }) => (
+            <Field>
+              <FieldLabel htmlFor={field.name}>{t("role")}</FieldLabel>
+              <div className="flex items-center gap-2">
+                <Input
+                  placeholder={t("rolePlaceholder")}
+                  {...field}
+                  id={field.name}
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon-sm"
+                  onClick={onRemove}
+                >
+                  <Trash className="size-3.5 stroke-destructive" />
+                  <span className="sr-only">{t("remove")}</span>
+                </Button>
+              </div>
+              <FieldError errors={[fieldState.error]} />
+            </Field>
+          )}
+        />
+
+        <div className="grid gap-6 2xl:grid-cols-2 2xl:gap-3">
+          <Controller
+            control={props.control}
+            name={`internships.${props.index}.company`}
+            render={({ field, fieldState }) => (
+              <Field>
+                <FieldLabel htmlFor={field.name}>{t("company")}</FieldLabel>
+                <Input
+                  placeholder={t("companyPlaceholder")}
+                  {...field}
+                  id={field.name}
+                />
+                <FieldError errors={[fieldState.error]} />
+              </Field>
+            )}
+          />
+
+          <Controller
+            control={props.control}
+            name={`internships.${props.index}.website`}
+            render={({ field, fieldState }) => (
+              <Field>
+                <FieldLabel htmlFor={field.name}>
+                  {t("companyWebsite")}
+                </FieldLabel>
+                <UrlInput
+                  id={field.name}
+                  value={field.value}
+                  placeholder={t("companyWebsitePlaceholder")}
+                  onChange={field.onChange}
+                  onBlur={field.onBlur}
+                />
+                <FieldError errors={[fieldState.error]} />
+              </Field>
+            )}
+          />
+        </div>
+
+        <DateRangeFields
+          control={props.control}
+          startName={`internships.${props.index}.startDate`}
+          endName={`internships.${props.index}.endDate`}
+          presentLabel={t("present")}
+        />
+
+        <Controller
+          control={props.control}
+          name={`internships.${props.index}.description`}
+          render={({ field, fieldState }) => (
+            <Field>
+              <FieldLabel htmlFor={field.name}>{t("summary")}</FieldLabel>
+              <RichTextEditor
+                id={field.name}
+                value={field.value}
+                features={PROSE_FEATURES}
+                placeholder={t("summaryPlaceholder")}
+                onChange={field.onChange}
+                onBlur={field.onBlur}
+              />
+              <FieldError errors={[fieldState.error]} />
+            </Field>
+          )}
+        />
+      </FieldGroup>
+    </FieldSet>
+  );
+}

--- a/src/components/editor/editor-sections/ed-section-internship/ed-section-internship-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-internship/ed-section-internship-form.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { Backpack, Plus } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useEffect } from "react";
+import { useFieldArray, useForm } from "react-hook-form";
+import { EmptyState } from "@/components/shared/empty-state";
+import { Button } from "@/components/ui/button";
+import {
+  FieldDescription,
+  FieldGroup,
+  FieldLegend,
+  FieldSet,
+} from "@/components/ui/field";
+import { emptyRichTextValue } from "@/lib/resume";
+import { useResumeStore } from "@/lib/store";
+import {
+  applyInternshipValues,
+  type InternshipFormValues,
+  type InternshipItemValues,
+  toInternshipValues,
+} from "../resume-form-adapter";
+import { EditorSectionInternshipFormItem } from "./ed-section-internship-form-item";
+
+function emptyInternship(): InternshipItemValues {
+  return {
+    title: "",
+    company: "",
+    website: "",
+    startDate: "",
+    endDate: "",
+    description: emptyRichTextValue(),
+  };
+}
+
+export function EditorSectionInternshipForm() {
+  const open = useResumeStore((state) => state.open);
+  const updateOpen = useResumeStore((state) => state.updateOpen);
+  const t = useTranslations("editor.internship");
+  const tc = useTranslations("editor.common");
+
+  const form = useForm<InternshipFormValues>({
+    defaultValues: open ? toInternshipValues(open) : { internships: [] },
+  });
+  const { fields, prepend, remove } = useFieldArray({
+    control: form.control,
+    name: "internships",
+  });
+
+  // The field array owns the list; every form change (including add/remove)
+  // rebuilds the store entries. Subscribing to the form and writing to the
+  // store is a valid external-system sync; the store debounces the IndexedDB
+  // write. Reading getValues() inside the callback avoids stale-value timing.
+  useEffect(() => {
+    const subscription = form.watch(() => {
+      updateOpen((draft) => applyInternshipValues(draft, form.getValues()));
+    });
+    return () => subscription.unsubscribe();
+  }, [form, updateOpen]);
+
+  if (!open) return null;
+
+  return (
+    <form>
+      <FieldSet className="gap-3">
+        <FieldLegend className="sr-only">{t("legend")}</FieldLegend>
+        <FieldDescription className="sr-only">
+          {t("legendDesc")}
+        </FieldDescription>
+        <Button
+          type="button"
+          onClick={() => prepend(emptyInternship())}
+          variant="outline"
+          className="w-full"
+        >
+          <Plus /> <span className="sr-only">{tc("add")} </span>
+          {t("add")}
+        </Button>
+
+        {fields.length === 0 ? (
+          <EmptyState
+            icon={Backpack}
+            title={t("emptyTitle")}
+            description={t("emptyDescription")}
+          />
+        ) : (
+          <FieldGroup className="gap-4">
+            {fields.map((field, index) => (
+              <EditorSectionInternshipFormItem
+                key={field.id}
+                control={form.control}
+                index={index}
+                onRemoveField={remove}
+              />
+            ))}
+          </FieldGroup>
+        )}
+      </FieldSet>
+    </form>
+  );
+}

--- a/src/components/editor/editor-sections/ed-section-internship/ed-section-internship.tsx
+++ b/src/components/editor/editor-sections/ed-section-internship/ed-section-internship.tsx
@@ -1,0 +1,24 @@
+import { Backpack } from "lucide-react";
+import { useTranslations } from "next-intl";
+import {
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { EditorSectionInternshipForm } from "./ed-section-internship-form";
+
+export function EditorSectionInternship() {
+  const t = useTranslations("editor.internship");
+
+  return (
+    <AccordionItem>
+      <AccordionTrigger className="items-center gap-3">
+        <Backpack className="size-4" /> {t("accordionTitle")}
+      </AccordionTrigger>
+
+      <AccordionContent>
+        <EditorSectionInternshipForm />
+      </AccordionContent>
+    </AccordionItem>
+  );
+}

--- a/src/components/editor/editor-sections/ed-section-list.tsx
+++ b/src/components/editor/editor-sections/ed-section-list.tsx
@@ -7,6 +7,7 @@ import { useResumeStore } from "@/lib/store";
 import { EditorSectionCertifications } from "./ed-section-certifications/ed-section-certifications";
 import { EditorSectionEducation } from "./ed-section-education/ed-section-education";
 import { EditorSectionExperience } from "./ed-section-experience/ed-section-experience";
+import { EditorSectionInternship } from "./ed-section-internship/ed-section-internship";
 import { EditorSectionLanguages } from "./ed-section-languages/ed-section-languages";
 import { EditorSectionOrganizations } from "./ed-section-organizations/ed-section-organizations";
 import { EditorSectionPersonal } from "./ed-section-personal/ed-section-personal";
@@ -49,6 +50,7 @@ export function EditorSectionList() {
       <EditorSectionPersonal />
       <EditorSectionSummary />
       <EditorSectionExperience />
+      <EditorSectionInternship />
       <EditorSectionOrganizations />
       <EditorSectionEducation />
       <EditorSectionCertifications />

--- a/src/components/editor/editor-sections/resume-form-adapter.ts
+++ b/src/components/editor/editor-sections/resume-form-adapter.ts
@@ -32,6 +32,19 @@ export interface ExperienceFormValues {
   experiences: ExperienceItemValues[];
 }
 
+export interface InternshipItemValues {
+  title: string;
+  company: string;
+  website: string;
+  startDate: string;
+  endDate: string;
+  description: JSONContent;
+}
+
+export interface InternshipFormValues {
+  internships: InternshipItemValues[];
+}
+
 export interface OrganizationItemValues {
   role: string;
   organization: string;
@@ -198,6 +211,44 @@ export function applyExperienceValues(
   const section = sectionOfType(draft, "experience");
   if (!section) return;
   section.entries = values.experiences.map((item, index) => ({
+    id: entryId(section, index),
+    fields: {
+      title: plain(item.title),
+      company: plain(item.company),
+      website: plain(item.website),
+      startDate: plain(item.startDate),
+      endDate: plain(item.endDate),
+      description: rich(item.description),
+    },
+  }));
+}
+
+// --- Internship (repeating section entries) ---------------------------------
+
+export function internshipEntries(resume: Resume): Entry[] {
+  return sectionOfType(resume, "internship")?.entries ?? [];
+}
+
+export function toInternshipValues(resume: Resume): InternshipFormValues {
+  return {
+    internships: internshipEntries(resume).map((entry) => ({
+      title: plainValue(entry.fields.title),
+      company: plainValue(entry.fields.company),
+      website: plainValue(entry.fields.website),
+      startDate: plainValue(entry.fields.startDate),
+      endDate: plainValue(entry.fields.endDate),
+      description: richValue(entry.fields.description),
+    })),
+  };
+}
+
+export function applyInternshipValues(
+  draft: Resume,
+  values: InternshipFormValues,
+): void {
+  const section = sectionOfType(draft, "internship");
+  if (!section) return;
+  section.entries = values.internships.map((item, index) => ({
     id: entryId(section, index),
     fields: {
       title: plain(item.title),

--- a/src/components/editor/resume-blocks.ts
+++ b/src/components/editor/resume-blocks.ts
@@ -127,8 +127,24 @@ export function buildResumeBlocks(resume: ResumePreview): ResumeBlock[] {
     );
   }
 
-  // Organization entries reuse the "experience" block kind: they render
-  // identically in every template and export, only the section heading differs.
+  // Internship and organization entries reuse the "experience" block kind: they
+  // render identically in every template and export, only the heading differs.
+  const internship = resume.internship.filter(hasExperience);
+  if (internship.length > 0) {
+    blocks.push(
+      heading("internship-heading", labels.internship),
+      ...internship.map(
+        (item, index): ResumeBlock => ({
+          id: item.id,
+          kind: "experience",
+          item,
+          gapBefore: entryGap(index),
+          keepWithNext: false,
+        }),
+      ),
+    );
+  }
+
   const organizations = resume.organizations.filter(hasExperience);
   if (organizations.length > 0) {
     blocks.push(

--- a/src/components/editor/resume-preview.ts
+++ b/src/components/editor/resume-preview.ts
@@ -73,6 +73,12 @@ export interface ResumePreview {
   summary: RichBlock[];
   experience: ExperienceItemView[];
   /**
+   * Internship entries are structurally identical to experience (same fields),
+   * so they reuse `ExperienceItemView` and every renderer's experience path;
+   * only the section heading differs.
+   */
+  internship: ExperienceItemView[];
+  /**
    * Organization entries (volunteer, student, community roles) are
    * presentationally identical to experience entries, so they reuse
    * `ExperienceItemView` (`company` holds the organization name) and every

--- a/src/components/editor/resume-to-preview.ts
+++ b/src/components/editor/resume-to-preview.ts
@@ -138,6 +138,21 @@ export function resumeToPreview(resume: Resume): ResumePreview {
       })
       .sort(byRecency)
       .map(localizeDates),
+    internship: (sectionOfType(resume, "internship")?.entries ?? [])
+      .map((entry) => {
+        const website = plain(entry.fields.website);
+        return {
+          id: entry.id,
+          role: plain(entry.fields.title),
+          company: plain(entry.fields.company),
+          companyHref: website ? withHttps(website) : undefined,
+          startDate: plain(entry.fields.startDate),
+          endDate: plain(entry.fields.endDate),
+          description: richBlocks(entry.fields.description),
+        };
+      })
+      .sort(byRecency)
+      .map(localizeDates),
     organizations: (sectionOfType(resume, "organizations")?.entries ?? [])
       .map((entry) => ({
         id: entry.id,

--- a/src/lib/resume/factory.ts
+++ b/src/lib/resume/factory.ts
@@ -76,6 +76,7 @@ export function createEmptyResume(title: string): Resume {
     sections: [
       createEmptySection("summary"),
       createEmptySection("experience"),
+      createEmptySection("internship"),
       createEmptySection("organizations"),
       createEmptySection("education"),
       createEmptySection("skills"),

--- a/src/lib/resume/labels.ts
+++ b/src/lib/resume/labels.ts
@@ -5,6 +5,7 @@ export const RESUME_LANGUAGES: ResumeLanguage[] = ["en", "id"];
 interface DocumentLabels {
   summary: string;
   experience: string;
+  internship: string;
   organizations: string;
   education: string;
   certificates: string;
@@ -25,6 +26,7 @@ export const RESUME_LABELS: Record<ResumeLanguage, DocumentLabels> = {
   en: {
     summary: "Summary",
     experience: "Experience",
+    internship: "Internship",
     organizations: "Organizations",
     education: "Education",
     certificates: "Certificates",
@@ -49,6 +51,7 @@ export const RESUME_LABELS: Record<ResumeLanguage, DocumentLabels> = {
   id: {
     summary: "Ringkasan",
     experience: "Pengalaman",
+    internship: "Magang",
     organizations: "Organisasi",
     education: "Pendidikan",
     certificates: "Sertifikat",

--- a/src/lib/resume/migrations.ts
+++ b/src/lib/resume/migrations.ts
@@ -286,6 +286,45 @@ const migrateV6toV7: Migration = (doc) => {
 };
 
 /**
+ * v7→v8: adds the Internship section (structurally identical to Experience, only
+ * the heading differs). Existing documents gain it (with one empty entry) if it
+ * is not already present, so the new editor form has somewhere to write.
+ */
+const migrateV7toV8: Migration = (doc) => {
+  const next = structuredClone(doc);
+  const sections = Array.isArray(next.sections)
+    ? (next.sections as Array<Record<string, unknown>>)
+    : [];
+
+  if (!sections.some((s) => s.type === "internship")) {
+    sections.push({
+      id: nanoid(),
+      type: "internship",
+      title: "Internship",
+      entries: [
+        {
+          id: nanoid(),
+          fields: {
+            title: plainField(""),
+            company: plainField(""),
+            website: plainField(""),
+            startDate: plainField(""),
+            endDate: plainField(""),
+            description: {
+              kind: "richtext",
+              value: { type: "doc", content: [{ type: "paragraph" }] },
+            },
+          },
+        },
+      ],
+    });
+  }
+
+  next.sections = sections;
+  return next;
+};
+
+/**
  * The migration ladder. Each key N is a forward-only step from version N to N+1.
  */
 const LADDER: Record<number, Migration> = {
@@ -295,6 +334,7 @@ const LADDER: Record<number, Migration> = {
   4: migrateV4toV5,
   5: migrateV5toV6,
   6: migrateV6toV7,
+  7: migrateV7toV8,
 };
 
 /** The persisted schemaVersion of a raw document; 0 when absent or malformed. */

--- a/src/lib/resume/schema-registry.ts
+++ b/src/lib/resume/schema-registry.ts
@@ -155,6 +155,49 @@ export const SECTION_REGISTRY: Record<SectionType, SectionSchema> = {
       },
     ],
   },
+  internship: {
+    type: "internship",
+    defaultTitle: "Internship",
+    singleton: false,
+    fields: [
+      {
+        key: "title",
+        label: "Role",
+        kind: "plain",
+        placeholder: "Frontend Engineering Intern",
+      },
+      {
+        key: "company",
+        label: "Company",
+        kind: "plain",
+        placeholder: "Acme Inc.",
+      },
+      {
+        key: "website",
+        label: "Company website",
+        kind: "plain",
+        placeholder: "acme.com",
+      },
+      {
+        key: "startDate",
+        label: "Start date",
+        kind: "plain",
+        placeholder: "Jan 2023",
+      },
+      {
+        key: "endDate",
+        label: "End date",
+        kind: "plain",
+        placeholder: "Present",
+      },
+      {
+        key: "description",
+        label: "Description",
+        kind: "richtext",
+        features: PROSE_FEATURES,
+      },
+    ],
+  },
   organizations: {
     type: "organizations",
     defaultTitle: "Organizations",

--- a/src/lib/resume/seed.ts
+++ b/src/lib/resume/seed.ts
@@ -234,6 +234,39 @@ export const SEED_RESUME: Resume = {
       ],
     },
     {
+      id: "seed-internship",
+      type: "internship",
+      title: "Internship",
+      entries: [
+        {
+          id: "seed-internship-1",
+          fields: {
+            title: plain("Frontend Engineering Intern"),
+            company: plain("Hooli"),
+            website: plain("hooli.example.com"),
+            startDate: plain("Jun 2015"),
+            endDate: plain("Aug 2015"),
+            description: prose(
+              ul(
+                li(
+                  t("Shipped a customer-facing settings page in "),
+                  b("React"),
+                  t(", used by the full beta cohort by the end of the summer."),
+                ),
+                li(
+                  t(
+                    "Wrote the team's first component unit tests, lifting coverage on the shared UI package to ",
+                  ),
+                  b("70%"),
+                  t("."),
+                ),
+              ),
+            ),
+          },
+        },
+      ],
+    },
+    {
       id: "seed-organizations",
       type: "organizations",
       title: "Organizations",

--- a/src/lib/resume/types.ts
+++ b/src/lib/resume/types.ts
@@ -5,7 +5,7 @@ import type { JSONContent } from "@tiptap/core";
  * governs object-store/index structure only. Bumped whenever a persisted field
  * shape changes; every bump gets a forward-only step in the migration ladder.
  */
-export const CURRENT_SCHEMA_VERSION = 7;
+export const CURRENT_SCHEMA_VERSION = 8;
 
 /** The language the rendered document's fixed labels (headings, dates) use. */
 export type ResumeLanguage = "en" | "id";
@@ -41,6 +41,7 @@ export interface Entry {
 export type SectionType =
   | "summary"
   | "experience"
+  | "internship"
   | "organizations"
   | "education"
   | "skills"


### PR DESCRIPTION
Adds an Internship section, structurally identical to Professional Experience (role, company, company website, date range, description) with its own heading. Internships are a distinct line on early-career résumés, and folding them into Experience buried that signal.

It follows the existing Organizations precedent: entries reuse the experience view-model and the shared "experience" block, so every template PDF, DOCX, and plain-text export renders it through the same path with no renderer changes. Reading order is Experience then Internship then Organizations.

The persisted shape moves to schemaVersion 8. New documents and the seed include the section; a forward-only migration adds it (with one empty entry) to existing documents that lack it, and bails out without touching data it does not recognize. The IndexedDB version is untouched, since no object store changed.

Verified the seed résumé exports cleanly across plain text, DOCX, and all seven PDF templates with reading order and every field preserved. Confirmed new and blank documents carry the section, a version 7 document without it migrates up and gains it with existing experience entries intact, and the section projects into the preview between Experience and Organizations. Both English and Indonesian carry the section copy and the document heading (Internship / Magang).