### PR TITLE
feat: add custom résumé sections

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -299,7 +299,8 @@
       "fileNameRequired": "Name the file before downloading.",
       "bugWhatHappened": "Describe what went wrong.",
       "featureProblem": "Describe the problem this would solve.",
-      "featureProposal": "Describe how you imagine it working."
+      "featureProposal": "Describe how you imagine it working.",
+      "sectionTitleRequired": "Enter a section name."
     },
     "create": {
       "title": "Create a new resume",
@@ -377,7 +378,8 @@
       "showSection": "Show section",
       "hideSection": "Hide section",
       "reorderSection": "Reorder section",
-      "resetOrder": "Reset section order"
+      "resetOrder": "Reset section order",
+      "addSection": "Custom Section"
     },
     "dateRange": {
       "startDate": "Start Date",
@@ -568,6 +570,37 @@
       "linkPlaceholder": "https://example.com",
       "apply": "Apply",
       "removeLink": "Remove link"
+    },
+    "custom": {
+      "defaultTitle": "Custom section",
+      "variantLabel": "Layout",
+      "variantText": "Text",
+      "variantTextAria": "Single text block",
+      "variantList": "List",
+      "variantListAria": "List of entries",
+      "menuLabel": "Section options",
+      "rename": "Rename",
+      "remove": "Delete",
+      "addHeading": "Add a section",
+      "addDescription": "Name your new section. You can rename it later.",
+      "renameHeading": "Rename section",
+      "renameDescription": "Give this section a new name.",
+      "nameLabel": "Section name",
+      "namePlaceholder": "Name this section",
+      "bodyLabel": "Content",
+      "bodyPlaceholder": "Write the section content…",
+      "addEntry": "Add entry",
+      "emptyTitle": "No entries yet",
+      "emptyDescription": "Add an entry to fill in this section.",
+      "itemLegend": "Entry {index}",
+      "entryTitle": "Title",
+      "entryTitlePlaceholder": "Entry title",
+      "entrySubtitle": "Subtitle",
+      "entrySubtitlePlaceholder": "Entry subtitle",
+      "present": "This is ongoing",
+      "entryDescription": "Description",
+      "entryDescriptionPlaceholder": "Add details…",
+      "removeEntry": "Remove entry"
     }
   }
 }

--- a/messages/id.json
+++ b/messages/id.json
@@ -299,7 +299,8 @@
       "fileNameRequired": "Kasih nama berkasnya dulu sebelum unduh.",
       "bugWhatHappened": "Ceritain apa yang salah.",
       "featureProblem": "Ceritain masalah yang mau diselesaikan.",
-      "featureProposal": "Ceritain gimana kamu ngebayanginnya jalan."
+      "featureProposal": "Ceritain gimana kamu ngebayanginnya jalan.",
+      "sectionTitleRequired": "Isi nama bagian."
     },
     "create": {
       "title": "Buat resume baru",
@@ -377,7 +378,8 @@
       "showSection": "Tampilkan bagian",
       "hideSection": "Sembunyikan bagian",
       "reorderSection": "Ubah urutan bagian",
-      "resetOrder": "Setel ulang urutan bagian"
+      "resetOrder": "Setel ulang urutan bagian",
+      "addSection": "Bagian Khusus"
     },
     "dateRange": {
       "startDate": "Tanggal Mulai",
@@ -568,6 +570,37 @@
       "linkPlaceholder": "https://example.com",
       "apply": "Terapkan",
       "removeLink": "Hapus tautan"
+    },
+    "custom": {
+      "defaultTitle": "Bagian khusus",
+      "variantLabel": "Tata letak",
+      "variantText": "Teks",
+      "variantTextAria": "Satu blok teks",
+      "variantList": "Daftar",
+      "variantListAria": "Daftar entri",
+      "menuLabel": "Opsi bagian",
+      "rename": "Ganti nama",
+      "remove": "Hapus",
+      "addHeading": "Tambah bagian",
+      "addDescription": "Beri nama bagian barumu. Bisa diganti nanti.",
+      "renameHeading": "Ganti nama bagian",
+      "renameDescription": "Beri nama baru untuk bagian ini.",
+      "nameLabel": "Nama bagian",
+      "namePlaceholder": "Beri nama bagian ini",
+      "bodyLabel": "Konten",
+      "bodyPlaceholder": "Tulis konten bagian…",
+      "addEntry": "Tambah entri",
+      "emptyTitle": "Belum ada entri",
+      "emptyDescription": "Tambah entri untuk mengisi bagian ini.",
+      "itemLegend": "Entri {index}",
+      "entryTitle": "Judul",
+      "entryTitlePlaceholder": "Judul entri",
+      "entrySubtitle": "Subjudul",
+      "entrySubtitlePlaceholder": "Subjudul entri",
+      "present": "Masih berlangsung",
+      "entryDescription": "Deskripsi",
+      "entryDescriptionPlaceholder": "Tambah detail…",
+      "removeEntry": "Hapus entri"
     }
   }
 }

--- a/src/app/[locale]/platform/layout.tsx
+++ b/src/app/[locale]/platform/layout.tsx
@@ -22,7 +22,10 @@ export default function PlatformLayout({ children }: PropsWithChildren) {
           <PlatformSidebar />
         </Sidebar>
 
-        <SidebarInset>
+        {/* min-w-0 lets this flex-1 region shrink instead of being forced wide
+            by its content (e.g. a long custom-section title), which otherwise
+            pushes the layout past the viewport. */}
+        <SidebarInset className="min-w-0">
           <PlatformNavbar />
           {children}
         </SidebarInset>

--- a/src/components/editor/editor-sections/ed-section-custom/ed-section-custom-add.tsx
+++ b/src/components/editor/editor-sections/ed-section-custom/ed-section-custom-add.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Plus } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { useResumeStore } from "@/lib/store";
+import { EditorSectionCustomNameDialog } from "./ed-section-custom-name-dialog";
+
+interface EditorSectionCustomAddProps {
+  /** Called with the new section's id so the list can open it. */
+  onAdded: (id: string) => void;
+}
+
+export function EditorSectionCustomAdd(props: EditorSectionCustomAddProps) {
+  const addCustomSection = useResumeStore((state) => state.addCustomSection);
+  const t = useTranslations("editor.chrome");
+  const tc = useTranslations("editor.custom");
+  const tcom = useTranslations("editor.common");
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="px-4 pt-4">
+      <Button
+        type="button"
+        variant="outline"
+        className="w-full"
+        onClick={() => setOpen(true)}
+      >
+        <Plus /> <span className="sr-only">{tcom("add")} </span>
+        {t("addSection")}
+      </Button>
+
+      <EditorSectionCustomNameDialog
+        open={open}
+        onOpenChange={setOpen}
+        heading={tc("addHeading")}
+        description={tc("addDescription")}
+        initialValue=""
+        onSubmit={(title) => props.onAdded(addCustomSection(title))}
+      />
+    </div>
+  );
+}

