### PR TITLE
feat: add a one or two column toggle to the resume skills section

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -519,7 +519,12 @@
       "namePlaceholder": "TypeScript",
       "proficiency": "Proficiency",
       "reorder": "Reorder skill",
-      "remove": "Remove skill"
+      "remove": "Remove skill",
+      "columnsLabel": "Columns",
+      "columnsOne": "1",
+      "columnsOneAria": "One column",
+      "columnsTwo": "2",
+      "columnsTwoAria": "Two columns"
     },
     "languages": {
       "accordionTitle": "Languages",

--- a/messages/id.json
+++ b/messages/id.json
@@ -519,7 +519,12 @@
       "namePlaceholder": "TypeScript",
       "proficiency": "Tingkat",
       "reorder": "Ubah urutan keahlian",
-      "remove": "Hapus keahlian"
+      "remove": "Hapus keahlian",
+      "columnsLabel": "Kolom",
+      "columnsOne": "1",
+      "columnsOneAria": "Satu kolom",
+      "columnsTwo": "2",
+      "columnsTwoAria": "Dua kolom"
     },
     "languages": {
       "accordionTitle": "Bahasa",

--- a/src/components/editor/editor-sections/ed-section-skills/ed-section-skills-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-skills/ed-section-skills-form.tsx
@@ -21,6 +21,7 @@ import {
   toSkillsValues,
 } from "../resume-form-adapter";
 import { EditorSectionSkillsFormItem } from "./ed-section-skills-form-item";
+import { SkillsColumnsToggle } from "./skills-columns-toggle";
 
 function emptySkill(): SkillItemValues {
   return { name: "", level: "" };
@@ -76,22 +77,25 @@ export function EditorSectionSkillsForm() {
             description={t("emptyDescription")}
           />
         ) : (
-          <SortableList
-            items={fields.map((field) => field.id)}
-            onReorder={handleReorder}
-          >
-            <FieldGroup className="gap-2">
-              {fields.map((field, index) => (
-                <EditorSectionSkillsFormItem
-                  key={field.id}
-                  id={field.id}
-                  control={form.control}
-                  index={index}
-                  onRemoveField={remove}
-                />
-              ))}
-            </FieldGroup>
-          </SortableList>
+          <>
+            <SkillsColumnsToggle />
+            <SortableList
+              items={fields.map((field) => field.id)}
+              onReorder={handleReorder}
+            >
+              <FieldGroup className="gap-2">
+                {fields.map((field, index) => (
+                  <EditorSectionSkillsFormItem
+                    key={field.id}
+                    id={field.id}
+                    control={form.control}
+                    index={index}
+                    onRemoveField={remove}
+                  />
+                ))}
+              </FieldGroup>
+            </SortableList>
+          </>
         )}
       </FieldSet>
     </form>

--- a/src/components/editor/editor-sections/ed-section-skills/skills-columns-toggle.tsx
+++ b/src/components/editor/editor-sections/ed-section-skills/skills-columns-toggle.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { SegmentedControl } from "@/components/shared/segmented-control";
+import type { SectionColumns } from "@/lib/resume/types";
+import { useResumeStore } from "@/lib/store";
+
+export function SkillsColumnsToggle() {
+  const columns = useResumeStore(
+    (state) =>
+      state.open?.sections.find((s) => s.type === "skills")?.columns ?? 2,
+  );
+  const updateOpen = useResumeStore((state) => state.updateOpen);
+  const t = useTranslations("editor.skills");
+
+  function handleChange(value: string) {
+    const next: SectionColumns = value === "1" ? 1 : 2;
+    updateOpen((draft) => {
+      const section = draft.sections.find((s) => s.type === "skills");
+      if (section) section.columns = next;
+    });
+  }
+
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-sm text-muted-foreground">{t("columnsLabel")}</span>
+      <SegmentedControl
+        aria-label={t("columnsLabel")}
+        value={String(columns)}
+        onValueChange={handleChange}
+        items={[
+          {
+            value: "1",
+            label: t("columnsOne"),
+            ariaLabel: t("columnsOneAria"),
+          },
+          {
+            value: "2",
+            label: t("columnsTwo"),
+            ariaLabel: t("columnsTwoAria"),
+          },
+        ]}
+      />
+    </div>
+  );
+}

