### PR TITLE
feat: reorder certifications by drag and drop

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -548,6 +548,7 @@
       "url": "Certificate URL",
       "urlPlaceholder": "acme.com/cert",
       "urlDesc": "Link to the certificate or the issuer's site.",
+      "reorder": "Reorder certification",
       "remove": "Remove"
     },
     "skills": {

--- a/messages/id.json
+++ b/messages/id.json
@@ -548,6 +548,7 @@
       "url": "URL Sertifikat",
       "urlPlaceholder": "acme.com/cert",
       "urlDesc": "Tautan ke sertifikat atau situs penerbitnya.",
+      "reorder": "Ubah urutan sertifikat",
       "remove": "Hapus"
     },
     "skills": {

--- a/src/components/editor/editor-sections/ed-section-certifications/ed-section-certifications-form-item.tsx
+++ b/src/components/editor/editor-sections/ed-section-certifications/ed-section-certifications-form-item.tsx
@@ -1,6 +1,7 @@
 import { Trash } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { type Control, Controller } from "react-hook-form";
+import { SortableItem } from "@/components/shared/sortable-list";
 import { UrlInput } from "@/components/shared/url-input";
 import { Button } from "@/components/ui/button";
 import {
@@ -13,10 +14,13 @@ import {
   FieldSet,
 } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
 import type { CertificationsFormValues } from "../resume-form-adapter";
 
 interface EditorSectionCertificationsFormItemProps {
+  id: string;
   index: number;
+  isLast: boolean;
   control: Control<CertificationsFormValues>;
   onRemoveField: (index: number) => void;
 }
@@ -30,73 +34,80 @@ export function EditorSectionCertificationsFormItem(
   };
 
   return (
-    <FieldSet className="not-last-of-type:pb-4 not-last-of-type:border-b">
-      <FieldLegend className="sr-only" variant="label">
-        {t("itemLegend", { index: props.index + 1 })}
-      </FieldLegend>
-      <FieldGroup className="gap-3">
-        <Controller
-          control={props.control}
-          name={`certifications.${props.index}.name`}
-          render={({ field, fieldState }) => (
-            <Field>
-              <FieldLabel htmlFor={field.name}>{t("name")}</FieldLabel>
-              <div className="flex items-center gap-2">
+    <SortableItem
+      id={props.id}
+      handleLabel={t("reorder")}
+      align="start"
+      handleClassName="mt-8"
+    >
+      <FieldSet className={cn(!props.isLast && "pb-4 border-b")}>
+        <FieldLegend className="sr-only" variant="label">
+          {t("itemLegend", { index: props.index + 1 })}
+        </FieldLegend>
+        <FieldGroup className="gap-3">
+          <Controller
+            control={props.control}
+            name={`certifications.${props.index}.name`}
+            render={({ field, fieldState }) => (
+              <Field>
+                <FieldLabel htmlFor={field.name}>{t("name")}</FieldLabel>
+                <div className="flex items-center gap-2">
+                  <Input
+                    placeholder={t("namePlaceholder")}
+                    {...field}
+                    id={field.name}
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon-sm"
+                    onClick={onRemove}
+                  >
+                    <Trash className="size-3.5 stroke-destructive" />
+                    <span className="sr-only">{t("remove")}</span>
+                  </Button>
+                </div>
+                <FieldError errors={[fieldState.error]} />
+              </Field>
+            )}
+          />
+
+          <Controller
+            control={props.control}
+            name={`certifications.${props.index}.issuer`}
+            render={({ field, fieldState }) => (
+              <Field>
+                <FieldLabel htmlFor={field.name}>{t("issuer")}</FieldLabel>
                 <Input
-                  placeholder={t("namePlaceholder")}
+                  placeholder={t("issuerPlaceholder")}
                   {...field}
                   id={field.name}
                 />
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="icon-sm"
-                  onClick={onRemove}
-                >
-                  <Trash className="size-3.5 stroke-destructive" />
-                  <span className="sr-only">{t("remove")}</span>
-                </Button>
-              </div>
-              <FieldError errors={[fieldState.error]} />
-            </Field>
-          )}
-        />
+                <FieldError errors={[fieldState.error]} />
+              </Field>
+            )}
+          />
 
-        <Controller
-          control={props.control}
-          name={`certifications.${props.index}.issuer`}
-          render={({ field, fieldState }) => (
-            <Field>
-              <FieldLabel htmlFor={field.name}>{t("issuer")}</FieldLabel>
-              <Input
-                placeholder={t("issuerPlaceholder")}
-                {...field}
-                id={field.name}
-              />
-              <FieldError errors={[fieldState.error]} />
-            </Field>
-          )}
-        />
-
-        <Controller
-          control={props.control}
-          name={`certifications.${props.index}.url`}
-          render={({ field, fieldState }) => (
-            <Field>
-              <FieldLabel htmlFor={field.name}>{t("url")}</FieldLabel>
-              <UrlInput
-                id={field.name}
-                value={field.value}
-                placeholder={t("urlPlaceholder")}
-                onChange={field.onChange}
-                onBlur={field.onBlur}
-              />
-              <FieldDescription>{t("urlDesc")}</FieldDescription>
-              <FieldError errors={[fieldState.error]} />
-            </Field>
-          )}
-        />
-      </FieldGroup>
-    </FieldSet>
+          <Controller
+            control={props.control}
+            name={`certifications.${props.index}.url`}
+            render={({ field, fieldState }) => (
+              <Field>
+                <FieldLabel htmlFor={field.name}>{t("url")}</FieldLabel>
+                <UrlInput
+                  id={field.name}
+                  value={field.value}
+                  placeholder={t("urlPlaceholder")}
+                  onChange={field.onChange}
+                  onBlur={field.onBlur}
+                />
+                <FieldDescription>{t("urlDesc")}</FieldDescription>
+                <FieldError errors={[fieldState.error]} />
+              </Field>
+            )}
+          />
+        </FieldGroup>
+      </FieldSet>
+    </SortableItem>
   );
 }

--- a/src/components/editor/editor-sections/ed-section-certifications/ed-section-certifications-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-certifications/ed-section-certifications-form.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { useEffect } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
 import { EmptyState } from "@/components/shared/empty-state";
+import { SortableList } from "@/components/shared/sortable-list";
 import { Button } from "@/components/ui/button";
 import {
   FieldDescription,
@@ -34,7 +35,7 @@ export function EditorSectionCertificationsForm() {
   const form = useForm<CertificationsFormValues>({
     defaultValues: open ? toCertificationsValues(open) : { certifications: [] },
   });
-  const { fields, prepend, remove } = useFieldArray({
+  const { fields, prepend, remove, move } = useFieldArray({
     control: form.control,
     name: "certifications",
   });
@@ -45,6 +46,11 @@ export function EditorSectionCertificationsForm() {
     });
     return () => subscription.unsubscribe();
   }, [form, updateOpen]);
+
+  function handleReorder(from: number, to: number) {
+    move(from, to);
+    updateOpen((draft) => applyCertificationsValues(draft, form.getValues()));
+  }
 
   if (!open) return null;
 
@@ -72,16 +78,23 @@ export function EditorSectionCertificationsForm() {
             description={t("emptyDescription")}
           />
         ) : (
-          <FieldGroup className="gap-4">
-            {fields.map((field, index) => (
-              <EditorSectionCertificationsFormItem
-                key={field.id}
-                control={form.control}
-                index={index}
-                onRemoveField={remove}
-              />
-            ))}
-          </FieldGroup>
+          <SortableList
+            items={fields.map((field) => field.id)}
+            onReorder={handleReorder}
+          >
+            <FieldGroup className="gap-4">
+              {fields.map((field, index) => (
+                <EditorSectionCertificationsFormItem
+                  key={field.id}
+                  id={field.id}
+                  control={form.control}
+                  index={index}
+                  isLast={index === fields.length - 1}
+                  onRemoveField={remove}
+                />
+              ))}
+            </FieldGroup>
+          </SortableList>
         )}
       </FieldSet>
     </form>

--- a/src/components/shared/sortable-list.tsx
+++ b/src/components/shared/sortable-list.tsx
@@ -74,6 +74,18 @@ export function SortableList(props: SortableListProps) {
 interface SortableItemProps {
   id: string;
   handleLabel: string;
+  /**
+   * Cross-axis alignment of the handle against the row. "center" (default)
+   * suits a compact single-line row; "start" top-aligns for a multi-field
+   * card, where the handle should sit on the first field rather than the
+   * card's vertical middle.
+   */
+  align?: "center" | "start";
+  /**
+   * Extra classes for the handle, e.g. a top margin that drops it onto a
+   * field's input when a label sits above it. Wins over the default via twMerge.
+   */
+  handleClassName?: string;
   children: ReactNode;
 }
 
@@ -87,18 +99,25 @@ export function SortableItem(props: SortableItemProps) {
     isDragging,
   } = useSortable({ id: props.id });
 
+  const align = props.align ?? "center";
+
   return (
     <div
       ref={setNodeRef}
       style={{ transform: CSS.Transform.toString(transform), transition }}
       className={cn(
-        "flex items-start gap-2 md:items-center",
+        "flex items-start gap-2",
+        align === "center" && "md:items-center",
         isDragging && "relative z-10 opacity-60",
       )}
     >
       <button
         type="button"
-        className="mt-1.5 flex size-8 shrink-0 touch-none items-center justify-center rounded-md text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring md:mt-0 cursor-grab active:cursor-grabbing"
+        className={cn(
+          "mt-1.5 flex size-8 shrink-0 touch-none items-center justify-center rounded-md text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring cursor-grab active:cursor-grabbing",
+          align === "center" && "md:mt-0",
+          props.handleClassName,
+        )}
         aria-label={props.handleLabel}
         {...attributes}
         {...listeners}


### PR DESCRIPTION
Certifications can now be reordered by drag and drop, bringing the section in line with skills and languages. Each card gets a grip handle that reorders through the same `SortableList` the other sections use; the drag updates ordering metadata only, so the underlying entry content and schema are untouched.

Because a certification is a multi-field card rather than a single-line row, `SortableItem` gained an `align` option (top-align the handle instead of centering it against the whole card) and a `handleClassName` seam. The certification handle uses these to sit on the Name input row, level with its delete button. Skills and languages keep their existing centered handle via the defaults.

Testing: created a résumé, added several certifications, and confirmed dragging reorders them and the new order persists. Verified the handle lines up with the Name input on each card.