### PR TITLE
feat: show a progress bar during page navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",
+    "@bprogress/next": "^3.2.12",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@base-ui/react':
         specifier: ^1.6.0
         version: 1.6.0(@date-fns/tz@1.5.0)(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@bprogress/next':
+        specifier: ^3.2.12
+        version: 3.2.12(next@16.2.9(@babel/core@7.29.7)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -680,6 +683,22 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@bprogress/core@1.3.4':
+    resolution: {integrity: sha512-q/AqpurI/1uJzOrQROuZWixn/+ARekh+uvJGwLCP6HQ/EqAX4SkvNf618tSBxL4NysC0MwqAppb/mRw6Tzi61w==}
+
+  '@bprogress/next@3.2.12':
+    resolution: {integrity: sha512-/ZvNwbAd0ty9QiQwCfT2AfwWVdAaEyCPx5RUz3CfiiJS/OLBohhDz/IC/srhwK9GnXeXavvtiUrpKzN5GJDwlw==}
+    peerDependencies:
+      next: '>=13.0.0'
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+
+  '@bprogress/react@1.2.7':
+    resolution: {integrity: sha512-MqJfHW+R5CQeWqyqrLxUjdBRHk24Xl63OkBLo5DMWqUqocUikRTfCIc/jtQQbPk7BRfdr5OP3Lx7YlfQ9QOZMQ==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
 
   '@cloudflare/kv-asset-handler@0.5.0':
     resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
@@ -5938,6 +5957,22 @@ snapshots:
 
   '@biomejs/cli-win32-x64@2.2.0':
     optional: true
+
+  '@bprogress/core@1.3.4': {}
+
+  '@bprogress/next@3.2.12(next@16.2.9(@babel/core@7.29.7)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@bprogress/core': 1.3.4
+      '@bprogress/react': 1.2.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.9(@babel/core@7.29.7)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@bprogress/react@1.2.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@bprogress/core': 1.3.4
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -67,7 +67,7 @@ export default async function Home(props: {
     <>
       <a
         href="#main"
-        className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:rounded-md focus:border focus:bg-background focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-ring"
+        className="fixed top-4 left-4 -translate-y-40 focus:translate-0 z-50 rounded-md border bg-background px-4 py-2 text-sm font-medium shadow-lg outline-none ring-2 ring-ring transition"
       >
         {tNav("skipToContent")}
       </a>

--- a/src/components/shared/providers.tsx
+++ b/src/components/shared/providers.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ProgressProvider } from "@bprogress/next/app";
 import { ThemeProvider } from "next-themes";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { type PropsWithChildren, useEffect } from "react";
@@ -18,7 +19,13 @@ export function Providers({ children }: PropsWithChildren) {
         enableColorScheme
         disableTransitionOnChange
       >
-        <TooltipProvider>{children}</TooltipProvider>
+        <ProgressProvider
+          height="2px"
+          color="var(--primary)"
+          options={{ showSpinner: false }}
+        >
+          <TooltipProvider>{children}</TooltipProvider>
+        </ProgressProvider>
       </ThemeProvider>
     </NuqsAdapter>
   );


### PR DESCRIPTION
Adds a slim navigation progress bar via `@bprogress/next`, so page transitions (for example landing to editor) give immediate feedback.

The bar is wired into the existing client `Providers`, inside `ThemeProvider`. It draws with `var(--primary)`, so it tracks the theme's teal in both light and dark rather than a fixed hex. `showSpinner` is off and the height is 2px. `shallowRouting` is intentionally left off: the editor drives search-param state through nuqs (tabs, search, dialogs) using History-API shallow updates, and enabling it would flash the bar on every keystroke and tab switch. As configured, the bar only shows on real route navigations.

Also refines the landing skip link so it slides into view on focus via a translate transition instead of toggling `sr-only`.

## Testing

Confirmed the landing page renders with the bar's styles applied, and that focusing the skip link brings it into view.
