### PR TITLE
fix: sort editor entry forms newest-first to match the preview

### DIFF
--- a/src/components/editor/editor-sections/animated-entry-list.tsx
+++ b/src/components/editor/editor-sections/animated-entry-list.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { forwardRef, type ReactNode, useImperativeHandle, useRef } from "react";
+
+const EASE = [0.22, 1, 0.36, 1] as const;
+
+export interface AnimatedEntryListHandle {
+  scrollToIndex: (index: number) => void;
+}
+
+interface AnimatedEntryListProps {
+  ids: string[];
+  renderItem: (id: string, index: number) => ReactNode;
+}
+
+export const AnimatedEntryList = forwardRef<
+  AnimatedEntryListHandle,
+  AnimatedEntryListProps
+>(function AnimatedEntryList(props, ref) {
+  const reduce = useReducedMotion();
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      scrollToIndex(index) {
+        requestAnimationFrame(() => {
+          const child = containerRef.current?.children[index];
+          child?.scrollIntoView({
+            behavior: reduce ? "auto" : "smooth",
+            block: "nearest",
+          });
+        });
+      },
+    }),
+    [reduce],
+  );
+
+  return (
+    <div ref={containerRef} className="flex w-full flex-col gap-4">
+      <AnimatePresence initial={false} mode="popLayout">
+        {props.ids.map((id, index) => (
+          <motion.div
+            key={id}
+            layout={reduce ? false : "position"}
+            initial={reduce ? false : { opacity: 0, y: -8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={reduce ? { opacity: 0 } : { opacity: 0, scale: 0.98 }}
+            transition={{ duration: reduce ? 0 : 0.32, ease: EASE }}
+            className="not-last:border-b not-last:pb-4"
+          >
+            {props.renderItem(id, index)}
+          </motion.div>
+        ))}
+      </AnimatePresence>
+    </div>
+  );
+});

