### PR TITLE
feat: add a tooltip to the sidebar create resume button

### DIFF
--- a/src/components/platform/platform-sidebar-resume-create.tsx
+++ b/src/components/platform/platform-sidebar-resume-create.tsx
@@ -4,6 +4,7 @@ import { Plus } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { Button } from "../ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 import { PlatformResumeCreateDialog } from "./platform-resume-create-dialog";
 
 export function PlatformSidebarResumeCreate() {
@@ -12,14 +13,21 @@ export function PlatformSidebarResumeCreate() {
 
   return (
     <>
-      <Button
-        size="icon-xs"
-        className="ml-auto"
-        variant="ghost"
-        onClick={() => setOpen(true)}
-      >
-        <Plus /> <span className="sr-only">{t("createResume")}</span>
-      </Button>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              size="icon-xs"
+              className="ml-auto"
+              variant="ghost"
+              onClick={() => setOpen(true)}
+            />
+          }
+        >
+          <Plus /> <span className="sr-only">{t("createResume")}</span>
+        </TooltipTrigger>
+        <TooltipContent>{t("createResume")}</TooltipContent>
+      </Tooltip>
 
       <PlatformResumeCreateDialog open={open} onOpenChange={setOpen} />
     </>


### PR DESCRIPTION
The collapsed sidebar's create button is an icon-only control, so its purpose was not obvious at a glance. This wraps it in a tooltip that surfaces the "Create résumé" label on hover and focus, reusing the existing createResume translation. Behavior and the accessible name are unchanged; the button still opens the create dialog.