### PR TITLE
feat: add a projects section to the resume editor

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -432,6 +432,25 @@
       "summaryPlaceholder": "Built internal tooling that....",
       "remove": "Remove"
     },
+    "projects": {
+      "accordionTitle": "Projects",
+      "legend": "Projects",
+      "legendDesc": "Show off the things you've built",
+      "add": "Project",
+      "emptyTitle": "No projects yet",
+      "emptyDescription": "Add side projects, open-source work, or things you've shipped.",
+      "itemLegend": "Project {index}",
+      "name": "Project name",
+      "namePlaceholder": "react-a11y-kit",
+      "role": "Role",
+      "rolePlaceholder": "Maintainer",
+      "url": "Project URL",
+      "urlPlaceholder": "github.com/you/project",
+      "present": "This is ongoing",
+      "summary": "Description",
+      "summaryPlaceholder": "What it does, what you built, the impact....",
+      "remove": "Remove"
+    },
     "organizations": {
       "accordionTitle": "Organization",
       "legend": "Organization Experience",

--- a/messages/id.json
+++ b/messages/id.json
@@ -432,6 +432,25 @@
       "summaryPlaceholder": "Membuat internal tooling yang....",
       "remove": "Hapus"
     },
+    "projects": {
+      "accordionTitle": "Proyek",
+      "legend": "Proyek",
+      "legendDesc": "Pamerin hal-hal yang udah kamu bikin",
+      "add": "Proyek",
+      "emptyTitle": "Belum ada proyek",
+      "emptyDescription": "Tambahin proyek sampingan, kerjaan open-source, atau apa pun yang udah kamu rilis.",
+      "itemLegend": "Proyek {index}",
+      "name": "Nama proyek",
+      "namePlaceholder": "react-a11y-kit",
+      "role": "Peran",
+      "rolePlaceholder": "Maintainer",
+      "url": "URL proyek",
+      "urlPlaceholder": "github.com/kamu/proyek",
+      "present": "Masih jalan",
+      "summary": "Deskripsi",
+      "summaryPlaceholder": "Fungsinya apa, kamu bikin apa, dampaknya....",
+      "remove": "Hapus"
+    },
     "organizations": {
       "accordionTitle": "Organisasi",
       "legend": "Pengalaman Organisasi",

--- a/src/components/editor/editor-sections.ts
+++ b/src/components/editor/editor-sections.ts
@@ -4,6 +4,7 @@ import {
   Backpack,
   Briefcase,
   CircleUserRound,
+  FolderGit2,
   GraduationCap,
   Languages,
   type LucideIcon,
@@ -15,6 +16,7 @@ export type EditorSectionId =
   | "personal-details"
   | "experience"
   | "internship"
+  | "projects"
   | "organizations"
   | "education"
   | "skills"
@@ -45,6 +47,7 @@ export const EDITOR_SECTIONS: EditorSectionDescriptor[] = [
   },
   { id: "experience", label: "Experience", icon: Briefcase, required: false },
   { id: "internship", label: "Internship", icon: Backpack, required: false },
+  { id: "projects", label: "Projects", icon: FolderGit2, required: false },
   {
     id: "organizations",
     label: "Organizations",

--- a/src/components/editor/editor-sections/ed-section-list.tsx
+++ b/src/components/editor/editor-sections/ed-section-list.tsx
@@ -11,6 +11,7 @@ import { EditorSectionInternship } from "./ed-section-internship/ed-section-inte
 import { EditorSectionLanguages } from "./ed-section-languages/ed-section-languages";
 import { EditorSectionOrganizations } from "./ed-section-organizations/ed-section-organizations";
 import { EditorSectionPersonal } from "./ed-section-personal/ed-section-personal";
+import { EditorSectionProjects } from "./ed-section-projects/ed-section-projects";
 import { EditorSectionSkills } from "./ed-section-skills/ed-section-skills";
 import { EditorSectionSummary } from "./ed-section-summary/ed-section-summary";
 
@@ -51,6 +52,7 @@ export function EditorSectionList() {
       <EditorSectionSummary />
       <EditorSectionExperience />
       <EditorSectionInternship />
+      <EditorSectionProjects />
       <EditorSectionOrganizations />
       <EditorSectionEducation />
       <EditorSectionCertifications />

--- a/src/components/editor/editor-sections/ed-section-projects/ed-section-projects-form-item.tsx
+++ b/src/components/editor/editor-sections/ed-section-projects/ed-section-projects-form-item.tsx
@@ -1,0 +1,132 @@
+import { Trash } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { type Control, Controller } from "react-hook-form";
+import { UrlInput } from "@/components/shared/url-input";
+import { Button } from "@/components/ui/button";
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+  FieldLegend,
+  FieldSet,
+} from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { PROSE_FEATURES } from "@/lib/resume/schema-registry";
+import { RichTextEditor } from "../../rich-text/rich-text-editor";
+import { DateRangeFields } from "../date-range-fields";
+import type { ProjectsFormValues } from "../resume-form-adapter";
+
+interface EditorSectionProjectsFormItemProps {
+  index: number;
+  control: Control<ProjectsFormValues>;
+  onRemoveField: (index: number) => void;
+}
+
+export function EditorSectionProjectsFormItem(
+  props: EditorSectionProjectsFormItemProps,
+) {
+  const t = useTranslations("editor.projects");
+  const onRemove = () => {
+    props.onRemoveField(props.index);
+  };
+
+  return (
+    <FieldSet className="not-last-of-type:pb-4 not-last-of-type:border-b">
+      <FieldLegend className="sr-only" variant="label">
+        {t("itemLegend", { index: props.index + 1 })}
+      </FieldLegend>
+
+      <FieldGroup className="gap-3">
+        <Controller
+          control={props.control}
+          name={`projects.${props.index}.title`}
+          render={({ field, fieldState }) => (
+            <Field>
+              <FieldLabel htmlFor={field.name}>{t("name")}</FieldLabel>
+              <div className="flex items-center gap-2">
+                <Input
+                  placeholder={t("namePlaceholder")}
+                  {...field}
+                  id={field.name}
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon-sm"
+                  onClick={onRemove}
+                >
+                  <Trash className="size-3.5 stroke-destructive" />
+                  <span className="sr-only">{t("remove")}</span>
+                </Button>
+              </div>
+              <FieldError errors={[fieldState.error]} />
+            </Field>
+          )}
+        />
+
+        <div className="grid gap-6 2xl:grid-cols-2 2xl:gap-3">
+          <Controller
+            control={props.control}
+            name={`projects.${props.index}.company`}
+            render={({ field, fieldState }) => (
+              <Field>
+                <FieldLabel htmlFor={field.name}>{t("role")}</FieldLabel>
+                <Input
+                  placeholder={t("rolePlaceholder")}
+                  {...field}
+                  id={field.name}
+                />
+                <FieldError errors={[fieldState.error]} />
+              </Field>
+            )}
+          />
+
+          <Controller
+            control={props.control}
+            name={`projects.${props.index}.website`}
+            render={({ field, fieldState }) => (
+              <Field>
+                <FieldLabel htmlFor={field.name}>{t("url")}</FieldLabel>
+                <UrlInput
+                  id={field.name}
+                  value={field.value}
+                  placeholder={t("urlPlaceholder")}
+                  onChange={field.onChange}
+                  onBlur={field.onBlur}
+                />
+                <FieldError errors={[fieldState.error]} />
+              </Field>
+            )}
+          />
+        </div>
+
+        <DateRangeFields
+          control={props.control}
+          startName={`projects.${props.index}.startDate`}
+          endName={`projects.${props.index}.endDate`}
+          presentLabel={t("present")}
+        />
+
+        <Controller
+          control={props.control}
+          name={`projects.${props.index}.description`}
+          render={({ field, fieldState }) => (
+            <Field>
+              <FieldLabel htmlFor={field.name}>{t("summary")}</FieldLabel>
+              <RichTextEditor
+                id={field.name}
+                value={field.value}
+                features={PROSE_FEATURES}
+                placeholder={t("summaryPlaceholder")}
+                onChange={field.onChange}
+                onBlur={field.onBlur}
+              />
+              <FieldError errors={[fieldState.error]} />
+            </Field>
+          )}
+        />
+      </FieldGroup>
+    </FieldSet>
+  );
+}

--- a/src/components/editor/editor-sections/ed-section-projects/ed-section-projects-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-projects/ed-section-projects-form.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { FolderGit2, Plus } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useEffect } from "react";
+import { useFieldArray, useForm } from "react-hook-form";
+import { EmptyState } from "@/components/shared/empty-state";
+import { Button } from "@/components/ui/button";
+import {
+  FieldDescription,
+  FieldGroup,
+  FieldLegend,
+  FieldSet,
+} from "@/components/ui/field";
+import { emptyRichTextValue } from "@/lib/resume";
+import { useResumeStore } from "@/lib/store";
+import {
+  applyProjectsValues,
+  type ProjectItemValues,
+  type ProjectsFormValues,
+  toProjectsValues,
+} from "../resume-form-adapter";
+import { EditorSectionProjectsFormItem } from "./ed-section-projects-form-item";
+
+function emptyProject(): ProjectItemValues {
+  return {
+    title: "",
+    company: "",
+    website: "",
+    startDate: "",
+    endDate: "",
+    description: emptyRichTextValue(),
+  };
+}
+
+export function EditorSectionProjectsForm() {
+  const open = useResumeStore((state) => state.open);
+  const updateOpen = useResumeStore((state) => state.updateOpen);
+  const t = useTranslations("editor.projects");
+  const tc = useTranslations("editor.common");
+
+  const form = useForm<ProjectsFormValues>({
+    defaultValues: open ? toProjectsValues(open) : { projects: [] },
+  });
+  const { fields, prepend, remove } = useFieldArray({
+    control: form.control,
+    name: "projects",
+  });
+
+  // The field array owns the list; every form change (including add/remove)
+  // rebuilds the store entries. Subscribing to the form and writing to the
+  // store is a valid external-system sync; the store debounces the IndexedDB
+  // write. Reading getValues() inside the callback avoids stale-value timing.
+  useEffect(() => {
+    const subscription = form.watch(() => {
+      updateOpen((draft) => applyProjectsValues(draft, form.getValues()));
+    });
+    return () => subscription.unsubscribe();
+  }, [form, updateOpen]);
+
+  if (!open) return null;
+
+  return (
+    <form>
+      <FieldSet className="gap-3">
+        <FieldLegend className="sr-only">{t("legend")}</FieldLegend>
+        <FieldDescription className="sr-only">
+          {t("legendDesc")}
+        </FieldDescription>
+        <Button
+          type="button"
+          onClick={() => prepend(emptyProject())}
+          variant="outline"
+          className="w-full"
+        >
+          <Plus /> <span className="sr-only">{tc("add")} </span>
+          {t("add")}
+        </Button>
+
+        {fields.length === 0 ? (
+          <EmptyState
+            icon={FolderGit2}
+            title={t("emptyTitle")}
+            description={t("emptyDescription")}
+          />
+        ) : (
+          <FieldGroup className="gap-4">
+            {fields.map((field, index) => (
+              <EditorSectionProjectsFormItem
+                key={field.id}
+                control={form.control}
+                index={index}
+                onRemoveField={remove}
+              />
+            ))}
+          </FieldGroup>
+        )}
+      </FieldSet>
+    </form>
+  );
+}

--- a/src/components/editor/editor-sections/ed-section-projects/ed-section-projects.tsx
+++ b/src/components/editor/editor-sections/ed-section-projects/ed-section-projects.tsx
@@ -1,0 +1,24 @@
+import { FolderGit2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import {
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { EditorSectionProjectsForm } from "./ed-section-projects-form";
+
+export function EditorSectionProjects() {
+  const t = useTranslations("editor.projects");
+
+  return (
+    <AccordionItem>
+      <AccordionTrigger className="items-center gap-3">
+        <FolderGit2 className="size-4" /> {t("accordionTitle")}
+      </AccordionTrigger>
+
+      <AccordionContent>
+        <EditorSectionProjectsForm />
+      </AccordionContent>
+    </AccordionItem>
+  );
+}

--- a/src/components/editor/editor-sections/resume-form-adapter.ts
+++ b/src/components/editor/editor-sections/resume-form-adapter.ts
@@ -45,6 +45,19 @@ export interface InternshipFormValues {
   internships: InternshipItemValues[];
 }
 
+export interface ProjectItemValues {
+  title: string;
+  company: string;
+  website: string;
+  startDate: string;
+  endDate: string;
+  description: JSONContent;
+}
+
+export interface ProjectsFormValues {
+  projects: ProjectItemValues[];
+}
+
 export interface OrganizationItemValues {
   role: string;
   organization: string;
@@ -249,6 +262,44 @@ export function applyInternshipValues(
   const section = sectionOfType(draft, "internship");
   if (!section) return;
   section.entries = values.internships.map((item, index) => ({
+    id: entryId(section, index),
+    fields: {
+      title: plain(item.title),
+      company: plain(item.company),
+      website: plain(item.website),
+      startDate: plain(item.startDate),
+      endDate: plain(item.endDate),
+      description: rich(item.description),
+    },
+  }));
+}
+
+// --- Projects (repeating section entries) -----------------------------------
+
+export function projectEntries(resume: Resume): Entry[] {
+  return sectionOfType(resume, "projects")?.entries ?? [];
+}
+
+export function toProjectsValues(resume: Resume): ProjectsFormValues {
+  return {
+    projects: projectEntries(resume).map((entry) => ({
+      title: plainValue(entry.fields.title),
+      company: plainValue(entry.fields.company),
+      website: plainValue(entry.fields.website),
+      startDate: plainValue(entry.fields.startDate),
+      endDate: plainValue(entry.fields.endDate),
+      description: richValue(entry.fields.description),
+    })),
+  };
+}
+
+export function applyProjectsValues(
+  draft: Resume,
+  values: ProjectsFormValues,
+): void {
+  const section = sectionOfType(draft, "projects");
+  if (!section) return;
+  section.entries = values.projects.map((item, index) => ({
     id: entryId(section, index),
     fields: {
       title: plain(item.title),

--- a/src/components/editor/resume-blocks.ts
+++ b/src/components/editor/resume-blocks.ts
@@ -145,6 +145,22 @@ export function buildResumeBlocks(resume: ResumePreview): ResumeBlock[] {
     );
   }
 
+  const projects = resume.projects.filter(hasExperience);
+  if (projects.length > 0) {
+    blocks.push(
+      heading("projects-heading", labels.projects),
+      ...projects.map(
+        (item, index): ResumeBlock => ({
+          id: item.id,
+          kind: "experience",
+          item,
+          gapBefore: entryGap(index),
+          keepWithNext: false,
+        }),
+      ),
+    );
+  }
+
   const organizations = resume.organizations.filter(hasExperience);
   if (organizations.length > 0) {
     blocks.push(

--- a/src/components/editor/resume-preview.ts
+++ b/src/components/editor/resume-preview.ts
@@ -79,6 +79,12 @@ export interface ResumePreview {
    */
   internship: ExperienceItemView[];
   /**
+   * Project entries reuse `ExperienceItemView`: `role` holds the project name
+   * and `company` the contributor role, so they render through the experience
+   * path in every template and export; only the section heading differs.
+   */
+  projects: ExperienceItemView[];
+  /**
    * Organization entries (volunteer, student, community roles) are
    * presentationally identical to experience entries, so they reuse
    * `ExperienceItemView` (`company` holds the organization name) and every

--- a/src/components/editor/resume-to-preview.ts
+++ b/src/components/editor/resume-to-preview.ts
@@ -153,6 +153,21 @@ export function resumeToPreview(resume: Resume): ResumePreview {
       })
       .sort(byRecency)
       .map(localizeDates),
+    projects: (sectionOfType(resume, "projects")?.entries ?? [])
+      .map((entry) => {
+        const website = plain(entry.fields.website);
+        return {
+          id: entry.id,
+          role: plain(entry.fields.title),
+          company: plain(entry.fields.company),
+          companyHref: website ? withHttps(website) : undefined,
+          startDate: plain(entry.fields.startDate),
+          endDate: plain(entry.fields.endDate),
+          description: richBlocks(entry.fields.description),
+        };
+      })
+      .sort(byRecency)
+      .map(localizeDates),
     organizations: (sectionOfType(resume, "organizations")?.entries ?? [])
       .map((entry) => ({
         id: entry.id,

--- a/src/lib/resume/factory.ts
+++ b/src/lib/resume/factory.ts
@@ -77,6 +77,7 @@ export function createEmptyResume(title: string): Resume {
       createEmptySection("summary"),
       createEmptySection("experience"),
       createEmptySection("internship"),
+      createEmptySection("projects"),
       createEmptySection("organizations"),
       createEmptySection("education"),
       createEmptySection("skills"),

--- a/src/lib/resume/labels.ts
+++ b/src/lib/resume/labels.ts
@@ -6,6 +6,7 @@ interface DocumentLabels {
   summary: string;
   experience: string;
   internship: string;
+  projects: string;
   organizations: string;
   education: string;
   certificates: string;
@@ -27,6 +28,7 @@ export const RESUME_LABELS: Record<ResumeLanguage, DocumentLabels> = {
     summary: "Summary",
     experience: "Experience",
     internship: "Internship",
+    projects: "Projects",
     organizations: "Organizations",
     education: "Education",
     certificates: "Certificates",
@@ -52,6 +54,7 @@ export const RESUME_LABELS: Record<ResumeLanguage, DocumentLabels> = {
     summary: "Ringkasan",
     experience: "Pengalaman",
     internship: "Magang",
+    projects: "Proyek",
     organizations: "Organisasi",
     education: "Pendidikan",
     certificates: "Sertifikat",

--- a/src/lib/resume/migrations.ts
+++ b/src/lib/resume/migrations.ts
@@ -325,6 +325,45 @@ const migrateV7toV8: Migration = (doc) => {
 };
 
 /**
+ * v8→v9: adds the Projects section (structurally identical to Experience, only
+ * the heading differs). Existing documents gain it (with one empty entry) if it
+ * is not already present, so the new editor form has somewhere to write.
+ */
+const migrateV8toV9: Migration = (doc) => {
+  const next = structuredClone(doc);
+  const sections = Array.isArray(next.sections)
+    ? (next.sections as Array<Record<string, unknown>>)
+    : [];
+
+  if (!sections.some((s) => s.type === "projects")) {
+    sections.push({
+      id: nanoid(),
+      type: "projects",
+      title: "Projects",
+      entries: [
+        {
+          id: nanoid(),
+          fields: {
+            title: plainField(""),
+            company: plainField(""),
+            website: plainField(""),
+            startDate: plainField(""),
+            endDate: plainField(""),
+            description: {
+              kind: "richtext",
+              value: { type: "doc", content: [{ type: "paragraph" }] },
+            },
+          },
+        },
+      ],
+    });
+  }
+
+  next.sections = sections;
+  return next;
+};
+
+/**
  * The migration ladder. Each key N is a forward-only step from version N to N+1.
  */
 const LADDER: Record<number, Migration> = {
@@ -335,6 +374,7 @@ const LADDER: Record<number, Migration> = {
   5: migrateV5toV6,
   6: migrateV6toV7,
   7: migrateV7toV8,
+  8: migrateV8toV9,
 };
 
 /** The persisted schemaVersion of a raw document; 0 when absent or malformed. */

--- a/src/lib/resume/schema-registry.ts
+++ b/src/lib/resume/schema-registry.ts
@@ -198,6 +198,49 @@ export const SECTION_REGISTRY: Record<SectionType, SectionSchema> = {
       },
     ],
   },
+  projects: {
+    type: "projects",
+    defaultTitle: "Projects",
+    singleton: false,
+    fields: [
+      {
+        key: "title",
+        label: "Project name",
+        kind: "plain",
+        placeholder: "react-a11y-kit",
+      },
+      {
+        key: "company",
+        label: "Role",
+        kind: "plain",
+        placeholder: "Maintainer",
+      },
+      {
+        key: "website",
+        label: "Project URL",
+        kind: "plain",
+        placeholder: "github.com/you/project",
+      },
+      {
+        key: "startDate",
+        label: "Start date",
+        kind: "plain",
+        placeholder: "Jan 2023",
+      },
+      {
+        key: "endDate",
+        label: "End date",
+        kind: "plain",
+        placeholder: "Present",
+      },
+      {
+        key: "description",
+        label: "Description",
+        kind: "richtext",
+        features: PROSE_FEATURES,
+      },
+    ],
+  },
   organizations: {
     type: "organizations",
     defaultTitle: "Organizations",

--- a/src/lib/resume/seed.ts
+++ b/src/lib/resume/seed.ts
@@ -267,6 +267,37 @@ export const SEED_RESUME: Resume = {
       ],
     },
     {
+      id: "seed-projects",
+      type: "projects",
+      title: "Projects",
+      entries: [
+        {
+          id: "seed-projects-1",
+          fields: {
+            title: plain("react-a11y-kit"),
+            company: plain("Creator & maintainer"),
+            website: plain("github.com/johndoe/react-a11y-kit"),
+            startDate: plain("2020"),
+            endDate: plain("Present"),
+            description: prose(
+              ul(
+                li(
+                  t("Open-source accessibility toolkit for React with "),
+                  b("2k+ stars"),
+                  t(" and 40+ contributors."),
+                ),
+                li(
+                  t(
+                    "Ships audited, WCAG-compliant primitives adopted across several production design systems.",
+                  ),
+                ),
+              ),
+            ),
+          },
+        },
+      ],
+    },
+    {
       id: "seed-organizations",
       type: "organizations",
       title: "Organizations",

--- a/src/lib/resume/types.ts
+++ b/src/lib/resume/types.ts
@@ -5,7 +5,7 @@ import type { JSONContent } from "@tiptap/core";
  * governs object-store/index structure only. Bumped whenever a persisted field
  * shape changes; every bump gets a forward-only step in the migration ladder.
  */
-export const CURRENT_SCHEMA_VERSION = 8;
+export const CURRENT_SCHEMA_VERSION = 9;
 
 /** The language the rendered document's fixed labels (headings, dates) use. */
 export type ResumeLanguage = "en" | "id";
@@ -42,6 +42,7 @@ export type SectionType =
   | "summary"
   | "experience"
   | "internship"
+  | "projects"
   | "organizations"
   | "education"
   | "skills"


### PR DESCRIPTION
Adds a Projects section so people can list side projects, open-source work, and things they've shipped as their own entries rather than burying them in Experience.

Each entry carries a project name, a role, a project URL, an optional date range, and a description. Structurally it reuses the experience view-model and the shared "experience" block, the same approach Internship and Organizations already take, so every template PDF, DOCX, and plain-text export renders it through the validated experience path with no renderer changes. The role line becomes the link when a URL is set. Reading order is Experience, Internship, Projects, Organizations.

The persisted shape moves to schemaVersion 9. New documents and the seed include the section; a forward-only migration adds it (with one empty entry) to existing documents that lack it, and bails out without touching data it does not recognize. The IndexedDB version is untouched, since no object store changed.

Verified the seed résumé exports cleanly across plain text, DOCX, and all seven PDF templates with reading order and every field preserved. Confirmed new and blank documents carry the section, a version 8 document without it migrates up and gains it with existing experience entries intact, and a project projects into the preview with its link resolving on the role line. Both English and Indonesian carry the section copy and the document heading (Projects / Proyek).

One behavior to note: because Projects reuses the experience item, an entry with no dates renders a bare "-" on the right, the same as Experience and Internship today. Happy to make the date range render conditionally across all experience-like items in a follow-up if we want that.