### PR TITLE
feat: add linkedin field to personal information

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -402,6 +402,8 @@
       "phonePlaceholder": "+62812345678",
       "website": "Website",
       "websitePlaceholder": "rimzzlabs.com",
+      "linkedin": "LinkedIn",
+      "linkedinPlaceholder": "johndoe",
       "location": "Location",
       "locationDesc": "Where are you from?",
       "city": "City",

--- a/messages/id.json
+++ b/messages/id.json
@@ -402,6 +402,8 @@
       "phonePlaceholder": "+62812345678",
       "website": "Situs web",
       "websitePlaceholder": "rimzzlabs.com",
+      "linkedin": "LinkedIn",
+      "linkedinPlaceholder": "johndoe",
       "location": "Lokasi",
       "locationDesc": "Kamu dari mana?",
       "city": "Kota",

--- a/src/components/editor/editor-sections/ed-section-personal/ed-section-personal-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-personal/ed-section-personal-form.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from "next-intl";
 import { useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
+import { LinkedinInput } from "@/components/shared/linkedin-input";
 import { PhoneNumberInput } from "@/components/shared/phone-number-input";
 import { UrlInput } from "@/components/shared/url-input";
 import {
@@ -159,6 +160,23 @@ export function EditorSectionPersonalForm() {
                     id={field.name}
                     value={field.value}
                     placeholder={t("websitePlaceholder")}
+                    onChange={field.onChange}
+                    onBlur={field.onBlur}
+                  />
+                  <FieldError errors={[fieldState.error]} />
+                </Field>
+              )}
+            />
+            <Controller
+              control={form.control}
+              name="linkedin"
+              render={({ field, fieldState }) => (
+                <Field>
+                  <FieldLabel htmlFor={field.name}>{t("linkedin")}</FieldLabel>
+                  <LinkedinInput
+                    id={field.name}
+                    value={field.value}
+                    placeholder={t("linkedinPlaceholder")}
                     onChange={field.onChange}
                     onBlur={field.onBlur}
                   />

--- a/src/components/editor/editor-sections/resume-form-adapter.ts
+++ b/src/components/editor/editor-sections/resume-form-adapter.ts
@@ -11,6 +11,7 @@ export interface PersonalFormValues {
   email: string;
   phone: string;
   website: string;
+  linkedin: string;
   city: string;
   province: string;
   country: string;
@@ -156,6 +157,7 @@ export function toPersonalValues(resume: Resume): PersonalFormValues {
     email: plainValue(fields.email),
     phone: plainValue(fields.phone),
     website: plainValue(fields.website),
+    linkedin: plainValue(fields.linkedin),
     city: plainValue(fields.city),
     province: plainValue(fields.province),
     country: plainValue(fields.country),
@@ -173,6 +175,7 @@ export function applyPersonalValues(
   fields.email = plain(values.email);
   fields.phone = plain(values.phone);
   fields.website = plain(values.website);
+  fields.linkedin = plain(values.linkedin);
   fields.city = plain(values.city);
   fields.province = plain(values.province);
   fields.country = plain(values.country);

--- a/src/components/editor/pdf/pdf-contact-icon.tsx
+++ b/src/components/editor/pdf/pdf-contact-icon.tsx
@@ -35,6 +35,19 @@ export function PdfContactIcon(props: { kind: ContactKind }) {
           <Path {...ICON} d="M2 12h20" />
         </Svg>
       );
+    case "linkedin":
+      return (
+        <Svg width={8} height={8} viewBox="0 0 24 24">
+          <Path
+            {...ICON}
+            d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"
+          />
+          <Path
+            {...ICON}
+            d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"
+          />
+        </Svg>
+      );
     case "location":
       return (
         <Svg width={8} height={8} viewBox="0 0 24 24">

--- a/src/components/editor/resume-header-contact.tsx
+++ b/src/components/editor/resume-header-contact.tsx
@@ -1,10 +1,11 @@
-import { Globe, Mail, MapPin, Phone } from "lucide-react";
+import { Globe, Link, Mail, MapPin, Phone } from "lucide-react";
 import type { ContactKind, ContactView } from "./resume-preview";
 
 const CONTACT_ICON: Record<ContactKind, typeof Phone> = {
   phone: Phone,
   email: Mail,
   website: Globe,
+  linkedin: Link,
   location: MapPin,
 };
 

--- a/src/components/editor/resume-preview.ts
+++ b/src/components/editor/resume-preview.ts
@@ -10,7 +10,12 @@
 import type { ResumeLanguage, SectionColumns } from "@/lib/resume/types";
 import type { RichBlock } from "./rich-content";
 
-export type ContactKind = "phone" | "email" | "website" | "location";
+export type ContactKind =
+  | "phone"
+  | "email"
+  | "website"
+  | "linkedin"
+  | "location";
 
 export interface ContactView {
   kind: ContactKind;

--- a/src/components/editor/resume-to-preview.ts
+++ b/src/components/editor/resume-to-preview.ts
@@ -50,6 +50,11 @@ function toHeaderView(resume: Resume): HeaderView {
     const url = withHttps(website);
     contacts.push({ kind: "website", value: url, href: url });
   }
+  const linkedin = plain(fields.linkedin);
+  if (linkedin) {
+    const url = withHttps(linkedin);
+    contacts.push({ kind: "linkedin", value: url, href: url });
+  }
   const location = [
     plain(fields.city),
     plain(fields.province),

--- a/src/components/editor/templates/ketat/ketat-header.tsx
+++ b/src/components/editor/templates/ketat/ketat-header.tsx
@@ -1,4 +1,4 @@
-import { Globe, Mail, MapPin, Phone } from "lucide-react";
+import { Globe, Link, Mail, MapPin, Phone } from "lucide-react";
 import type {
   ContactKind,
   ContactView,
@@ -9,6 +9,7 @@ const CONTACT_ICON: Record<ContactKind, typeof Phone> = {
   phone: Phone,
   email: Mail,
   website: Globe,
+  linkedin: Link,
   location: MapPin,
 };
 

--- a/src/components/shared/linkedin-input.tsx
+++ b/src/components/shared/linkedin-input.tsx
@@ -1,0 +1,53 @@
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+  InputGroupText,
+} from "@/components/ui/input-group";
+
+interface LinkedinInputProps {
+  id?: string;
+  value: string;
+  placeholder?: string;
+  onChange: (value: string) => void;
+  onBlur?: () => void;
+}
+
+const LINKEDIN_PREFIX = "linkedin.com/in/";
+
+/** Reduces a stored value or pasted URL down to the bare profile username. */
+function toUsername(value: string): string {
+  return value
+    .replace(/^https?:\/\//i, "")
+    .replace(/^www\./i, "")
+    .replace(/^linkedin\.com\/in\//i, "")
+    .replace(/^\/+/, "");
+}
+
+/**
+ * LinkedIn field with a fixed `linkedin.com/in/` prefix so the user only types
+ * their username. The stored value keeps the full path (`linkedin.com/in/<user>`)
+ * so the preview restores `https://` like any other URL; an empty username stores
+ * an empty string rather than a bare, linkless prefix.
+ */
+export function LinkedinInput(props: LinkedinInputProps) {
+  const display = toUsername(props.value);
+  return (
+    // Tighten the gap between the prefix and the input (default is pl-1.5).
+    <InputGroup className="has-[>[data-align=inline-start]]:[&>input]:pl-0">
+      <InputGroupAddon className="pr-0">
+        <InputGroupText>{LINKEDIN_PREFIX}</InputGroupText>
+      </InputGroupAddon>
+      <InputGroupInput
+        id={props.id}
+        value={display}
+        placeholder={props.placeholder}
+        onChange={(event) => {
+          const username = toUsername(event.target.value);
+          props.onChange(username ? `${LINKEDIN_PREFIX}${username}` : "");
+        }}
+        onBlur={props.onBlur}
+      />
+    </InputGroup>
+  );
+}

--- a/src/lib/resume/migrations.ts
+++ b/src/lib/resume/migrations.ts
@@ -383,6 +383,22 @@ const migrateV9toV10: Migration = (doc) => {
 };
 
 /**
+ * v10→v11: adds the header `linkedin` field. Existing documents gain it (empty)
+ * so the new personal-info input has somewhere to write. Bail-safe: a document
+ * without header fields, or one that already carries `linkedin`, is left as-is.
+ */
+const migrateV10toV11: Migration = (doc) => {
+  const next = structuredClone(doc);
+  const header = next.header as
+    | { fields?: Record<string, unknown> }
+    | undefined;
+  if (header?.fields && !("linkedin" in header.fields)) {
+    header.fields.linkedin = plainField("");
+  }
+  return next;
+};
+
+/**
  * The migration ladder. Each key N is a forward-only step from version N to N+1.
  */
 const LADDER: Record<number, Migration> = {
@@ -395,6 +411,7 @@ const LADDER: Record<number, Migration> = {
   7: migrateV7toV8,
   8: migrateV8toV9,
   9: migrateV9toV10,
+  10: migrateV10toV11,
 };
 
 /** The persisted schemaVersion of a raw document; 0 when absent or malformed. */

--- a/src/lib/resume/schema-registry.ts
+++ b/src/lib/resume/schema-registry.ts
@@ -78,6 +78,12 @@ export const HEADER_SCHEMA: FieldSchema[] = [
     kind: "plain",
     placeholder: "https://doe.dev",
   },
+  {
+    key: "linkedin",
+    label: "LinkedIn",
+    kind: "plain",
+    placeholder: "johndoe",
+  },
   { key: "city", label: "City", kind: "plain", placeholder: "San Francisco" },
   {
     key: "province",

--- a/src/lib/resume/seed.ts
+++ b/src/lib/resume/seed.ts
@@ -61,6 +61,7 @@ export const SEED_RESUME: Resume = {
       email: plain("john.doe@example.com"),
       phone: plain("+15550101234"),
       website: plain("johndoe.dev"),
+      linkedin: plain("linkedin.com/in/johndoe"),
       city: plain("San Francisco"),
       province: plain("California"),
       country: plain("United States"),

--- a/src/lib/resume/types.ts
+++ b/src/lib/resume/types.ts
@@ -5,7 +5,7 @@ import type { JSONContent } from "@tiptap/core";
  * governs object-store/index structure only. Bumped whenever a persisted field
  * shape changes; every bump gets a forward-only step in the migration ladder.
  */
-export const CURRENT_SCHEMA_VERSION = 10;
+export const CURRENT_SCHEMA_VERSION = 11;
 
 /** The language the rendered document's fixed labels (headings, dates) use. */
 export type ResumeLanguage = "en" | "id";


### PR DESCRIPTION
Adds a LinkedIn field to the personal information section, alongside the existing website field.

The input is username-only: it renders a fixed `linkedin.com/in/` prefix and the user types just their handle. The stored value keeps the full path so the preview restores `https://` like any other URL, and downstream renderers need no special-casing. Pasting a full profile URL collapses back to the username so the prefix never doubles up, and clearing the field stores an empty string rather than a bare, linkless prefix.

The field flows through the versioned schema (header schema entry, `CURRENT_SCHEMA_VERSION` bump to 11, a bail-safe v10 to v11 migration rung that adds an empty field to existing documents, and the seed), the personal form, and every render and export path: the preview projection emits a LinkedIn contact after website, and the on-screen, PDF, and docx headers pick it up. It uses lucide's `Link` glyph, distinct from the globe used for website; Simple Icons was ruled out because it does not carry a LinkedIn mark.

Testing: verified the migration adds the empty field and preserves an existing value, the preview surfaces the contact with a valid link, and the username input round-trips display, storage, paste, and clearing. Typecheck and lint pass.
