### PR TITLE
docs: add the 0.7.0 changelog entry for the what's new sheet

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -153,6 +153,11 @@
       "latest": "Latest",
       "fullChangelog": "Full changelog on GitHub",
       "entries": {
+        "0_7_0": [
+          "New Internship section: list internships as their own entries, separate from full-time roles, with the same fields as Experience.",
+          "New Projects section: give side projects, open-source work, and anything you've shipped their own space, each with a name, link, dates, and description.",
+          "A blank résumé now shows a preview placeholder in your library instead of an empty white card, so a new résumé looks intentional until you start writing."
+        ],
         "0_6_0": [
           "Lanjut now speaks Bahasa Indonesia. Switch the entire interface between English and Indonesian anytime with the language toggle in the navbar.",
           "Give each résumé its own language: pick English or Indonesian per document, and the section headings and dates in your PDF, DOCX, and TXT exports follow that choice.",

--- a/messages/id.json
+++ b/messages/id.json
@@ -153,6 +153,11 @@
       "latest": "Terbaru",
       "fullChangelog": "Changelog lengkap di GitHub",
       "entries": {
+        "0_7_0": [
+          "Ada bagian Magang baru: tulis pengalaman magang sebagai entri terpisah dari pekerjaan tetap, dengan kolom yang sama seperti Pengalaman.",
+          "Ada bagian Proyek baru: pamerkan proyek sampingan, kontribusi open-source, atau apa pun yang pernah kamu rilis, lengkap dengan nama, tautan, tanggal, dan deskripsi.",
+          "Resume yang masih kosong kini menampilkan pratinjau samar di pustaka, bukan kartu putih polos, jadi resume baru tetap terlihat rapi sebelum kamu mulai mengisinya."
+        ],
         "0_6_0": [
           "Lanjut sekarang bisa Bahasa Indonesia. Ganti seluruh tampilan antara Bahasa Inggris dan Indonesia kapan saja lewat tombol bahasa di bilah navigasi.",
           "Tiap resume bisa punya bahasanya sendiri: pilih Bahasa Inggris atau Indonesia per dokumen, dan judul bagian serta tanggal di ekspor PDF, DOCX, dan TXT kamu mengikuti pilihan itu.",

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -10,6 +10,7 @@ export interface ChangelogEntry {
  * highlights in both locale files as part of each release PR.
  */
 export const CHANGELOG: ChangelogEntry[] = [
+  { version: "0.7.0", date: "2026-07-10" },
   { version: "0.6.0", date: "2026-07-08" },
   { version: "0.5.0", date: "2026-07-06" },
   { version: "0.4.0", date: "2026-07-05" },


### PR DESCRIPTION
Adds the 0.7.0 entry to the in-app What's new sheet, covering everything shipped since 0.6.0: the Internship section, the Projects section, and the blank-résumé preview placeholder in the library. Highlights are written in the same plain, benefit-first voice as prior entries, in both English and Indonesian.

Adds the version and date to the changelog metadata and the highlight strings to both locale files. This also flips LATEST_CHANGELOG_VERSION to 0.7.0, so the navbar surfaces the unseen indicator until a user opens the sheet.

Version and package bumps are left to the release tooling; this is only the human-readable sheet content.