--- a/src/components/editor/pdf/awal-pdf-document.tsx
+++ b/src/components/editor/pdf/awal-pdf-document.tsx
@@ -166,7 +166,7 @@ function PdfBlock(props: { block: ResumeBlock }) {
     case "certificate":
       return <PdfCertificate item={block.item} />;
     case "skills":
-      return <PdfGrid items={block.items} />;
+      return <PdfGrid items={block.items} columns={block.columns} />;
     case "languages":
       return <PdfGrid items={block.items} />;
   }

--- a/src/components/editor/pdf/ketat-pdf-document.tsx
+++ b/src/components/editor/pdf/ketat-pdf-document.tsx
@@ -189,7 +189,7 @@ function KetatBlock(props: { block: ResumeBlock }) {
     case "certificate":
       return <KetatCertificate item={block.item} />;
     case "skills":
-      return <PdfGrid items={block.items} />;
+      return <PdfGrid items={block.items} columns={block.columns} />;
     case "languages":
       return <PdfGrid items={block.items} />;
   }

--- a/src/components/editor/pdf/ketik-pdf-document.tsx
+++ b/src/components/editor/pdf/ketik-pdf-document.tsx
@@ -182,7 +182,7 @@ function KetikBlock(props: { block: ResumeBlock }) {
     case "certificate":
       return <KetikCertificate item={block.item} />;
     case "skills":
-      return <PdfGrid items={block.items} />;
+      return <PdfGrid items={block.items} columns={block.columns} />;
     case "languages":
       return <PdfGrid items={block.items} />;
   }

--- a/src/components/editor/pdf/klasik-pdf-document.tsx
+++ b/src/components/editor/pdf/klasik-pdf-document.tsx
@@ -182,7 +182,7 @@ function KlasikBlock(props: { block: ResumeBlock }) {
     case "certificate":
       return <KlasikCertificate item={block.item} />;
     case "skills":
-      return <PdfGrid items={block.items} />;
+      return <PdfGrid items={block.items} columns={block.columns} />;
     case "languages":
       return <PdfGrid items={block.items} />;
   }

--- a/src/components/editor/pdf/luasa-pdf-document.tsx
+++ b/src/components/editor/pdf/luasa-pdf-document.tsx
@@ -184,7 +184,7 @@ function LuasaBlock(props: { block: ResumeBlock }) {
     case "certificate":
       return <LuasaCertificate item={block.item} />;
     case "skills":
-      return <PdfGrid items={block.items} />;
+      return <PdfGrid items={block.items} columns={block.columns} />;
     case "languages":
       return <PdfGrid items={block.items} />;
   }

--- a/src/components/editor/pdf/pdf-grid.tsx
+++ b/src/components/editor/pdf/pdf-grid.tsx
@@ -1,11 +1,11 @@
 import { StyleSheet, Text, View } from "@react-pdf/renderer";