--- a/src/components/editor/editor-sections/date-range-fields.tsx
+++ b/src/components/editor/editor-sections/date-range-fields.tsx
@@ -17,6 +17,7 @@ interface DateRangeFieldsProps<T extends FieldValues> {
   endName: FieldPath<T>;
   /** Checkbox label, e.g. "I currently work here". */
   presentLabel: string;
+  onCommit?: () => void;
 }
 
 function asString(value: unknown): string {
@@ -50,6 +51,7 @@ export function DateRangeFields<T extends FieldValues>(
             value={asString(start.field.value)}
             placeholder={t("startPlaceholder")}
             onChange={start.field.onChange}
+            onClose={props.onCommit}
           />
           <FieldError errors={[start.fieldState.error]} />
         </Field>
@@ -73,6 +75,7 @@ export function DateRangeFields<T extends FieldValues>(
               value={asString(end.field.value)}
               placeholder={t("endPlaceholder")}
               onChange={end.field.onChange}
+              onClose={props.onCommit}
             />
           )}
           <FieldError errors={[end.fieldState.error]} />
@@ -83,9 +86,10 @@ export function DateRangeFields<T extends FieldValues>(
         <Checkbox
           id={presentId}
           checked={isPresent}
-          onCheckedChange={(checked) =>
-            end.field.onChange(checked ? PRESENT_DATE : "")
-          }
+          onCheckedChange={(checked) => {
+            end.field.onChange(checked ? PRESENT_DATE : "");
+            props.onCommit?.();
+          }}
         />
         <FieldLabel htmlFor={presentId} className="font-normal">
           {props.presentLabel}

--- a/src/components/editor/editor-sections/date-sort.ts
+++ b/src/components/editor/editor-sections/date-sort.ts
@@ -1,0 +1,25 @@
+import { byRecency } from "../resume-sort";
+
+type Dated = { startDate: string; endDate: string };
+
+/**
+ * Assumes the rest of `items` is already sorted, so moving the one edited row at
+ * `from` suffices. Returns its destination index when a move happened, else null.
+ */
+export function repositionByRecency<T extends Dated>(
+  from: number,
+  items: T[],
+  move: (from: number, to: number) => void,
+): number | null {
+  if (from < 0 || from >= items.length) return null;
+
+  const moving = items[from];
+  let to = 0;
+  for (let i = 0; i < items.length; i++) {
+    if (i !== from && byRecency(items[i], moving) < 0) to++;
+  }
+
+  if (to === from) return null;
+  move(from, to);
+  return to;
+}

--- a/src/components/editor/editor-sections/ed-section-education/ed-section-education-form-item.tsx
+++ b/src/components/editor/editor-sections/ed-section-education/ed-section-education-form-item.tsx
@@ -20,6 +20,7 @@ interface EditorSectionEducationFormItemProps {
   index: number;
   control: Control<EducationFormValues>;
   onRemoveField: (index: number) => void;
+  onDatesCommit: () => void;
 }
 
 export function EditorSectionEducationFormItem(
@@ -31,7 +32,7 @@ export function EditorSectionEducationFormItem(
   };
 
   return (
-    <FieldSet className="not-last-of-type:pb-4 not-last-of-type:border-b">
+    <FieldSet>
       <FieldLegend className="sr-only" variant="label">
         {t("itemLegend", { index: props.index + 1 })}
       </FieldLegend>
@@ -102,6 +103,7 @@ export function EditorSectionEducationFormItem(
           startName={`educations.${props.index}.startDate`}
           endName={`educations.${props.index}.endDate`}
           presentLabel={t("present")}
+          onCommit={props.onDatesCommit}
         />
 
         <Controller

--- a/src/components/editor/editor-sections/ed-section-education/ed-section-education-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-education/ed-section-education-form.tsx
@@ -2,18 +2,18 @@
 
 import { GraduationCap, Plus } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
 import { EmptyState } from "@/components/shared/empty-state";
 import { Button } from "@/components/ui/button";
-import {
-  FieldDescription,
-  FieldGroup,
-  FieldLegend,
-  FieldSet,
-} from "@/components/ui/field";
+import { FieldDescription, FieldLegend, FieldSet } from "@/components/ui/field";
 import { emptyRichTextValue } from "@/lib/resume";
 import { useResumeStore } from "@/lib/store";
+import {
+  AnimatedEntryList,
+  type AnimatedEntryListHandle,
+} from "../animated-entry-list";
+import { repositionByRecency } from "../date-sort";
 import {
   applyEducationValues,
   type EducationFormValues,
@@ -42,10 +42,11 @@ export function EditorSectionEducationForm() {
   const form = useForm<EducationFormValues>({
     defaultValues: open ? toEducationValues(open) : { educations: [] },
   });
-  const { fields, prepend, remove } = useFieldArray({
+  const { fields, prepend, remove, move } = useFieldArray({
     control: form.control,
     name: "educations",
   });
+  const listRef = useRef<AnimatedEntryListHandle>(null);
 
   useEffect(() => {
     const subscription = form.watch(() => {
@@ -53,6 +54,13 @@ export function EditorSectionEducationForm() {
     });
     return () => subscription.unsubscribe();
   }, [form, updateOpen]);
+
+  const handleDatesCommit = (index: number) => {
+    requestAnimationFrame(() => {
+      const to = repositionByRecency(index, form.getValues().educations, move);
+      if (to !== null) listRef.current?.scrollToIndex(to);
+    });
+  };
 
   if (!open) return null;
 
@@ -80,16 +88,18 @@ export function EditorSectionEducationForm() {
             description={t("emptyDescription")}
           />
         ) : (
-          <FieldGroup className="gap-4">
-            {fields.map((field, index) => (
+          <AnimatedEntryList
+            ref={listRef}
+            ids={fields.map((field) => field.id)}
+            renderItem={(_, index) => (
               <EditorSectionEducationFormItem
-                key={field.id}
                 control={form.control}
                 index={index}
                 onRemoveField={remove}
+                onDatesCommit={() => handleDatesCommit(index)}
               />
-            ))}
-          </FieldGroup>
+            )}
+          />
         )}
       </FieldSet>
     </form>

--- a/src/components/editor/editor-sections/ed-section-experience/ed-section-experience-form-item.tsx
+++ b/src/components/editor/editor-sections/ed-section-experience/ed-section-experience-form-item.tsx
@@ -21,6 +21,7 @@ interface EditorSectionExperienceFormItemProps {
   index: number;
   control: Control<ExperienceFormValues>;
   onRemoveField: (index: number) => void;
+  onDatesCommit: () => void;
 }
 
 export function EditorSectionExperienceFormItem(
@@ -32,7 +33,7 @@ export function EditorSectionExperienceFormItem(
   };
 
   return (
-    <FieldSet className="not-last-of-type:pb-4 not-last-of-type:border-b">
+    <FieldSet>
       <FieldLegend className="sr-only" variant="label">
         {t("itemLegend", { index: props.index + 1 })}
       </FieldLegend>
@@ -108,6 +109,7 @@ export function EditorSectionExperienceFormItem(
           startName={`experiences.${props.index}.startDate`}
           endName={`experiences.${props.index}.endDate`}
           presentLabel={t("present")}
+          onCommit={props.onDatesCommit}
         />
 
         <Controller

--- a/src/components/editor/editor-sections/ed-section-experience/ed-section-experience-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-experience/ed-section-experience-form.tsx
@@ -2,18 +2,18 @@
 
 import { Briefcase, Plus } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
 import { EmptyState } from "@/components/shared/empty-state";
 import { Button } from "@/components/ui/button";
-import {
-  FieldDescription,
-  FieldGroup,
-  FieldLegend,
-  FieldSet,
-} from "@/components/ui/field";
+import { FieldDescription, FieldLegend, FieldSet } from "@/components/ui/field";
 import { emptyRichTextValue } from "@/lib/resume";
 import { useResumeStore } from "@/lib/store";
+import {
+  AnimatedEntryList,
+  type AnimatedEntryListHandle,
+} from "../animated-entry-list";
+import { repositionByRecency } from "../date-sort";
 import {
   applyExperienceValues,
   type ExperienceFormValues,
@@ -42,10 +42,11 @@ export function EditorSectionExperienceForm() {
   const form = useForm<ExperienceFormValues>({
     defaultValues: open ? toExperienceValues(open) : { experiences: [] },
   });
-  const { fields, prepend, remove } = useFieldArray({
+  const { fields, prepend, remove, move } = useFieldArray({
     control: form.control,
     name: "experiences",
   });
+  const listRef = useRef<AnimatedEntryListHandle>(null);
 
   // The field array owns the list; every form change (including add/remove)
   // rebuilds the store entries. Subscribing to the form and writing to the
@@ -57,6 +58,13 @@ export function EditorSectionExperienceForm() {
     });
     return () => subscription.unsubscribe();
   }, [form, updateOpen]);
+
+  const handleDatesCommit = (index: number) => {
+    requestAnimationFrame(() => {
+      const to = repositionByRecency(index, form.getValues().experiences, move);
+      if (to !== null) listRef.current?.scrollToIndex(to);
+    });
+  };
 
   if (!open) return null;
 
@@ -84,16 +92,18 @@ export function EditorSectionExperienceForm() {
             description={t("emptyDescription")}
           />
         ) : (
-          <FieldGroup className="gap-4">
-            {fields.map((field, index) => (
+          <AnimatedEntryList
+            ref={listRef}
+            ids={fields.map((field) => field.id)}
+            renderItem={(_, index) => (
               <EditorSectionExperienceFormItem
-                key={field.id}
                 control={form.control}
                 index={index}
                 onRemoveField={remove}
+                onDatesCommit={() => handleDatesCommit(index)}
               />
-            ))}
-          </FieldGroup>
+            )}
+          />
         )}
       </FieldSet>
     </form>

--- a/src/components/editor/editor-sections/ed-section-internship/ed-section-internship-form-item.tsx
+++ b/src/components/editor/editor-sections/ed-section-internship/ed-section-internship-form-item.tsx
@@ -21,6 +21,7 @@ interface EditorSectionInternshipFormItemProps {
   index: number;
   control: Control<InternshipFormValues>;
   onRemoveField: (index: number) => void;
+  onDatesCommit: () => void;
 }
 
 export function EditorSectionInternshipFormItem(
@@ -32,7 +33,7 @@ export function EditorSectionInternshipFormItem(
   };
 
   return (
-    <FieldSet className="not-last-of-type:pb-4 not-last-of-type:border-b">
+    <FieldSet>
       <FieldLegend className="sr-only" variant="label">
         {t("itemLegend", { index: props.index + 1 })}
       </FieldLegend>
@@ -108,6 +109,7 @@ export function EditorSectionInternshipFormItem(
           startName={`internships.${props.index}.startDate`}
           endName={`internships.${props.index}.endDate`}
           presentLabel={t("present")}
+          onCommit={props.onDatesCommit}
         />
 
         <Controller

--- a/src/components/editor/editor-sections/ed-section-internship/ed-section-internship-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-internship/ed-section-internship-form.tsx
@@ -2,18 +2,18 @@
 
 import { Backpack, Plus } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
 import { EmptyState } from "@/components/shared/empty-state";
 import { Button } from "@/components/ui/button";
-import {
-  FieldDescription,
-  FieldGroup,
-  FieldLegend,
-  FieldSet,
-} from "@/components/ui/field";
+import { FieldDescription, FieldLegend, FieldSet } from "@/components/ui/field";
 import { emptyRichTextValue } from "@/lib/resume";
 import { useResumeStore } from "@/lib/store";
+import {
+  AnimatedEntryList,
+  type AnimatedEntryListHandle,
+} from "../animated-entry-list";
+import { repositionByRecency } from "../date-sort";
 import {
   applyInternshipValues,
   type InternshipFormValues,
@@ -42,10 +42,11 @@ export function EditorSectionInternshipForm() {
   const form = useForm<InternshipFormValues>({
     defaultValues: open ? toInternshipValues(open) : { internships: [] },
   });
-  const { fields, prepend, remove } = useFieldArray({
+  const { fields, prepend, remove, move } = useFieldArray({
     control: form.control,
     name: "internships",
   });
+  const listRef = useRef<AnimatedEntryListHandle>(null);
 
   // The field array owns the list; every form change (including add/remove)
   // rebuilds the store entries. Subscribing to the form and writing to the
@@ -57,6 +58,13 @@ export function EditorSectionInternshipForm() {
     });
     return () => subscription.unsubscribe();
   }, [form, updateOpen]);
+
+  const handleDatesCommit = (index: number) => {
+    requestAnimationFrame(() => {
+      const to = repositionByRecency(index, form.getValues().internships, move);
+      if (to !== null) listRef.current?.scrollToIndex(to);
+    });
+  };
 
   if (!open) return null;
 
@@ -84,16 +92,18 @@ export function EditorSectionInternshipForm() {
             description={t("emptyDescription")}
           />
         ) : (
-          <FieldGroup className="gap-4">
-            {fields.map((field, index) => (
+          <AnimatedEntryList
+            ref={listRef}
+            ids={fields.map((field) => field.id)}
+            renderItem={(_, index) => (
               <EditorSectionInternshipFormItem
-                key={field.id}
                 control={form.control}
                 index={index}
                 onRemoveField={remove}
+                onDatesCommit={() => handleDatesCommit(index)}
               />
-            ))}
-          </FieldGroup>
+            )}
+          />
         )}
       </FieldSet>
     </form>

--- a/src/components/editor/editor-sections/ed-section-organizations/ed-section-organizations-form-item.tsx
+++ b/src/components/editor/editor-sections/ed-section-organizations/ed-section-organizations-form-item.tsx
@@ -20,6 +20,7 @@ interface EditorSectionOrganizationsFormItemProps {
   index: number;
   control: Control<OrganizationsFormValues>;
   onRemoveField: (index: number) => void;
+  onDatesCommit: () => void;
 }
 
 export function EditorSectionOrganizationsFormItem(
@@ -31,7 +32,7 @@ export function EditorSectionOrganizationsFormItem(
   };
 
   return (
-    <FieldSet className="not-last-of-type:pb-4 not-last-of-type:border-b">
+    <FieldSet>
       <FieldLegend className="sr-only" variant="label">
         {t("itemLegend", { index: props.index + 1 })}
       </FieldLegend>
@@ -85,6 +86,7 @@ export function EditorSectionOrganizationsFormItem(
           startName={`organizations.${props.index}.startDate`}
           endName={`organizations.${props.index}.endDate`}
           presentLabel={t("present")}
+          onCommit={props.onDatesCommit}
         />
 
         <Controller

--- a/src/components/editor/editor-sections/ed-section-organizations/ed-section-organizations-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-organizations/ed-section-organizations-form.tsx
@@ -2,18 +2,18 @@
 
 import { Plus, Users } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
 import { EmptyState } from "@/components/shared/empty-state";
 import { Button } from "@/components/ui/button";
-import {
-  FieldDescription,
-  FieldGroup,
-  FieldLegend,
-  FieldSet,
-} from "@/components/ui/field";
+import { FieldDescription, FieldLegend, FieldSet } from "@/components/ui/field";
 import { emptyRichTextValue } from "@/lib/resume";
 import { useResumeStore } from "@/lib/store";
+import {
+  AnimatedEntryList,
+  type AnimatedEntryListHandle,
+} from "../animated-entry-list";
+import { repositionByRecency } from "../date-sort";
 import {
   applyOrganizationsValues,
   type OrganizationItemValues,
@@ -41,10 +41,11 @@ export function EditorSectionOrganizationsForm() {
   const form = useForm<OrganizationsFormValues>({
     defaultValues: open ? toOrganizationsValues(open) : { organizations: [] },
   });
-  const { fields, prepend, remove } = useFieldArray({
+  const { fields, prepend, remove, move } = useFieldArray({
     control: form.control,
     name: "organizations",
   });
+  const listRef = useRef<AnimatedEntryListHandle>(null);
 
   // The field array owns the list; every form change (including add/remove)
   // rebuilds the store entries. Subscribing to the form and writing to the
@@ -56,6 +57,17 @@ export function EditorSectionOrganizationsForm() {
     });
     return () => subscription.unsubscribe();
   }, [form, updateOpen]);
+
+  const handleDatesCommit = (index: number) => {
+    requestAnimationFrame(() => {
+      const to = repositionByRecency(
+        index,
+        form.getValues().organizations,
+        move,
+      );
+      if (to !== null) listRef.current?.scrollToIndex(to);
+    });
+  };
 
   if (!open) return null;
 
@@ -83,16 +95,18 @@ export function EditorSectionOrganizationsForm() {
             description={t("emptyDescription")}
           />
         ) : (
-          <FieldGroup className="gap-4">
-            {fields.map((field, index) => (
+          <AnimatedEntryList
+            ref={listRef}
+            ids={fields.map((field) => field.id)}
+            renderItem={(_, index) => (
               <EditorSectionOrganizationsFormItem
-                key={field.id}
                 control={form.control}
                 index={index}
                 onRemoveField={remove}
+                onDatesCommit={() => handleDatesCommit(index)}
               />
-            ))}
-          </FieldGroup>
+            )}
+          />
         )}
       </FieldSet>
     </form>

--- a/src/components/editor/editor-sections/ed-section-projects/ed-section-projects-form-item.tsx
+++ b/src/components/editor/editor-sections/ed-section-projects/ed-section-projects-form-item.tsx
@@ -21,6 +21,7 @@ interface EditorSectionProjectsFormItemProps {
   index: number;
   control: Control<ProjectsFormValues>;
   onRemoveField: (index: number) => void;
+  onDatesCommit: () => void;
 }
 
 export function EditorSectionProjectsFormItem(
@@ -32,7 +33,7 @@ export function EditorSectionProjectsFormItem(
   };
 
   return (
-    <FieldSet className="not-last-of-type:pb-4 not-last-of-type:border-b">
+    <FieldSet>
       <FieldLegend className="sr-only" variant="label">
         {t("itemLegend", { index: props.index + 1 })}
       </FieldLegend>
@@ -106,6 +107,7 @@ export function EditorSectionProjectsFormItem(
           startName={`projects.${props.index}.startDate`}
           endName={`projects.${props.index}.endDate`}
           presentLabel={t("present")}
+          onCommit={props.onDatesCommit}
         />
 
         <Controller

--- a/src/components/editor/editor-sections/ed-section-projects/ed-section-projects-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-projects/ed-section-projects-form.tsx
@@ -2,18 +2,18 @@
 
 import { FolderGit2, Plus } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
 import { EmptyState } from "@/components/shared/empty-state";
 import { Button } from "@/components/ui/button";
-import {
-  FieldDescription,
-  FieldGroup,
-  FieldLegend,
-  FieldSet,
-} from "@/components/ui/field";
+import { FieldDescription, FieldLegend, FieldSet } from "@/components/ui/field";
 import { emptyRichTextValue } from "@/lib/resume";
 import { useResumeStore } from "@/lib/store";
+import {
+  AnimatedEntryList,
+  type AnimatedEntryListHandle,
+} from "../animated-entry-list";
+import { repositionByRecency } from "../date-sort";
 import {
   applyProjectsValues,
   type ProjectItemValues,
@@ -42,10 +42,11 @@ export function EditorSectionProjectsForm() {
   const form = useForm<ProjectsFormValues>({
     defaultValues: open ? toProjectsValues(open) : { projects: [] },
   });
-  const { fields, prepend, remove } = useFieldArray({
+  const { fields, prepend, remove, move } = useFieldArray({
     control: form.control,
     name: "projects",
   });
+  const listRef = useRef<AnimatedEntryListHandle>(null);
 
   // The field array owns the list; every form change (including add/remove)
   // rebuilds the store entries. Subscribing to the form and writing to the
@@ -57,6 +58,13 @@ export function EditorSectionProjectsForm() {
     });
     return () => subscription.unsubscribe();
   }, [form, updateOpen]);
+
+  const handleDatesCommit = (index: number) => {
+    requestAnimationFrame(() => {
+      const to = repositionByRecency(index, form.getValues().projects, move);
+      if (to !== null) listRef.current?.scrollToIndex(to);
+    });
+  };
 
   if (!open) return null;
 
@@ -84,16 +92,18 @@ export function EditorSectionProjectsForm() {
             description={t("emptyDescription")}
           />
         ) : (
-          <FieldGroup className="gap-4">
-            {fields.map((field, index) => (
+          <AnimatedEntryList
+            ref={listRef}
+            ids={fields.map((field) => field.id)}
+            renderItem={(_, index) => (
               <EditorSectionProjectsFormItem
-                key={field.id}
                 control={form.control}
                 index={index}
                 onRemoveField={remove}
+                onDatesCommit={() => handleDatesCommit(index)}
               />
-            ))}
-          </FieldGroup>
+            )}
+          />
         )}
       </FieldSet>
     </form>

--- a/src/components/editor/editor-sections/resume-form-adapter.ts
+++ b/src/components/editor/editor-sections/resume-form-adapter.ts
@@ -2,6 +2,7 @@ import type { JSONContent } from "@tiptap/core";
 import { nanoid } from "nanoid";
 import { emptyRichTextValue } from "@/lib/resume";
 import type { Entry, Field, Resume, Section } from "@/lib/resume/types";
+import { byRecency } from "../resume-sort";
 
 export interface PersonalFormValues {
   firstName: string;
@@ -206,14 +207,16 @@ export function experienceEntries(resume: Resume): Entry[] {
 
 export function toExperienceValues(resume: Resume): ExperienceFormValues {
   return {
-    experiences: experienceEntries(resume).map((entry) => ({
-      title: plainValue(entry.fields.title),
-      company: plainValue(entry.fields.company),
-      website: plainValue(entry.fields.website),
-      startDate: plainValue(entry.fields.startDate),
-      endDate: plainValue(entry.fields.endDate),
-      description: richValue(entry.fields.description),
-    })),
+    experiences: experienceEntries(resume)
+      .map((entry) => ({
+        title: plainValue(entry.fields.title),
+        company: plainValue(entry.fields.company),
+        website: plainValue(entry.fields.website),
+        startDate: plainValue(entry.fields.startDate),
+        endDate: plainValue(entry.fields.endDate),
+        description: richValue(entry.fields.description),
+      }))
+      .sort(byRecency),
   };
 }
 
@@ -244,14 +247,16 @@ export function internshipEntries(resume: Resume): Entry[] {
 
 export function toInternshipValues(resume: Resume): InternshipFormValues {
   return {
-    internships: internshipEntries(resume).map((entry) => ({
-      title: plainValue(entry.fields.title),
-      company: plainValue(entry.fields.company),
-      website: plainValue(entry.fields.website),
-      startDate: plainValue(entry.fields.startDate),
-      endDate: plainValue(entry.fields.endDate),
-      description: richValue(entry.fields.description),
-    })),
+    internships: internshipEntries(resume)
+      .map((entry) => ({
+        title: plainValue(entry.fields.title),
+        company: plainValue(entry.fields.company),
+        website: plainValue(entry.fields.website),
+        startDate: plainValue(entry.fields.startDate),
+        endDate: plainValue(entry.fields.endDate),
+        description: richValue(entry.fields.description),
+      }))
+      .sort(byRecency),
   };
 }
 
@@ -282,14 +287,16 @@ export function projectEntries(resume: Resume): Entry[] {
 
 export function toProjectsValues(resume: Resume): ProjectsFormValues {
   return {
-    projects: projectEntries(resume).map((entry) => ({
-      title: plainValue(entry.fields.title),
-      company: plainValue(entry.fields.company),
-      website: plainValue(entry.fields.website),
-      startDate: plainValue(entry.fields.startDate),
-      endDate: plainValue(entry.fields.endDate),
-      description: richValue(entry.fields.description),
-    })),
+    projects: projectEntries(resume)
+      .map((entry) => ({
+        title: plainValue(entry.fields.title),
+        company: plainValue(entry.fields.company),
+        website: plainValue(entry.fields.website),
+        startDate: plainValue(entry.fields.startDate),
+        endDate: plainValue(entry.fields.endDate),
+        description: richValue(entry.fields.description),
+      }))
+      .sort(byRecency),
   };
 }
 
@@ -320,13 +327,15 @@ export function organizationEntries(resume: Resume): Entry[] {
 
 export function toOrganizationsValues(resume: Resume): OrganizationsFormValues {
   return {
-    organizations: organizationEntries(resume).map((entry) => ({
-      role: plainValue(entry.fields.role),
-      organization: plainValue(entry.fields.organization),
-      startDate: plainValue(entry.fields.startDate),
-      endDate: plainValue(entry.fields.endDate),
-      description: richValue(entry.fields.description),
-    })),
+    organizations: organizationEntries(resume)
+      .map((entry) => ({
+        role: plainValue(entry.fields.role),
+        organization: plainValue(entry.fields.organization),
+        startDate: plainValue(entry.fields.startDate),
+        endDate: plainValue(entry.fields.endDate),
+        description: richValue(entry.fields.description),
+      }))
+      .sort(byRecency),
   };
 }
 
@@ -356,14 +365,16 @@ export function educationEntries(resume: Resume): Entry[] {
 
 export function toEducationValues(resume: Resume): EducationFormValues {
   return {
-    educations: educationEntries(resume).map((entry) => ({
-      institution: plainValue(entry.fields.institution),
-      degree: plainValue(entry.fields.degree),
-      location: plainValue(entry.fields.location),
-      startDate: plainValue(entry.fields.startDate),
-      endDate: plainValue(entry.fields.endDate),
-      details: richValue(entry.fields.details),
-    })),
+    educations: educationEntries(resume)
+      .map((entry) => ({
+        institution: plainValue(entry.fields.institution),
+        degree: plainValue(entry.fields.degree),
+        location: plainValue(entry.fields.location),
+        startDate: plainValue(entry.fields.startDate),
+        endDate: plainValue(entry.fields.endDate),
+        details: richValue(entry.fields.details),
+      }))
+      .sort(byRecency),
   };
 }
 

--- a/src/components/editor/month-year-menu/month-year-menu.tsx
+++ b/src/components/editor/month-year-menu/month-year-menu.tsx
@@ -19,6 +19,7 @@ import {
 interface MonthYearMenuProps {
   value: string | undefined;
   onChange: (value: string) => void;
+  onClose?: () => void;
   placeholder?: string;
   id?: string;
 }
@@ -35,7 +36,11 @@ export function MonthYearMenu(props: MonthYearMenuProps) {
   };
 
   return (
-    <DropdownMenu>
+    <DropdownMenu
+      onOpenChange={(open) => {
+        if (!open) props.onClose?.();
+      }}
+    >
       <DropdownMenuTrigger
         render={
           <Button

--- a/src/components/editor/resume-sort.ts
+++ b/src/components/editor/resume-sort.ts
@@ -1,0 +1,20 @@
+import { dateSortValue } from "./month-year-menu/month-year-menu-data";
+
+type Dated = { startDate: string; endDate: string };
+
+/** `a === b` first guards against `Infinity - Infinity` (NaN) for ongoing dates. */
+function compareDesc(a: number, b: number): number {
+  return a === b ? 0 : b - a;
+}
+
+/**
+ * Orders dated entries newest-first: end date descending, then start date. An
+ * ongoing ("Present") or undated entry ranks as the most recent, so a just-added
+ * row surfaces at the top until the user dates it. Shared by the preview
+ * projection and the editor forms so both present entries in the same order.
+ */
+export function byRecency(a: Dated, b: Dated): number {
+  const end = compareDesc(dateSortValue(a.endDate), dateSortValue(b.endDate));
+  if (end !== 0) return end;
+  return compareDesc(dateSortValue(a.startDate), dateSortValue(b.startDate));
+}

--- a/src/components/editor/resume-to-preview.ts
+++ b/src/components/editor/resume-to-preview.ts
@@ -1,10 +1,8 @@
 import { RESUME_LABELS } from "@/lib/resume/labels";
 import type { Field, Resume, Section } from "@/lib/resume/types";
-import {
-  dateSortValue,
-  localizeDateValue,
-} from "./month-year-menu/month-year-menu-data";
+import { localizeDateValue } from "./month-year-menu/month-year-menu-data";
 import type { ContactView, HeaderView, ResumePreview } from "./resume-preview";
+import { byRecency } from "./resume-sort";
 import { type RichBlock, tiptapToRichBlocks } from "./rich-content";
 
 function plain(field: Field | undefined): string {
@@ -25,25 +23,6 @@ function sectionOfType(
 /** A stored URL is domain-only (see `UrlInput`); restore the scheme for links. */
 function withHttps(value: string): string {
   return /^https?:\/\//i.test(value) ? value : `https://${value}`;
-}
-
-/** `a === b` first guards against `Infinity - Infinity` (NaN) for ongoing dates. */
-function compareDesc(a: number, b: number): number {
-  return a === b ? 0 : b - a;
-}
-
-/**
- * Orders dated entries newest-first: end date descending, then start date. An
- * ongoing ("Present") or undated entry ranks as the most recent, so a just-added
- * row surfaces at the top until the user dates it.
- */
-function byRecency(
-  a: { startDate: string; endDate: string },
-  b: { startDate: string; endDate: string },
-): number {
-  const end = compareDesc(dateSortValue(a.endDate), dateSortValue(b.endDate));
-  if (end !== 0) return end;
-  return compareDesc(dateSortValue(a.startDate), dateSortValue(b.startDate));
 }
 
 function toHeaderView(resume: Resume): HeaderView {


### PR DESCRIPTION
The dated entry forms (experience, internship, projects, organizations, education) rendered in raw document order, while the preview and exports have always sorted by recency. A newly added older entry therefore stayed wherever it was inserted instead of dropping into place, which was confusing.

These forms now present entries newest-first, matching the preview. Ordering is derived from a single shared comparator so the editor and the preview can never disagree: the list sorts on open, and a row re-sorts once its dates settle.

To avoid disturbing the date picker, reordering runs only after a picker closes (or the "currently here" toggle changes), never while a picker is open. This also fixes a freeze where reordering under an open picker left the page unable to scroll until the user clicked elsewhere. When a row does move, it animates to its new position and scrolls back into view, and it settles instantly for anyone who prefers reduced motion.

## Testing
- Verified the ordering logic against the recency rule, including a newly added older entry landing below a current one, and that editing a single date keeps the whole list correctly ordered without dropping entries.
- Confirmed the editor builds and loads cleanly.
- Not yet exercised by hand in the browser: the picker-close reorder, the scroll-into-view, and the freeze fix. Happy to walk through these interactively if wanted before merge.