--- a/src/components/editor/editor-sections/ed-section-custom/ed-section-custom-body-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-custom/ed-section-custom-body-form.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useEffect } from "react";
+import { Controller, useForm } from "react-hook-form";
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from "@/components/ui/field";
+import { emptyRichTextValue } from "@/lib/resume";
+import { PROSE_FEATURES } from "@/lib/resume/schema-registry";
+import { useResumeStore } from "@/lib/store";
+import { RichTextEditor } from "../../rich-text/rich-text-editor";
+import {
+  applyCustomBodyValues,
+  type CustomBodyFormValues,
+  toCustomBodyValues,
+} from "../resume-form-adapter";
+
+interface EditorSectionCustomBodyFormProps {
+  sectionId: string;
+}
+
+export function EditorSectionCustomBodyForm(
+  props: EditorSectionCustomBodyFormProps,
+) {
+  const updateOpen = useResumeStore((state) => state.updateOpen);
+  const t = useTranslations("editor.custom");
+
+  // Read the section once at mount (via getState, not a subscription): the form
+  // owns its state afterward and the store is synced through the watch below.
+  const initial = useResumeStore
+    .getState()
+    .open?.sections.find((s) => s.id === props.sectionId);
+  const form = useForm<CustomBodyFormValues>({
+    defaultValues:
+      initial?.type === "custom"
+        ? toCustomBodyValues(initial)
+        : { body: emptyRichTextValue() },
+  });
+
+  useEffect(() => {
+    const subscription = form.watch(() => {
+      updateOpen((draft) =>
+        applyCustomBodyValues(draft, props.sectionId, form.getValues()),
+      );
+    });
+    return () => subscription.unsubscribe();
+  }, [form, updateOpen, props.sectionId]);
+
+  return (
+    <form>
+      <FieldGroup>
+        <Controller
+          control={form.control}
+          name="body"
+          render={({ field, fieldState }) => (
+            <Field>
+              <FieldLabel htmlFor={field.name}>{t("bodyLabel")}</FieldLabel>
+              <RichTextEditor
+                id={field.name}
+                value={field.value}
+                features={PROSE_FEATURES}
+                placeholder={t("bodyPlaceholder")}
+                onChange={field.onChange}
+                onBlur={field.onBlur}
+              />
+              <FieldError errors={[fieldState.error]} />
+            </Field>
+          )}
+        />
+      </FieldGroup>
+    </form>
+  );
+}

--- a/src/components/editor/editor-sections/ed-section-custom/ed-section-custom-list-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-custom/ed-section-custom-list-form.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { List, Plus } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useEffect } from "react";
+import { useFieldArray, useForm } from "react-hook-form";
+import { EmptyState } from "@/components/shared/empty-state";
+import { Button } from "@/components/ui/button";
+import { FieldGroup } from "@/components/ui/field";
+import { emptyRichTextValue } from "@/lib/resume";
+import { useResumeStore } from "@/lib/store";
+import { AnimatedEntryList } from "../animated-entry-list";
+import {
+  applyCustomListValues,
+  type CustomListFormValues,
+  type CustomListItemValues,
+  toCustomListValues,
+} from "../resume-form-adapter";
+import { EditorSectionCustomListItem } from "./ed-section-custom-list-item";
+
+function emptyEntry(): CustomListItemValues {
+  return {
+    title: "",
+    subtitle: "",
+    startDate: "",
+    endDate: "",
+    description: emptyRichTextValue(),
+  };
+}
+
+interface EditorSectionCustomListFormProps {
+  sectionId: string;
+}
+
+export function EditorSectionCustomListForm(
+  props: EditorSectionCustomListFormProps,
+) {
+  const updateOpen = useResumeStore((state) => state.updateOpen);
+  const t = useTranslations("editor.custom");
+
+  // Read the section once at mount (via getState, not a subscription): the form
+  // owns its state afterward and the store is synced through the watch below.
+  const initial = useResumeStore
+    .getState()
+    .open?.sections.find((s) => s.id === props.sectionId);
+  const form = useForm<CustomListFormValues>({
+    defaultValues:
+      initial?.type === "custom"
+        ? toCustomListValues(initial)
+        : { entries: [] },
+  });
+  const { fields, append, remove } = useFieldArray({
+    control: form.control,
+    name: "entries",
+  });
+
+  useEffect(() => {
+    const subscription = form.watch(() => {
+      updateOpen((draft) =>
+        applyCustomListValues(draft, props.sectionId, form.getValues()),
+      );
+    });
+    return () => subscription.unsubscribe();
+  }, [form, updateOpen, props.sectionId]);
+
+  return (
+    <form>
+      <FieldGroup className="gap-3">
+        <Button
+          type="button"
+          onClick={() => append(emptyEntry())}
+          variant="outline"
+          className="w-full"
+        >
+          <Plus /> {t("addEntry")}
+        </Button>
+
+        {fields.length === 0 ? (
+          <EmptyState
+            icon={List}
+            title={t("emptyTitle")}
+            description={t("emptyDescription")}
+          />
+        ) : (
+          <AnimatedEntryList
+            ids={fields.map((field) => field.id)}
+            renderItem={(_, index) => (
+              <EditorSectionCustomListItem
+                control={form.control}
+                index={index}
+                onRemoveField={remove}
+              />
+            )}
+          />
+        )}
+      </FieldGroup>
+    </form>
+  );
+}