+import type { SectionColumns } from "@/lib/resume/types";
 import type { LanguageItemView, SkillItemView } from "../resume-preview";
 import { PDF_COLORS } from "./pdf-fonts";
 
 const styles = StyleSheet.create({
   grid: { flexDirection: "row", flexWrap: "wrap" },
   gridItem: {
-    width: "50%",
     flexDirection: "row",
     justifyContent: "space-between",
     gap: 8,
@@ -22,14 +22,20 @@ export function dateRange(start: string, end: string): string {
   return `${start} - ${end}`;
 }
 
-/** Two-column [name … proficiency] grid shared by the Skills/Languages blocks. */
+/**
+ * [name … proficiency] grid shared by the Skills/Languages blocks. `columns`
+ * controls only the visual layout: items are still emitted in linear reading
+ * order, so text extraction is unaffected by the column count (defaults to two).
+ */
 export function PdfGrid(props: {
   items: (SkillItemView | LanguageItemView)[];
+  columns?: SectionColumns;
 }) {
+  const width = props.columns === 1 ? "100%" : "50%";
   return (
     <View style={styles.grid}>
       {props.items.map((item) => (
-        <View key={item.id} style={styles.gridItem}>
+        <View key={item.id} style={[styles.gridItem, { width }]}>
           <Text style={styles.gridName}>{item.name}</Text>
           {item.proficiency ? (
             <Text style={styles.muted}>{item.proficiency}</Text>

--- a/src/components/editor/pdf/tebal-pdf-document.tsx
+++ b/src/components/editor/pdf/tebal-pdf-document.tsx
@@ -178,7 +178,7 @@ function TebalBlock(props: { block: ResumeBlock }) {
     case "certificate":
       return <TebalCertificate item={block.item} />;
     case "skills":
-      return <PdfGrid items={block.items} />;
+      return <PdfGrid items={block.items} columns={block.columns} />;
     case "languages":
       return <PdfGrid items={block.items} />;
   }

--- a/src/components/editor/resume-block-view.tsx
+++ b/src/components/editor/resume-block-view.tsx
@@ -28,7 +28,7 @@ export function ResumeBlockView(props: ResumeBlockViewProps) {
     case "certificate":
       return <ResumeCertificateItem {...block.item} />;
     case "skills":
-      return <ResumeSkillsList items={block.items} />;
+      return <ResumeSkillsList items={block.items} columns={block.columns} />;
     case "languages":
       return <ResumeLanguagesList items={block.items} />;
   }

--- a/src/components/editor/resume-blocks.ts
+++ b/src/components/editor/resume-blocks.ts
@@ -1,4 +1,5 @@
 import { RESUME_LABELS } from "@/lib/resume/labels";
+import type { SectionColumns } from "@/lib/resume/types";
 import type {
   CertificateItemView,
   EducationItemView,
@@ -35,7 +36,7 @@ export type ResumeBlock = BlockMeta &
     | { kind: "experience"; item: ExperienceItemView }
     | { kind: "education"; item: EducationItemView }
     | { kind: "certificate"; item: CertificateItemView }
-    | { kind: "skills"; items: SkillItemView[] }
+    | { kind: "skills"; items: SkillItemView[]; columns: SectionColumns }
     | { kind: "languages"; items: LanguageItemView[] }
   );
 
@@ -215,6 +216,7 @@ export function buildResumeBlocks(resume: ResumePreview): ResumeBlock[] {
       id: "skills-body",
       kind: "skills",
       items: skills,
+      columns: resume.skillsColumns,
       gapBefore: GAP.body,
       keepWithNext: false,
     });

--- a/src/components/editor/resume-preview.ts
+++ b/src/components/editor/resume-preview.ts
@@ -7,7 +7,7 @@
  * Data → adapter → consumer: these types are the consumer contract.
  */
 
-import type { ResumeLanguage } from "@/lib/resume/types";
+import type { ResumeLanguage, SectionColumns } from "@/lib/resume/types";
 import type { RichBlock } from "./rich-content";
 
 export type ContactKind = "phone" | "email" | "website" | "location";
@@ -94,5 +94,7 @@ export interface ResumePreview {
   education: EducationItemView[];
   certificates: CertificateItemView[];
   skills: SkillItemView[];
+  /** Presentation-only column count for the skills grid; defaults to two. */
+  skillsColumns: SectionColumns;
   languages: LanguageItemView[];
 }

--- a/src/components/editor/resume-skills-list.tsx
+++ b/src/components/editor/resume-skills-list.tsx
@@ -1,13 +1,21 @@
+import type { SectionColumns } from "@/lib/resume/types";
+import { cn } from "@/lib/utils";
 import type { SkillItemView } from "./resume-preview";
 import { ResumeSkillItem } from "./resume-skill-item";
 
 interface ResumeSkillsListProps {
   items: SkillItemView[];
+  columns: SectionColumns;
 }
 
 export function ResumeSkillsList(props: ResumeSkillsListProps) {
   return (
-    <ul className="grid grid-cols-2 gap-x-8 gap-y-1">
+    <ul
+      className={cn(
+        "grid gap-x-8 gap-y-1",
+        props.columns === 1 ? "grid-cols-1" : "grid-cols-2",
+      )}
+    >
       {props.items.map((item) => (
         <ResumeSkillItem key={item.id} {...item} />
       ))}

--- a/src/components/editor/resume-to-preview.ts
+++ b/src/components/editor/resume-to-preview.ts
@@ -208,6 +208,7 @@ export function resumeToPreview(resume: Resume): ResumePreview {
       name: plain(entry.fields.name),
       proficiency: plain(entry.fields.level),
     })),
+    skillsColumns: sectionOfType(resume, "skills")?.columns ?? 2,
     languages: (sectionOfType(resume, "languages")?.entries ?? []).map(
       (entry) => ({
         id: entry.id,

--- a/src/components/editor/templates/ketat/ketat-block-view.tsx
+++ b/src/components/editor/templates/ketat/ketat-block-view.tsx
@@ -29,7 +29,7 @@ export function KetatBlockView(props: KetatBlockViewProps) {
     case "certificate":
       return <KetatCertificateItem {...block.item} />;
     case "skills":
-      return <ResumeSkillsList items={block.items} />;
+      return <ResumeSkillsList items={block.items} columns={block.columns} />;
     case "languages":
       return <ResumeLanguagesList items={block.items} />;
   }

--- a/src/components/editor/templates/ketik/ketik-block-view.tsx
+++ b/src/components/editor/templates/ketik/ketik-block-view.tsx
@@ -29,7 +29,7 @@ export function KetikBlockView(props: KetikBlockViewProps) {
     case "certificate":
       return <KetikCertificateItem {...block.item} />;
     case "skills":
-      return <ResumeSkillsList items={block.items} />;
+      return <ResumeSkillsList items={block.items} columns={block.columns} />;
     case "languages":
       return <ResumeLanguagesList items={block.items} />;
   }

--- a/src/components/editor/templates/klasik/klasik-block-view.tsx
+++ b/src/components/editor/templates/klasik/klasik-block-view.tsx
@@ -31,7 +31,7 @@ export function KlasikBlockView(props: KlasikBlockViewProps) {
     case "skills":
       return (
         <div className="font-serif">
-          <ResumeSkillsList items={block.items} />
+          <ResumeSkillsList items={block.items} columns={block.columns} />
         </div>
       );
     case "languages":

--- a/src/components/editor/templates/luasa/luasa-block-view.tsx
+++ b/src/components/editor/templates/luasa/luasa-block-view.tsx
@@ -29,7 +29,7 @@ export function LuasaBlockView(props: LuasaBlockViewProps) {
     case "certificate":
       return <LuasaCertificateItem {...block.item} />;
     case "skills":
-      return <ResumeSkillsList items={block.items} />;
+      return <ResumeSkillsList items={block.items} columns={block.columns} />;
     case "languages":
       return <ResumeLanguagesList items={block.items} />;
   }

--- a/src/components/editor/templates/tebal/tebal-block-view.tsx
+++ b/src/components/editor/templates/tebal/tebal-block-view.tsx
@@ -29,7 +29,7 @@ export function TebalBlockView(props: TebalBlockViewProps) {
     case "certificate":
       return <TebalCertificateItem {...block.item} />;
     case "skills":
-      return <ResumeSkillsList items={block.items} />;
+      return <ResumeSkillsList items={block.items} columns={block.columns} />;
     case "languages":
       return <ResumeLanguagesList items={block.items} />;
   }

--- a/src/lib/resume/factory.ts
+++ b/src/lib/resume/factory.ts
@@ -47,12 +47,15 @@ export function createEmptyEntry(type: SectionType): Entry {
 
 export function createEmptySection(type: SectionType): Section {
   const schema = getSectionSchema(type);
-  return {
+  const section: Section = {
     id: nanoid(),
     type,
     title: schema.defaultTitle,
     entries: [],
   };
+  // The Skills grid is column-toggleable; new sections start two-column.
+  if (type === "skills") section.columns = 2;
+  return section;
 }
 
 export function createEmptyHeader(): Header {

--- a/src/lib/resume/migrations.ts
+++ b/src/lib/resume/migrations.ts
@@ -364,6 +364,25 @@ const migrateV8toV9: Migration = (doc) => {
 };
 
 /**
+ * v9→v10: adds the presentation-only `columns` count to the Skills section so its
+ * grid can be toggled between one and two columns. Existing documents default to
+ * two, preserving their current layout. Bail-safe: no Skills section means no-op.
+ */
+const migrateV9toV10: Migration = (doc) => {
+  const next = structuredClone(doc);
+  const sections = Array.isArray(next.sections)
+    ? (next.sections as Array<Record<string, unknown>>)
+    : [];
+
+  const skills = sections.find((s) => s.type === "skills");
+  if (skills && skills.columns !== 1 && skills.columns !== 2) {
+    skills.columns = 2;
+  }
+
+  return next;
+};
+
+/**
  * The migration ladder. Each key N is a forward-only step from version N to N+1.
  */
 const LADDER: Record<number, Migration> = {
@@ -375,6 +394,7 @@ const LADDER: Record<number, Migration> = {
   6: migrateV6toV7,
   7: migrateV7toV8,
   8: migrateV8toV9,
+  9: migrateV9toV10,
 };
 
 /** The persisted schemaVersion of a raw document; 0 when absent or malformed. */

--- a/src/lib/resume/seed.ts
+++ b/src/lib/resume/seed.ts
@@ -392,6 +392,7 @@ export const SEED_RESUME: Resume = {
       id: "seed-skills",
       type: "skills",
       title: "Skills",
+      columns: 2,
       entries: [
         {
           id: "seed-skills-1",

--- a/src/lib/resume/types.ts
+++ b/src/lib/resume/types.ts
@@ -5,10 +5,17 @@ import type { JSONContent } from "@tiptap/core";
  * governs object-store/index structure only. Bumped whenever a persisted field
  * shape changes; every bump gets a forward-only step in the migration ladder.
  */
-export const CURRENT_SCHEMA_VERSION = 9;
+export const CURRENT_SCHEMA_VERSION = 10;
 
 /** The language the rendered document's fixed labels (headings, dates) use. */
 export type ResumeLanguage = "en" | "id";
+
+/**
+ * Presentation-only column count for grid-rendered sections (skills). Governs the
+ * on-screen preview and PDF visual layout only; it never changes reading order,
+ * and inherently linear exports (docx, plain text) ignore it.
+ */
+export type SectionColumns = 1 | 2;
 
 export type FieldKind = "plain" | "richtext";
 
@@ -59,6 +66,11 @@ export interface Section {
   type: SectionType;
   title: string;
   entries: Entry[];
+  /**
+   * Presentation-only column count for grid-rendered sections (skills). Absent on
+   * non-grid sections; renderers default to a two-column grid when unset.
+   */
+  columns?: SectionColumns;
 }
 
 /**


### PR DESCRIPTION
Adds a per-résumé toggle for rendering the skills section as one or two columns, controlled from a segmented control in the skills editor. The choice is stored on the skills section as presentation-only metadata and defaults to two columns, so existing résumés look unchanged.

This is a presentation-layer change only. The column count affects the on-screen preview and the visual PDF layout, but skills are still emitted in linear reading order, so PDF text extraction and the docx export are untouched (docx stays one skill per line regardless). The document shape moves to schemaVersion 10 with a bail-safe read-time migration that defaults existing skills sections to two columns and preserves any explicit value.

## Testing
- Rendered the skills grid at one and two columns and extracted the PDF text: identical and in correct reading order at both, with each skill name kept next to its own proficiency.
- Migrating a pre-v10 document defaults its skills to two columns, keeps an already-set value, and no-ops safely when there is no skills section.
- Type check and lint pass.
- The toggle wiring (preview re-render and persistence) reuses the existing store update path and type-checks; it has not yet been clicked through in the running editor.