### PR TITLE
docs: add the 0.8.0 changelog entry for the what's new sheet

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -164,6 +164,12 @@
       "latest": "Latest",
       "fullChangelog": "Full changelog on GitHub",
       "entries": {
+        "0_8_0": [
+          "Show your skills in one column or two: a new toggle in the Skills section switches the layout, and your choice carries through to the preview and every export.",
+          "The editor now lists your entries newest first, matching the order they appear in the preview, so the forms and your resume always line up.",
+          "The landing page has a new navigation bar, with a menu that opens cleanly on mobile.",
+          "Moving between pages now shows a slim progress bar at the top, so you get instant feedback while a page loads."
+        ],
         "0_7_0": [
           "New Internship section: list internships as their own entries, separate from full-time roles, with the same fields as Experience.",
           "New Projects section: give side projects, open-source work, and anything you've shipped their own space, each with a name, link, dates, and description.",

--- a/messages/id.json
+++ b/messages/id.json
@@ -164,6 +164,12 @@
       "latest": "Terbaru",
       "fullChangelog": "Changelog lengkap di GitHub",
       "entries": {
+        "0_8_0": [
+          "Tampilkan keahlianmu dalam satu kolom atau dua: tombol baru di bagian Keahlian mengganti tata letaknya, dan pilihanmu ikut terbawa ke pratinjau dan semua ekspor.",
+          "Editor kini menampilkan entri dari yang terbaru lebih dulu, sesuai urutannya di pratinjau, jadi formulir dan resume kamu selalu sejalan.",
+          "Halaman depan punya bilah navigasi baru, lengkap dengan menu yang rapi saat dibuka di ponsel.",
+          "Berpindah antar halaman kini menampilkan bilah progres tipis di bagian atas, jadi kamu langsung dapat feedback saat halaman dimuat."
+        ],
         "0_7_0": [
           "Ada bagian Magang baru: tulis pengalaman magang sebagai entri terpisah dari pekerjaan tetap, dengan kolom yang sama seperti Pengalaman.",
           "Ada bagian Proyek baru: pamerkan proyek sampingan, kontribusi open-source, atau apa pun yang pernah kamu rilis, lengkap dengan nama, tautan, tanggal, dan deskripsi.",

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -10,6 +10,7 @@ export interface ChangelogEntry {
  * highlights in both locale files as part of each release PR.
  */
 export const CHANGELOG: ChangelogEntry[] = [
+  { version: "0.8.0", date: "2026-07-11" },
   { version: "0.7.0", date: "2026-07-10" },
   { version: "0.6.0", date: "2026-07-08" },
   { version: "0.5.0", date: "2026-07-06" },


### PR DESCRIPTION
Adds the 0.8.0 entry to the "What's new" sheet, covering the changes shipped since 0.7.0.

Highlights, in both English and Indonesian:
- One or two column layout toggle for the Skills section.
- Editor entries now list newest first, matching the preview order.
- New landing navigation bar with a mobile menu.
- A slim progress bar during page navigation.

The screenshot refresh and JSON-LD work from this cycle is left out, since it has no user-facing surface in the app.

## Testing

Both locale files parse, and the new version resolves as the latest in the sheet.