--- a/src/components/editor/editor-sections/ed-section-custom/ed-section-custom-list-item.tsx
+++ b/src/components/editor/editor-sections/ed-section-custom/ed-section-custom-list-item.tsx
@@ -1,0 +1,113 @@
+import { Trash } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { type Control, Controller } from "react-hook-form";
+import { Button } from "@/components/ui/button";
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+  FieldLegend,
+  FieldSet,
+} from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { PROSE_FEATURES } from "@/lib/resume/schema-registry";
+import { RichTextEditor } from "../../rich-text/rich-text-editor";
+import { DateRangeFields } from "../date-range-fields";
+import type { CustomListFormValues } from "../resume-form-adapter";
+
+interface EditorSectionCustomListItemProps {
+  index: number;
+  control: Control<CustomListFormValues>;
+  onRemoveField: (index: number) => void;
+}
+
+export function EditorSectionCustomListItem(
+  props: EditorSectionCustomListItemProps,
+) {
+  const t = useTranslations("editor.custom");
+  const onRemove = () => {
+    props.onRemoveField(props.index);
+  };
+
+  return (
+    <FieldSet>
+      <FieldLegend className="sr-only" variant="label">
+        {t("itemLegend", { index: props.index + 1 })}
+      </FieldLegend>
+
+      <FieldGroup className="gap-3">
+        <Controller
+          control={props.control}
+          name={`entries.${props.index}.title`}
+          render={({ field, fieldState }) => (
+            <Field>
+              <FieldLabel htmlFor={field.name}>{t("entryTitle")}</FieldLabel>
+              <div className="flex items-center gap-2">
+                <Input
+                  placeholder={t("entryTitlePlaceholder")}
+                  {...field}
+                  id={field.name}
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon-sm"
+                  onClick={onRemove}
+                >
+                  <Trash className="size-3.5 stroke-destructive" />
+                  <span className="sr-only">{t("removeEntry")}</span>
+                </Button>
+              </div>
+              <FieldError errors={[fieldState.error]} />
+            </Field>
+          )}
+        />
+
+        <Controller
+          control={props.control}
+          name={`entries.${props.index}.subtitle`}
+          render={({ field, fieldState }) => (
+            <Field>
+              <FieldLabel htmlFor={field.name}>{t("entrySubtitle")}</FieldLabel>
+              <Input
+                placeholder={t("entrySubtitlePlaceholder")}
+                {...field}
+                id={field.name}
+              />
+              <FieldError errors={[fieldState.error]} />
+            </Field>
+          )}
+        />
+
+        <DateRangeFields
+          control={props.control}
+          startName={`entries.${props.index}.startDate`}
+          endName={`entries.${props.index}.endDate`}
+          presentLabel={t("present")}
+        />
+
+        <Controller
+          control={props.control}
+          name={`entries.${props.index}.description`}
+          render={({ field, fieldState }) => (
+            <Field>
+              <FieldLabel htmlFor={field.name}>
+                {t("entryDescription")}
+              </FieldLabel>
+              <RichTextEditor
+                id={field.name}
+                value={field.value}
+                features={PROSE_FEATURES}
+                placeholder={t("entryDescriptionPlaceholder")}
+                onChange={field.onChange}
+                onBlur={field.onBlur}
+              />
+              <FieldError errors={[fieldState.error]} />
+            </Field>
+          )}
+        />
+      </FieldGroup>
+    </FieldSet>
+  );
+}

--- a/src/components/editor/editor-sections/ed-section-custom/ed-section-custom-menu.tsx
+++ b/src/components/editor/editor-sections/ed-section-custom/ed-section-custom-menu.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { MoreVertical, Pen, Trash } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useResumeStore } from "@/lib/store";
+import { EditorSectionCustomNameDialog } from "./ed-section-custom-name-dialog";
+
+interface EditorSectionCustomMenuProps {
+  sectionId: string;
+  title: string;
+}
+
+export function EditorSectionCustomMenu(props: EditorSectionCustomMenuProps) {
+  const renameCustomSection = useResumeStore(
+    (state) => state.renameCustomSection,
+  );
+  const removeCustomSection = useResumeStore(
+    (state) => state.removeCustomSection,
+  );
+  const t = useTranslations("editor.custom");
+  const [renameOpen, setRenameOpen] = useState(false);
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger render={<Button size="icon-sm" variant="ghost" />}>
+          <span className="sr-only">{t("menuLabel")}</span>
+          <MoreVertical />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={() => setRenameOpen(true)}>
+            <Pen /> {t("rename")}
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            variant="destructive"
+            onClick={() => removeCustomSection(props.sectionId)}
+          >
+            <Trash /> {t("remove")}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <EditorSectionCustomNameDialog
+        open={renameOpen}
+        onOpenChange={setRenameOpen}
+        heading={t("renameHeading")}
+        description={t("renameDescription")}
+        initialValue={props.title}
+        onSubmit={(title) => renameCustomSection(props.sectionId, title)}
+      />
+    </>
+  );
+}

--- a/src/components/editor/editor-sections/ed-section-custom/ed-section-custom-name-dialog.tsx
+++ b/src/components/editor/editor-sections/ed-section-custom/ed-section-custom-name-dialog.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
+import { Save, TextInitial, XIcon } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useEffect, useMemo } from "react";
+import { Controller, useForm } from "react-hook-form";
+import {
+  ResponsiveDialog,
+  ResponsiveDialogClose,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogFooter,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "@/components/shared/responsive-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from "@/components/ui/field";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "@/components/ui/input-group";
+import { useValidationTranslator } from "@/hooks/use-validation-translator";
+import {
+  createSectionTitleSchema,
+  SECTION_TITLE_MAX_LENGTH,
+  type SectionTitleForm,
+} from "@/lib/forms/section";
+
+interface EditorSectionCustomNameDialogProps {
+  open: boolean;
+  onOpenChange: (next: boolean) => void;
+  /** Dialog heading and description text. */
+  heading: string;
+  description: string;
+  /** Prefilled value: empty when adding, the current title when renaming. */
+  initialValue: string;
+  onSubmit: (title: string) => void;
+}
+
+export function EditorSectionCustomNameDialog(
+  props: EditorSectionCustomNameDialogProps,
+) {
+  const t = useTranslations("editor.custom");
+  const tc = useTranslations("forms.common");
+  const tv = useValidationTranslator();
+  const schema = useMemo(() => createSectionTitleSchema(tv), [tv]);
+  const form = useForm<SectionTitleForm>({
+    resolver: standardSchemaResolver(schema),
+    defaultValues: { title: props.initialValue },
+    mode: "onChange",
+  });
+
+  // Reset to the current value each time the dialog opens (add starts empty,
+  // rename starts from the section's title).
+  useEffect(() => {
+    if (props.open) form.reset({ title: props.initialValue });
+  }, [props.open, props.initialValue, form]);
+
+  const onSubmit = form.handleSubmit((values) => {
+    props.onSubmit(values.title);
+    props.onOpenChange(false);
+  });
+
+  return (
+    <ResponsiveDialog open={props.open} onOpenChange={props.onOpenChange}>
+      <ResponsiveDialogContent showCloseButton={false}>
+        <ResponsiveDialogHeader>
+          <ResponsiveDialogTitle>{props.heading}</ResponsiveDialogTitle>
+          <ResponsiveDialogDescription>
+            {props.description}
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
+
+        <form onSubmit={onSubmit}>
+          <FieldGroup>
+            <Controller
+              control={form.control}
+              name="title"
+              render={({ field, fieldState }) => (
+                <Field data-invalid={fieldState.invalid}>
+                  <FieldLabel htmlFor="custom-section-name">
+                    {t("nameLabel")}
+                  </FieldLabel>
+                  <InputGroup>
+                    <InputGroupAddon>
+                      <TextInitial />
+                    </InputGroupAddon>
+                    <InputGroupInput
+                      id="custom-section-name"
+                      maxLength={SECTION_TITLE_MAX_LENGTH}
+                      placeholder={t("namePlaceholder")}
+                      aria-invalid={fieldState.invalid}
+                      {...field}
+                    />
+                  </InputGroup>
+                  <FieldError errors={[fieldState.error]} />
+                </Field>
+              )}
+            />
+          </FieldGroup>
+
+          <ResponsiveDialogFooter className="mt-6">
+            <ResponsiveDialogClose type="button" variant="outline">
+              <XIcon /> {tc("cancel")}
+            </ResponsiveDialogClose>
+            <Button type="submit" disabled={!form.formState.isValid}>
+              <Save /> {tc("save")}
+            </Button>
+          </ResponsiveDialogFooter>
+        </form>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  );
+}

--- a/src/components/editor/editor-sections/ed-section-custom/ed-section-custom.tsx
+++ b/src/components/editor/editor-sections/ed-section-custom/ed-section-custom.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { Shapes } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { SegmentedControl } from "@/components/shared/segmented-control";
+import { TruncatedLabel } from "@/components/shared/truncated-label";
+import {
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import type { CustomVariant } from "@/lib/resume";
+import { useResumeStore } from "@/lib/store";
+import { EditorSectionCustomBodyForm } from "./ed-section-custom-body-form";
+import { EditorSectionCustomListForm } from "./ed-section-custom-list-form";
+import { EditorSectionCustomMenu } from "./ed-section-custom-menu";
+
+interface EditorSectionCustomProps {
+  sectionId: string;
+}
+
+export function EditorSectionCustom(props: EditorSectionCustomProps) {
+  const section = useResumeStore((state) =>
+    state.open?.sections.find((s) => s.id === props.sectionId),
+  );
+  const setCustomVariant = useResumeStore((state) => state.setCustomVariant);
+  const t = useTranslations("editor.custom");
+
+  if (!section || section.type !== "custom") return null;
+  const variant = section.variant ?? "rich";
+  const label = section.title.trim() || t("defaultTitle");
+
+  return (
+    <AccordionItem value={section.id} className="relative">
+      <AccordionTrigger className="min-w-0 items-center gap-3">
+        <Shapes className="size-4 shrink-0" />
+        {/* mr reserves room for the absolutely-positioned menu so the title
+            truncates before it, leaving order: title, menu, chevron. */}
+        <TruncatedLabel
+          text={label}
+          className="mr-9 min-w-0 flex-1 text-left"
+        />
+      </AccordionTrigger>
+
+      {/* The menu sits in the trigger row (not nested in the trigger button, and
+          not inside the panel) so a section can be renamed or removed without
+          expanding it first. It is placed just left of the trigger's chevron. */}
+      <div className="absolute top-2.5 right-9 z-10">
+        <EditorSectionCustomMenu sectionId={section.id} title={section.title} />
+      </div>
+
+      <AccordionContent>
+        <div className="mb-4">
+          <SegmentedControl
+            aria-label={t("variantLabel")}
+            value={variant}
+            onValueChange={(value) =>
+              setCustomVariant(section.id, value as CustomVariant)
+            }
+            items={[
+              {
+                value: "rich",
+                label: t("variantText"),
+                ariaLabel: t("variantTextAria"),
+              },
+              {
+                value: "list",
+                label: t("variantList"),
+                ariaLabel: t("variantListAria"),
+              },
+            ]}
+          />
+        </div>
+
+        {variant === "list" ? (
+          <EditorSectionCustomListForm
+            key={`${section.id}-list`}
+            sectionId={section.id}
+          />
+        ) : (
+          <EditorSectionCustomBodyForm
+            key={`${section.id}-rich`}
+            sectionId={section.id}
+          />
+        )}
+      </AccordionContent>
+    </AccordionItem>
+  );
+}

--- a/src/components/editor/editor-sections/ed-section-list.tsx
+++ b/src/components/editor/editor-sections/ed-section-list.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import type { ReactNode } from "react";
+import { type ReactNode, useState } from "react";
 import { SortableList } from "@/components/shared/sortable-list";
 import { Accordion } from "@/components/ui/accordion";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -9,6 +9,8 @@ import { isReorderableSection, type SectionType } from "@/lib/resume";
 import { useResumeStore } from "@/lib/store";
 import { cn } from "@/lib/utils";
 import { EditorSectionCertifications } from "./ed-section-certifications/ed-section-certifications";
+import { EditorSectionCustom } from "./ed-section-custom/ed-section-custom";
+import { EditorSectionCustomAdd } from "./ed-section-custom/ed-section-custom-add";
 import { EditorSectionEducation } from "./ed-section-education/ed-section-education";
 import { EditorSectionExperience } from "./ed-section-experience/ed-section-experience";
 import { EditorSectionInternship } from "./ed-section-internship/ed-section-internship";
@@ -43,6 +45,11 @@ export function EditorSectionList() {
   const reorderSections = useResumeStore((state) => state.reorderSections);
   const t = useTranslations("editor.chrome");
 
+  // Controlled accordion open-state. Item values are the section id for custom
+  // sections (so a newly added one can be opened by id) and base-ui-generated
+  // ids for the rest. Stale ids from another résumé simply match nothing.
+  const [openSections, setOpenSections] = useState<string[]>([]);
+
   if (!open) {
     if (openStatus === "missing") {
       return (
@@ -73,32 +80,50 @@ export function EditorSectionList() {
   // the uncontrolled rich-text editors pick up the loaded document. Personal
   // Details (the Header) and Summary are pinned; the rest drag to reorder.
   return (
-    <Accordion key={open.id} multiple className="border-none">
-      <div className={cn("not-last:border-b", SECTION_TRIGGER_INSET)}>
-        <EditorSectionPersonal />
-      </div>
-      <div className={cn("not-last:border-b", SECTION_TRIGGER_INSET)}>
-        <EditorSectionSummary />
-      </div>
-      <SortableList
-        items={reorderable.map((section) => section.id)}
-        onReorder={reorderSections}
-        remeasureWhileDragging
+    <>
+      <Accordion
+        key={open.id}
+        multiple
+        value={openSections}
+        onValueChange={setOpenSections}
+        className="border-none"
       >
-        {reorderable.map((section) => {
-          const Editor = SECTION_EDITORS[section.type];
-          if (!Editor) return null;
-          return (
-            <EditorSectionSortableItem
-              key={section.id}
-              id={section.id}
-              handleLabel={t("reorderSection")}
-            >
-              <Editor />
-            </EditorSectionSortableItem>
-          );
-        })}
-      </SortableList>
-    </Accordion>
+        <div className={cn("not-last:border-b", SECTION_TRIGGER_INSET)}>
+          <EditorSectionPersonal />
+        </div>
+        <div className={cn("not-last:border-b", SECTION_TRIGGER_INSET)}>
+          <EditorSectionSummary />
+        </div>
+        <SortableList
+          items={reorderable.map((section) => section.id)}
+          onReorder={reorderSections}
+          remeasureWhileDragging
+        >
+          {reorderable.map((section) => {
+            const Editor = SECTION_EDITORS[section.type];
+            const content =
+              section.type === "custom" ? (
+                <EditorSectionCustom sectionId={section.id} />
+              ) : Editor ? (
+                <Editor />
+              ) : null;
+            if (!content) return null;
+            return (
+              <EditorSectionSortableItem
+                key={section.id}
+                id={section.id}
+                handleLabel={t("reorderSection")}
+              >
+                {content}
+              </EditorSectionSortableItem>
+            );
+          })}
+        </SortableList>
+      </Accordion>
+
+      <EditorSectionCustomAdd
+        onAdded={(id) => setOpenSections((prev) => [...prev, id])}
+      />
+    </>
   );
 }

--- a/src/components/editor/editor-sections/resume-form-adapter.ts
+++ b/src/components/editor/editor-sections/resume-form-adapter.ts
@@ -487,3 +487,74 @@ export function applyLanguagesValues(
     fields: { name: plain(item.name), level: plain(item.level) },
   }));
 }
+
+// --- Custom sections (addressed by id; shape depends on the variant) --------
+
+function sectionById(resume: Resume, id: string): Section | undefined {
+  return resume.sections.find((section) => section.id === id);
+}
+
+export interface CustomBodyFormValues {
+  body: JSONContent;
+}
+
+export function toCustomBodyValues(section: Section): CustomBodyFormValues {
+  return { body: richValue(section.entries[0]?.fields.body) };
+}
+
+// The section title is managed outside the form (add/rename dialogs), so these
+// adapters only own the content and never touch `section.title`.
+export function applyCustomBodyValues(
+  draft: Resume,
+  id: string,
+  values: CustomBodyFormValues,
+): void {
+  const section = sectionById(draft, id);
+  if (!section || section.type !== "custom") return;
+  section.entries = [
+    { id: entryId(section, 0), fields: { body: rich(values.body) } },
+  ];
+}
+
+export interface CustomListItemValues {
+  title: string;
+  subtitle: string;
+  startDate: string;
+  endDate: string;
+  description: JSONContent;
+}
+
+export interface CustomListFormValues {
+  entries: CustomListItemValues[];
+}
+
+export function toCustomListValues(section: Section): CustomListFormValues {
+  return {
+    entries: section.entries.map((entry) => ({
+      title: plainValue(entry.fields.title),
+      subtitle: plainValue(entry.fields.subtitle),
+      startDate: plainValue(entry.fields.startDate),
+      endDate: plainValue(entry.fields.endDate),
+      description: richValue(entry.fields.description),
+    })),
+  };
+}
+
+export function applyCustomListValues(
+  draft: Resume,
+  id: string,
+  values: CustomListFormValues,
+): void {
+  const section = sectionById(draft, id);
+  if (!section || section.type !== "custom") return;
+  section.entries = values.entries.map((item, index) => ({
+    id: entryId(section, index),
+    fields: {
+      title: plain(item.title),
+      subtitle: plain(item.subtitle),
+      startDate: plain(item.startDate),
+      endDate: plain(item.endDate),
+      description: rich(item.description),
+    },
+  }));
+}

--- a/src/components/editor/resume-blocks.ts
+++ b/src/components/editor/resume-blocks.ts
@@ -3,6 +3,7 @@ import type { ReorderableSectionType } from "@/lib/resume/schema-registry";
 import type { SectionColumns } from "@/lib/resume/types";
 import type {
   CertificateItemView,
+  CustomSectionView,
   EducationItemView,
   ExperienceItemView,
   HeaderView,
@@ -190,6 +191,40 @@ function languagesBlocks(
   ];
 }
 
+// A custom section reuses existing block kinds: `rich` renders like Summary
+// (heading + one rich-text block), `list` renders like Experience (heading +
+// entries). Omitted when it has no content, so an empty custom section is hidden.
+function customBlocks(view: CustomSectionView): ResumeBlock[] {
+  const headingId = `custom-${view.id}-heading`;
+  if (view.variant === "list") {
+    const entries = view.entries.filter(hasExperience);
+    if (entries.length === 0) return [];
+    return [
+      heading(headingId, view.title),
+      ...entries.map(
+        (item, index): ResumeBlock => ({
+          id: item.id,
+          kind: "experience",
+          item,
+          gapBefore: entryGap(index),
+          keepWithNext: false,
+        }),
+      ),
+    ];
+  }
+  if (isRichEmpty(view.body)) return [];
+  return [
+    heading(headingId, view.title),
+    {
+      id: `custom-${view.id}-body`,
+      kind: "summary",
+      body: view.body,
+      gapBefore: GAP.body,
+      keepWithNext: false,
+    },
+  ];
+}
+
 /**
  * Builds the linear block sequence. The Header and Summary are pinned at the top;
  * every other section is emitted in the document's `sectionOrder` (the user's
@@ -218,7 +253,10 @@ export function buildResumeBlocks(resume: ResumePreview): ResumeBlock[] {
     });
   }
 
-  const emitters: Record<ReorderableSectionType, () => ResumeBlock[]> = {
+  const emitters: Record<
+    Exclude<ReorderableSectionType, "custom">,
+    () => ResumeBlock[]
+  > = {
     experience: () =>
       experienceLikeBlocks(
         resume.experience,
@@ -249,12 +287,19 @@ export function buildResumeBlocks(resume: ResumePreview): ResumeBlock[] {
     skills: () =>
       skillsBlocks(resume.skills, resume.skillsColumns, labels.skills),
     languages: () => languagesBlocks(resume.languages, labels.languages),
-    // Custom sections carry no preview data yet; wired up in a later increment.
-    custom: () => [],
   };
 
-  for (const type of resume.sectionOrder) {
-    blocks.push(...emitters[type]());
+  const customById = new Map(
+    resume.customSections.map((section) => [section.id, section]),
+  );
+
+  for (const ref of resume.sectionOrder) {
+    if (ref.type === "custom") {
+      const view = customById.get(ref.id);
+      if (view) blocks.push(...customBlocks(view));
+    } else {
+      blocks.push(...emitters[ref.type]());
+    }
   }
 
   return blocks;

--- a/src/components/editor/resume-preview.ts
+++ b/src/components/editor/resume-preview.ts
@@ -8,7 +8,11 @@
  */
 
 import type { ReorderableSectionType } from "@/lib/resume/schema-registry";
-import type { ResumeLanguage, SectionColumns } from "@/lib/resume/types";
+import type {
+  CustomVariant,
+  ResumeLanguage,
+  SectionColumns,
+} from "@/lib/resume/types";
 import type { RichBlock } from "./rich-content";
 
 export type ContactKind =
@@ -72,15 +76,38 @@ export interface LanguageItemView {
   proficiency: string;
 }
 
+/**
+ * A user-defined custom section. `rich` renders its `body` like Summary; `list`
+ * renders its `entries` through the experience path. Both are carried so the
+ * block builder can pick by `variant`, and each is addressed by `id` from the
+ * section order (unlike core sections, several custom sections can coexist).
+ */
+export interface CustomSectionView {
+  id: string;
+  title: string;
+  variant: CustomVariant;
+  body: RichBlock[];
+  entries: ExperienceItemView[];
+}
+
+/** A reference to a reorderable section in reading order, addressable by id. */
+export interface SectionRef {
+  type: ReorderableSectionType;
+  id: string;
+}
+
 export interface ResumePreview {
   /** Document language for fixed labels (headings, dates); drives localization. */
   language: ResumeLanguage;
   /**
    * The reorderable sections in document (reading) order. Drives the order blocks
-   * are emitted in after the pinned Header and Summary. A type appears at most
-   * once; empty sections stay in the list and are gated out at block-build time.
+   * are emitted in after the pinned Header and Summary. Core types appear at most
+   * once; `custom` may repeat, so each ref carries the section `id` used to look
+   * it up in `customSections`. Empty sections are gated out at block-build time.
    */
-  sectionOrder: ReorderableSectionType[];
+  sectionOrder: SectionRef[];
+  /** Custom sections by id, resolved from `sectionOrder` refs of type `custom`. */
+  customSections: CustomSectionView[];
   header: HeaderView;
   summary: RichBlock[];
   experience: ExperienceItemView[];

--- a/src/components/editor/resume-to-preview.ts
+++ b/src/components/editor/resume-to-preview.ts
@@ -5,7 +5,12 @@ import {
 } from "@/lib/resume/schema-registry";
 import type { Field, Resume, Section } from "@/lib/resume/types";
 import { localizeDateValue } from "./month-year-menu/month-year-menu-data";
-import type { ContactView, HeaderView, ResumePreview } from "./resume-preview";
+import type {
+  ContactView,
+  CustomSectionView,
+  HeaderView,
+  ResumePreview,
+} from "./resume-preview";
 import { byRecency } from "./resume-sort";
 import { type RichBlock, tiptapToRichBlocks } from "./rich-content";
 
@@ -87,7 +92,8 @@ export function isResumePreviewEmpty(preview: ResumePreview): boolean {
     preview.education.length === 0 &&
     preview.certificates.length === 0 &&
     preview.skills.length === 0 &&
-    preview.languages.length === 0
+    preview.languages.length === 0 &&
+    preview.customSections.length === 0
   );
 }
 
@@ -109,11 +115,43 @@ export function resumeToPreview(resume: Resume): ResumePreview {
 
   const sectionOrder = resume.sections
     .filter((section) => isReorderableSection(section.type))
-    .map((section) => section.type as ReorderableSectionType);
+    .map((section) => ({
+      type: section.type as ReorderableSectionType,
+      id: section.id,
+    }));
+
+  const customSections: CustomSectionView[] = resume.sections
+    .filter((section) => section.type === "custom")
+    .map((section) => {
+      const variant = section.variant ?? "rich";
+      return {
+        id: section.id,
+        title: section.title,
+        variant,
+        body:
+          variant === "rich" ? richBlocks(section.entries[0]?.fields.body) : [],
+        // Custom list entries keep document order (no recency sort): they are
+        // freeform and often carry no dates.
+        entries:
+          variant === "list"
+            ? section.entries
+                .map((entry) => ({
+                  id: entry.id,
+                  role: plain(entry.fields.title),
+                  company: plain(entry.fields.subtitle),
+                  startDate: plain(entry.fields.startDate),
+                  endDate: plain(entry.fields.endDate),
+                  description: richBlocks(entry.fields.description),
+                }))
+                .map(localizeDates)
+            : [],
+      };
+    });
 
   return {
     language: resume.language,
     sectionOrder,
+    customSections,
     header: toHeaderView(resume),
     summary: richBlocks(summaryBody),
     experience: (sectionOfType(resume, "experience")?.entries ?? [])

--- a/src/components/shared/truncated-label.tsx
+++ b/src/components/shared/truncated-label.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+
+interface TruncatedLabelProps {
+  text: string;
+  className?: string;
+}
+
+/**
+ * Renders text on a single line, truncated with an ellipsis. When (and only
+ * when) the text actually overflows its container, it exposes the full value via
+ * the native `title` tooltip on hover. A native title is used deliberately: it
+ * works everywhere the label appears (including a trigger nested inside a
+ * collapsed accordion button, where a portalled tooltip did not open reliably).
+ * Relies on the parent allowing the label to shrink (e.g. a flex row `min-w-0`).
+ */
+export function TruncatedLabel(props: TruncatedLabelProps) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const [truncated, setTruncated] = useState(false);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `props.text` is a deliberate re-run trigger; changing the text alters scrollWidth without resizing the observed box, so the ResizeObserver alone would miss a short→long content change.
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    let raf = 0;
+    const check = () => setTruncated(el.scrollWidth > el.clientWidth);
+    // Measure after the next paint so layout (and the min-w-0 flex constraint) is
+    // settled; a synchronous measure on mount can read a not-yet-constrained box.
+    const schedule = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(check);
+    };
+    schedule();
+    const observer = new ResizeObserver(schedule);
+    observer.observe(el);
+    // A web font swap changes the text's rendered width without resizing the
+    // element's (flex-constrained) box, so the ResizeObserver never fires; re-check
+    // once fonts are ready.
+    document.fonts?.ready.then(schedule);
+    return () => {
+      cancelAnimationFrame(raf);
+      observer.disconnect();
+    };
+  }, [props.text]);
+
+  return (
+    <span
+      ref={ref}
+      title={truncated ? props.text : undefined}
+      className={cn("block truncate", props.className)}
+    >
+      {props.text}
+    </span>
+  );
+}

--- a/src/lib/forms/section.ts
+++ b/src/lib/forms/section.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+export const SECTION_TITLE_MAX_LENGTH = 50;
+
+type Translator = (key: string, values?: Record<string, unknown>) => string;
+
+/**
+ * Validation for a custom section's title, used by the add and rename dialogs.
+ * `trim` runs before the checks, so the parsed submit value is already trimmed;
+ * a title is required (non-empty) and capped so it stays a single heading line.
+ */
+export function createSectionTitleSchema(t: Translator) {
+  return z.object({
+    title: z
+      .string()
+      .trim()
+      .min(1, t("sectionTitleRequired"))
+      .max(
+        SECTION_TITLE_MAX_LENGTH,
+        t("titleMax", { max: SECTION_TITLE_MAX_LENGTH }),
+      ),
+  });
+}
+
+export type SectionTitleForm = z.infer<
+  ReturnType<typeof createSectionTitleSchema>
+>;

--- a/src/lib/resume/custom-section.ts
+++ b/src/lib/resume/custom-section.ts
@@ -1,0 +1,103 @@
+import { G } from "@mobily/ts-belt";
+import type { JSONContent } from "@tiptap/core";
+import { nanoid } from "nanoid";
+import { emptyRichTextValue } from "./factory";
+import type { CustomVariant, Entry, Field, Section } from "./types";
+
+function plainField(value: string): Field {
+  return { kind: "plain", value };
+}
+
+function plainValue(field: Field | undefined): string {
+  return field?.kind === "plain" ? field.value : "";
+}
+
+function richValue(field: Field | undefined): JSONContent {
+  return field?.kind === "richtext" ? field.value : emptyRichTextValue();
+}
+
+/** Concatenates every text node within a rich-text node subtree. */
+function collectText(node: unknown): string {
+  if (!G.isObject(node)) return "";
+  const record = node as { text?: unknown; content?: unknown };
+  let text = G.isString(record.text) ? record.text : "";
+  if (Array.isArray(record.content)) {
+    for (const child of record.content) text += collectText(child);
+  }
+  return text;
+}
+
+function blockHasText(block: JSONContent): boolean {
+  return collectText(block).trim().length > 0;
+}
+
+/** Moves a `rich` section's single body into one `list` entry's description. */
+function richBodyToListEntries(section: Section): Entry[] {
+  const body = richValue(section.entries[0]?.fields.body);
+  return [
+    {
+      id: nanoid(),
+      fields: {
+        title: plainField(""),
+        subtitle: plainField(""),
+        startDate: plainField(""),
+        endDate: plainField(""),
+        description: { kind: "richtext", value: body },
+      },
+    },
+  ];
+}
+
+/** The bold heading line for one `list` entry, or null when it has no meta. */
+function entryHeadingParagraph(entry: Entry): JSONContent | null {
+  const title = plainValue(entry.fields.title).trim();
+  const subtitle = plainValue(entry.fields.subtitle).trim();
+  const dates = [
+    plainValue(entry.fields.startDate).trim(),
+    plainValue(entry.fields.endDate).trim(),
+  ]
+    .filter(Boolean)
+    .join(" - ");
+  const meta = [subtitle, dates].filter(Boolean).join(", ");
+
+  const runs: JSONContent[] = [];
+  if (title)
+    runs.push({ type: "text", text: title, marks: [{ type: "bold" }] });
+  if (meta) runs.push({ type: "text", text: title ? ` ${meta}` : meta });
+  return runs.length > 0 ? { type: "paragraph", content: runs } : null;
+}
+
+/** Flattens every `list` entry into one `rich` body (heading line + description). */
+function listEntriesToRichBody(section: Section): Entry[] {
+  const blocks: JSONContent[] = [];
+  for (const entry of section.entries) {
+    const heading = entryHeadingParagraph(entry);
+    if (heading) blocks.push(heading);
+    const description = richValue(entry.fields.description);
+    for (const block of description.content ?? []) {
+      if (blockHasText(block)) blocks.push(block);
+    }
+  }
+  const value: JSONContent =
+    blocks.length > 0 ? { type: "doc", content: blocks } : emptyRichTextValue();
+  return [{ id: nanoid(), fields: { body: { kind: "richtext", value } } }];
+}
+
+/**
+ * Convert a custom Section to the target variant, transforming its content:
+ * `rich` -> `list` moves the body into a single entry's description; `list` ->
+ * `rich` flattens every entry (a bold heading line plus its description) into one
+ * body. Lossy by design (structured fields collapse to text); a no-op when the
+ * section is already in the target variant.
+ */
+export function convertCustomSection(
+  section: Section,
+  target: CustomVariant,
+): Section {
+  if ((section.variant ?? "rich") === target) return section;
+  const entries =
+    target === "list"
+      ? richBodyToListEntries(section)
+      : listEntriesToRichBody(section);
+  return { ...section, variant: target, entries };
+}

--- a/src/lib/resume/factory.ts
+++ b/src/lib/resume/factory.ts
@@ -3,11 +3,13 @@ import type { JSONContent } from "@tiptap/core";
 import { nanoid } from "nanoid";
 import {
   type FieldSchema,
+  getCustomFields,
   getSectionSchema,
   HEADER_SCHEMA,
 } from "./schema-registry";
 import {
   CURRENT_SCHEMA_VERSION,
+  type CustomVariant,
   type Entry,
   type Field,
   type FieldKey,
@@ -56,6 +58,28 @@ export function createEmptySection(type: SectionType): Section {
   // The Skills grid is column-toggleable; new sections start two-column.
   if (type === "skills") section.columns = 2;
   return section;
+}
+
+/** An empty entry shaped for a custom Section in the given variant. */
+export function createCustomEntry(variant: CustomVariant): Entry {
+  return { id: nanoid(), fields: fieldsFromSchema(getCustomFields(variant)) };
+}
+
+/**
+ * A new custom Section: a variant (default `rich`), a default heading the user
+ * can rename, and one starter entry shaped for that variant.
+ */
+export function createCustomSection(
+  variant: CustomVariant = "rich",
+  title: string = getSectionSchema("custom").defaultTitle,
+): Section {
+  return {
+    id: nanoid(),
+    type: "custom",
+    title,
+    variant,
+    entries: [createCustomEntry(variant)],
+  };
 }
 
 export function createEmptyHeader(): Header {

--- a/src/lib/resume/index.ts
+++ b/src/lib/resume/index.ts
@@ -1,5 +1,8 @@
+export { convertCustomSection } from "./custom-section";
 export {
   cloneResumeAsNew,
+  createCustomEntry,
+  createCustomSection,
   createEmptyEntry,
   createEmptyHeader,
   createEmptyResume,
@@ -10,8 +13,10 @@ export { RESUME_LABELS, RESUME_LANGUAGES } from "./labels";
 export { needsMigration, readSchemaVersion, runMigrations } from "./migrations";
 export {
   CANONICAL_SECTION_ORDER,
+  CUSTOM_LIST_FIELDS,
   canonicalSectionIndex,
   type FieldSchema,
+  getCustomFields,
   getSectionSchema,
   HEADER_SCHEMA,
   isReorderableSection,
@@ -25,6 +30,7 @@ export { filterResumeIndex, nearestResumeById } from "./search";
 export { SEED_RESUME } from "./seed";
 export {
   CURRENT_SCHEMA_VERSION,
+  type CustomVariant,
   type Entry,
   type Field,
   type FieldKey,

--- a/src/lib/resume/schema-registry.ts
+++ b/src/lib/resume/schema-registry.ts
@@ -1,4 +1,4 @@
-import type { FieldKey, SectionType } from "./types";
+import type { CustomVariant, FieldKey, SectionType } from "./types";
 
 /**
  * The allowed TipTap features for a richtext Field: the Restricted schema
@@ -375,17 +375,14 @@ export const SECTION_REGISTRY: Record<SectionType, SectionSchema> = {
       },
     ],
   },
+  // A custom Section's Field shape depends on its `variant`; the registry lists
+  // the `rich` (default) fields. Use `getCustomFields(variant)` for the actual
+  // per-entry shape and `CUSTOM_LIST_FIELDS` for the `list` variant.
   custom: {
     type: "custom",
     defaultTitle: "Custom Section",
     singleton: false,
     fields: [
-      {
-        key: "title",
-        label: "Title",
-        kind: "plain",
-        placeholder: "Certification",
-      },
       {
         key: "body",
         label: "Body",
@@ -395,6 +392,37 @@ export const SECTION_REGISTRY: Record<SectionType, SectionSchema> = {
     ],
   },
 };
+
+/** The per-entry Field shape of a `list`-variant custom Section (experience-like). */
+export const CUSTOM_LIST_FIELDS: FieldSchema[] = [
+  { key: "title", label: "Title", kind: "plain", placeholder: "Award name" },
+  {
+    key: "subtitle",
+    label: "Subtitle",
+    kind: "plain",
+    placeholder: "Issuer or place",
+  },
+  {
+    key: "startDate",
+    label: "Start date",
+    kind: "plain",
+    placeholder: "Jan 2023",
+  },
+  { key: "endDate", label: "End date", kind: "plain", placeholder: "Present" },
+  {
+    key: "description",
+    label: "Description",
+    kind: "richtext",
+    features: PROSE_FEATURES,
+  },
+];
+
+/** The per-entry Field shape for a custom Section in the given variant. */
+export function getCustomFields(variant: CustomVariant): FieldSchema[] {
+  return variant === "list"
+    ? CUSTOM_LIST_FIELDS
+    : SECTION_REGISTRY.custom.fields;
+}
 
 export function getSectionSchema(type: SectionType): SectionSchema {
   return SECTION_REGISTRY[type];

--- a/src/lib/resume/types.ts
+++ b/src/lib/resume/types.ts
@@ -58,6 +58,13 @@ export type SectionType =
   | "custom";
 
 /**
+ * How a `custom` Section presents its content. `rich` is a single rich-text body
+ * (like Summary); `list` is repeatable entries (like Experience). Only custom
+ * Sections carry this; core Sections have a fixed presentation and omit it.
+ */
+export type CustomVariant = "rich" | "list";
+
+/**
  * A typed, reorderable unit below the Header. `title` is presentation/label data
  * only; relabeling never changes the Section's parse shape or Field schema.
  */
@@ -71,6 +78,12 @@ export interface Section {
    * non-grid sections; renderers default to a two-column grid when unset.
    */
   columns?: SectionColumns;
+  /**
+   * Presentation variant for `custom` Sections only: `rich` (a single rich-text
+   * body) or `list` (repeatable entries). Absent on core Sections; the custom
+   * factory always sets it, and renderers treat an unset value as `rich`.
+   */
+  variant?: CustomVariant;
 }
 
 /**

--- a/src/lib/store/resume-store.ts
+++ b/src/lib/store/resume-store.ts
@@ -8,8 +8,11 @@ import {
   setLastOpenedResumeId,
 } from "@/lib/db";
 import {
+  type CustomVariant,
   canonicalSectionIndex,
   cloneResumeAsNew,
+  convertCustomSection,
+  createCustomSection,
   createEmptyResume,
   isReorderableSection,
   type Resume,
@@ -63,6 +66,14 @@ interface ResumeStoreState {
   reorderSections: (from: number, to: number) => void;
   /** Restore sections to the canonical reading order (the default). */
   resetSectionOrder: () => void;
+  /** Append a new custom section (rich variant) with the given title; returns its id. */
+  addCustomSection: (title: string) => string;
+  /** Rename a custom section by id; no-op for a core or missing section. */
+  renameCustomSection: (id: string, title: string) => void;
+  /** Remove a custom section by id; no-op for a core or missing section. */
+  removeCustomSection: (id: string) => void;
+  /** Switch a custom section's variant, converting its content across. */
+  setCustomVariant: (id: string, variant: CustomVariant) => void;
   /** Force any pending write to commit now (e.g. before navigating away). */
   flush: () => Promise<void>;
 }
@@ -222,6 +233,45 @@ export const useResumeStore = create<ResumeStoreState>()((set, get) => ({
       // at the end. Pinned sections already sort to their fixed slots.
       draft.sections.sort(
         (a, b) => canonicalSectionIndex(a.type) - canonicalSectionIndex(b.type),
+      );
+    });
+  },
+
+  addCustomSection(title) {
+    const section = createCustomSection("rich", title);
+    get().updateOpen((draft) => {
+      draft.sections.push(section);
+    });
+    return section.id;
+  },
+
+  renameCustomSection(id, title) {
+    get().updateOpen((draft) => {
+      const section = draft.sections.find(
+        (s) => s.id === id && s.type === "custom",
+      );
+      if (section) section.title = title;
+    });
+  },
+
+  removeCustomSection(id) {
+    get().updateOpen((draft) => {
+      const index = draft.sections.findIndex(
+        (section) => section.id === id && section.type === "custom",
+      );
+      if (index !== -1) draft.sections.splice(index, 1);
+    });
+  },
+
+  setCustomVariant(id, variant) {
+    get().updateOpen((draft) => {
+      const index = draft.sections.findIndex(
+        (section) => section.id === id && section.type === "custom",
+      );
+      if (index === -1) return;
+      draft.sections[index] = convertCustomSection(
+        draft.sections[index],
+        variant,
       );
     });
   },


### PR DESCRIPTION
Add a résumé section of your own alongside the built-in ones. Each custom section has an editable heading and a toggle between two layouts: a single rich-text body (like Summary) or a list of entries with a title, subtitle, date range, and description (like Experience). Switching the layout converts the existing content across. Custom sections drag to reorder and appear in the preview and every export like any other section.

Add a section from the button below the list; it opens a small dialog (a drawer on mobile) to name it, and the new section opens ready to edit. Rename or delete from the menu in the section's header, without opening it first. A long heading truncates to one line and shows its full text on hover.

Under the hood, custom sections reuse the existing summary and experience block kinds, so no template or export path needed changes. The render pipeline now addresses sections by id so several custom sections can coexist. There is no document-schema bump: the layout marker lives only on newly created custom sections, so existing résumés are untouched. A separate fix gives the platform's main region `min-w-0` so a wide section heading can no longer push the sidebar past the viewport.

Testing: created custom sections in both layouts and confirmed the preview, PDF, DOCX, and plain-text export all reflect them; switched layouts and verified the content carries over; reordered, renamed, and deleted sections; confirmed a long title truncates with its full text on hover and no longer pushes the editor sidebar off screen; and verified existing résumés open unchanged.
