### PR TITLE
feat: add proficiency toggles and language column layout

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -566,7 +566,8 @@
       "columnsOne": "1",
       "columnsOneAria": "One column",
       "columnsTwo": "2",
-      "columnsTwoAria": "Two columns"
+      "columnsTwoAria": "Two columns",
+      "proficiencyLabel": "Show proficiency"
     },
     "languages": {
       "accordionTitle": "Languages",
@@ -577,6 +578,12 @@
       "emptyDescription": "Add the languages you speak and your proficiency.",
       "namePlaceholder": "English",
       "proficiency": "Proficiency",
+      "proficiencyLabel": "Show proficiency",
+      "columnsLabel": "Columns",
+      "columnsOne": "1",
+      "columnsOneAria": "One column",
+      "columnsTwo": "2",
+      "columnsTwoAria": "Two columns",
       "reorder": "Reorder language",
       "remove": "Remove language"
     },

--- a/messages/id.json
+++ b/messages/id.json
@@ -566,7 +566,8 @@
       "columnsOne": "1",
       "columnsOneAria": "Satu kolom",
       "columnsTwo": "2",
-      "columnsTwoAria": "Dua kolom"
+      "columnsTwoAria": "Dua kolom",
+      "proficiencyLabel": "Tampilkan tingkat"
     },
     "languages": {
       "accordionTitle": "Bahasa",
@@ -577,6 +578,12 @@
       "emptyDescription": "Tambahin bahasa yang kamu kuasai dan tingkatnya.",
       "namePlaceholder": "English",
       "proficiency": "Tingkat",
+      "proficiencyLabel": "Tampilkan tingkat",
+      "columnsLabel": "Kolom",
+      "columnsOne": "1",
+      "columnsOneAria": "Satu kolom",
+      "columnsTwo": "2",
+      "columnsTwoAria": "Dua kolom",
       "reorder": "Ubah urutan bahasa",
       "remove": "Hapus bahasa"
     },

--- a/src/components/editor/editor-sections/ed-section-languages/ed-section-languages-form-item.tsx
+++ b/src/components/editor/editor-sections/ed-section-languages/ed-section-languages-form-item.tsx
@@ -25,6 +25,7 @@ const LANGUAGE_LEVELS = [
 interface EditorSectionLanguagesFormItemProps {
   id: string;
   index: number;
+  showProficiency: boolean;
   control: Control<LanguagesFormValues>;
   onRemoveField: (index: number) => void;
 }
@@ -37,7 +38,10 @@ export function EditorSectionLanguagesFormItem(
   return (
     <SortableItem id={props.id} handleLabel={t("reorder")}>
       <div className="flex flex-col md:flex-row md:items-center gap-2">
-        <div className="flex items-center gap-2">
+        <div
+          data-proficiency={props.showProficiency}
+          className="flex items-center gap-2 flex-1"
+        >
           <Controller
             control={props.control}
             name={`languages.${props.index}.name`}
@@ -65,27 +69,29 @@ export function EditorSectionLanguagesFormItem(
           </Button>
         </div>
 
-        <Controller
-          control={props.control}
-          name={`languages.${props.index}.level`}
-          render={({ field }) => (
-            <Select
-              value={field.value || null}
-              onValueChange={(value) => field.onChange(value)}
-            >
-              <SelectTrigger className="w-[87.888%] md:w-40">
-                <SelectValue placeholder={t("proficiency")} />
-              </SelectTrigger>
-              <SelectContent>
-                {LANGUAGE_LEVELS.map((level) => (
-                  <SelectItem key={level} value={level}>
-                    {level}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          )}
-        />
+        {props.showProficiency && (
+          <Controller
+            control={props.control}
+            name={`languages.${props.index}.level`}
+            render={({ field }) => (
+              <Select
+                value={field.value || null}
+                onValueChange={(value) => field.onChange(value)}
+              >
+                <SelectTrigger className="w-[87.888%] md:w-40">
+                  <SelectValue placeholder={t("proficiency")} />
+                </SelectTrigger>
+                <SelectContent>
+                  {LANGUAGE_LEVELS.map((level) => (
+                    <SelectItem key={level} value={level}>
+                      {level}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+          />
+        )}
 
         <Button
           type="button"

--- a/src/components/editor/editor-sections/ed-section-languages/ed-section-languages-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-languages/ed-section-languages-form.tsx
@@ -21,6 +21,8 @@ import {
   toLanguagesValues,
 } from "../resume-form-adapter";
 import { EditorSectionLanguagesFormItem } from "./ed-section-languages-form-item";
+import { LanguagesColumnsToggle } from "./languages-columns-toggle";
+import { LanguagesProficiencyToggle } from "./languages-proficiency-toggle";
 
 function emptyLanguage(): LanguageItemValues {
   return { name: "", level: "" };
@@ -29,6 +31,8 @@ function emptyLanguage(): LanguageItemValues {
 export function EditorSectionLanguagesForm() {
   const open = useResumeStore((state) => state.open);
   const updateOpen = useResumeStore((state) => state.updateOpen);
+  const showProficiency =
+    open?.sections.find((s) => s.type === "languages")?.showProficiency ?? true;
   const t = useTranslations("editor.languages");
   const tc = useTranslations("editor.common");
 
@@ -78,22 +82,27 @@ export function EditorSectionLanguagesForm() {
             description={t("emptyDescription")}
           />
         ) : (
-          <SortableList
-            items={fields.map((field) => field.id)}
-            onReorder={handleReorder}
-          >
-            <FieldGroup className="gap-2">
-              {fields.map((field, index) => (
-                <EditorSectionLanguagesFormItem
-                  key={field.id}
-                  id={field.id}
-                  control={form.control}
-                  index={index}
-                  onRemoveField={remove}
-                />
-              ))}
-            </FieldGroup>
-          </SortableList>
+          <>
+            <LanguagesColumnsToggle />
+            <LanguagesProficiencyToggle />
+            <SortableList
+              items={fields.map((field) => field.id)}
+              onReorder={handleReorder}
+            >
+              <FieldGroup className="gap-2">
+                {fields.map((field, index) => (
+                  <EditorSectionLanguagesFormItem
+                    key={field.id}
+                    id={field.id}
+                    control={form.control}
+                    index={index}
+                    showProficiency={showProficiency}
+                    onRemoveField={remove}
+                  />
+                ))}
+              </FieldGroup>
+            </SortableList>
+          </>
         )}
       </FieldSet>
     </form>

--- a/src/components/editor/editor-sections/ed-section-languages/languages-columns-toggle.tsx
+++ b/src/components/editor/editor-sections/ed-section-languages/languages-columns-toggle.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { SegmentedControl } from "@/components/shared/segmented-control";
+import type { SectionColumns } from "@/lib/resume/types";
+import { useResumeStore } from "@/lib/store";
+
+export function LanguagesColumnsToggle() {
+  const columns = useResumeStore(
+    (state) =>
+      state.open?.sections.find((s) => s.type === "languages")?.columns ?? 2,
+  );
+  const updateOpen = useResumeStore((state) => state.updateOpen);
+  const t = useTranslations("editor.languages");
+
+  function handleChange(value: string) {
+    const next: SectionColumns = value === "1" ? 1 : 2;
+    updateOpen((draft) => {
+      const section = draft.sections.find((s) => s.type === "languages");
+      if (section) section.columns = next;
+    });
+  }
+
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-sm text-muted-foreground">{t("columnsLabel")}</span>
+      <SegmentedControl
+        aria-label={t("columnsLabel")}
+        value={String(columns)}
+        onValueChange={handleChange}
+        items={[
+          {
+            value: "1",
+            label: t("columnsOne"),
+            ariaLabel: t("columnsOneAria"),
+          },
+          {
+            value: "2",
+            label: t("columnsTwo"),
+            ariaLabel: t("columnsTwoAria"),
+          },
+        ]}
+      />
+    </div>
+  );
+}

--- a/src/components/editor/editor-sections/ed-section-languages/languages-proficiency-toggle.tsx
+++ b/src/components/editor/editor-sections/ed-section-languages/languages-proficiency-toggle.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Switch } from "@/components/ui/switch";
+import { useResumeStore } from "@/lib/store";
+
+export function LanguagesProficiencyToggle() {
+  const showProficiency = useResumeStore(
+    (state) =>
+      state.open?.sections.find((s) => s.type === "languages")
+        ?.showProficiency ?? true,
+  );
+  const updateOpen = useResumeStore((state) => state.updateOpen);
+  const t = useTranslations("editor.languages");
+
+  function handleChange(next: boolean) {
+    updateOpen((draft) => {
+      const section = draft.sections.find((s) => s.type === "languages");
+      if (section) section.showProficiency = next;
+    });
+  }
+
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span
+        id="languages-proficiency-label"
+        className="text-sm text-muted-foreground"
+      >
+        {t("proficiencyLabel")}
+      </span>
+      <Switch
+        aria-labelledby="languages-proficiency-label"
+        checked={showProficiency}
+        onCheckedChange={handleChange}
+      />
+    </div>
+  );
+}

--- a/src/components/editor/editor-sections/ed-section-skills/ed-section-skills-form-item.tsx
+++ b/src/components/editor/editor-sections/ed-section-skills/ed-section-skills-form-item.tsx
@@ -24,6 +24,7 @@ const PROFICIENCY_LEVELS = [
 interface EditorSectionSkillsFormItemProps {
   id: string;
   index: number;
+  showProficiency: boolean;
   control: Control<SkillsFormValues>;
   onRemoveField: (index: number) => void;
 }
@@ -36,7 +37,10 @@ export function EditorSectionSkillsFormItem(
   return (
     <SortableItem id={props.id} handleLabel={t("reorder")}>
       <div className="flex flex-col md:flex-row md:items-center gap-2">
-        <div className="flex items-center gap-2">
+        <div
+          data-proficiency={props.showProficiency}
+          className="flex items-center gap-2 flex-1"
+        >
           <Controller
             control={props.control}
             name={`skills.${props.index}.name`}
@@ -64,27 +68,29 @@ export function EditorSectionSkillsFormItem(
           </Button>
         </div>
 
-        <Controller
-          control={props.control}
-          name={`skills.${props.index}.level`}
-          render={({ field }) => (
-            <Select
-              value={field.value || null}
-              onValueChange={(value) => field.onChange(value)}
-            >
-              <SelectTrigger className="w-[87.888%] md:w-36">
-                <SelectValue placeholder={t("proficiency")} />
-              </SelectTrigger>
-              <SelectContent>
-                {PROFICIENCY_LEVELS.map((level) => (
-                  <SelectItem key={level} value={level}>
-                    {level}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          )}
-        />
+        {props.showProficiency && (
+          <Controller
+            control={props.control}
+            name={`skills.${props.index}.level`}
+            render={({ field }) => (
+              <Select
+                value={field.value || null}
+                onValueChange={(value) => field.onChange(value)}
+              >
+                <SelectTrigger className="w-[87.888%] md:w-36">
+                  <SelectValue placeholder={t("proficiency")} />
+                </SelectTrigger>
+                <SelectContent>
+                  {PROFICIENCY_LEVELS.map((level) => (
+                    <SelectItem key={level} value={level}>
+                      {level}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+          />
+        )}
 
         <Button
           type="button"

--- a/src/components/editor/editor-sections/ed-section-skills/ed-section-skills-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-skills/ed-section-skills-form.tsx
@@ -22,6 +22,7 @@ import {
 } from "../resume-form-adapter";
 import { EditorSectionSkillsFormItem } from "./ed-section-skills-form-item";
 import { SkillsColumnsToggle } from "./skills-columns-toggle";
+import { SkillsProficiencyToggle } from "./skills-proficiency-toggle";
 
 function emptySkill(): SkillItemValues {
   return { name: "", level: "" };
@@ -30,6 +31,8 @@ function emptySkill(): SkillItemValues {
 export function EditorSectionSkillsForm() {
   const open = useResumeStore((state) => state.open);
   const updateOpen = useResumeStore((state) => state.updateOpen);
+  const showProficiency =
+    open?.sections.find((s) => s.type === "skills")?.showProficiency ?? true;
   const t = useTranslations("editor.skills");
   const tc = useTranslations("editor.common");
 
@@ -79,6 +82,7 @@ export function EditorSectionSkillsForm() {
         ) : (
           <>
             <SkillsColumnsToggle />
+            <SkillsProficiencyToggle />
             <SortableList
               items={fields.map((field) => field.id)}
               onReorder={handleReorder}
@@ -90,6 +94,7 @@ export function EditorSectionSkillsForm() {
                     id={field.id}
                     control={form.control}
                     index={index}
+                    showProficiency={showProficiency}
                     onRemoveField={remove}
                   />
                 ))}

--- a/src/components/editor/editor-sections/ed-section-skills/skills-proficiency-toggle.tsx
+++ b/src/components/editor/editor-sections/ed-section-skills/skills-proficiency-toggle.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Switch } from "@/components/ui/switch";
+import { useResumeStore } from "@/lib/store";
+
+export function SkillsProficiencyToggle() {
+  const showProficiency = useResumeStore(
+    (state) =>
+      state.open?.sections.find((s) => s.type === "skills")?.showProficiency ??
+      true,
+  );
+  const updateOpen = useResumeStore((state) => state.updateOpen);
+  const t = useTranslations("editor.skills");
+
+  function handleChange(next: boolean) {
+    updateOpen((draft) => {
+      const section = draft.sections.find((s) => s.type === "skills");
+      if (section) section.showProficiency = next;
+    });
+  }
+
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span
+        id="skills-proficiency-label"
+        className="text-sm text-muted-foreground"
+      >
+        {t("proficiencyLabel")}
+      </span>
+      <Switch
+        aria-labelledby="skills-proficiency-label"
+        checked={showProficiency}
+        onCheckedChange={handleChange}
+      />
+    </div>
+  );
+}

--- a/src/components/editor/editor-sidebar-content.tsx
+++ b/src/components/editor/editor-sidebar-content.tsx
@@ -16,7 +16,7 @@ const TABS = [
   { value: "document", labelKey: "tabDocument", id: "tour-document-tab" },
 ];
 
-const PANEL_HEIGHT = "h-[calc(100vh-7rem)] xl:h-[calc(100vh-10.25rem)]";
+const PANEL_HEIGHT = "h-[calc(100vh-7rem)] xl:h-[calc(100vh-7.625rem)]";
 
 export function EditorSidebarContent() {
   const t = useTranslations("editor.chrome");

--- a/src/components/editor/editor-sidebar.tsx
+++ b/src/components/editor/editor-sidebar.tsx
@@ -10,7 +10,7 @@ export function EditorSidebar() {
   return (
     <ResizablePanel
       defaultSize={open ? "36%" : "38%"}
-      minSize={open ? "28%" : "30%"}
+      minSize={open ? "36%" : "32%"}
       maxSize="40%"
       style={{ maxHeight: "auto", height: "auto", overflow: "hidden" }}
     >

--- a/src/components/editor/pdf/awal-pdf-document.tsx
+++ b/src/components/editor/pdf/awal-pdf-document.tsx
@@ -168,7 +168,7 @@ function PdfBlock(props: { block: ResumeBlock }) {
     case "skills":
       return <PdfGrid items={block.items} columns={block.columns} />;
     case "languages":
-      return <PdfGrid items={block.items} />;
+      return <PdfGrid items={block.items} columns={block.columns} />;
   }
 }
 

--- a/src/components/editor/pdf/ketat-pdf-document.tsx
+++ b/src/components/editor/pdf/ketat-pdf-document.tsx
@@ -191,7 +191,7 @@ function KetatBlock(props: { block: ResumeBlock }) {
     case "skills":
       return <PdfGrid items={block.items} columns={block.columns} />;
     case "languages":
-      return <PdfGrid items={block.items} />;
+      return <PdfGrid items={block.items} columns={block.columns} />;
   }
 }
 

--- a/src/components/editor/pdf/ketik-pdf-document.tsx
+++ b/src/components/editor/pdf/ketik-pdf-document.tsx
@@ -184,7 +184,7 @@ function KetikBlock(props: { block: ResumeBlock }) {
     case "skills":
       return <PdfGrid items={block.items} columns={block.columns} />;
     case "languages":
-      return <PdfGrid items={block.items} />;
+      return <PdfGrid items={block.items} columns={block.columns} />;
   }
 }
 

--- a/src/components/editor/pdf/klasik-pdf-document.tsx
+++ b/src/components/editor/pdf/klasik-pdf-document.tsx
@@ -184,7 +184,7 @@ function KlasikBlock(props: { block: ResumeBlock }) {
     case "skills":
       return <PdfGrid items={block.items} columns={block.columns} />;
     case "languages":
-      return <PdfGrid items={block.items} />;
+      return <PdfGrid items={block.items} columns={block.columns} />;
   }
 }
 

--- a/src/components/editor/pdf/luasa-pdf-document.tsx
+++ b/src/components/editor/pdf/luasa-pdf-document.tsx
@@ -186,7 +186,7 @@ function LuasaBlock(props: { block: ResumeBlock }) {
     case "skills":
       return <PdfGrid items={block.items} columns={block.columns} />;
     case "languages":
-      return <PdfGrid items={block.items} />;
+      return <PdfGrid items={block.items} columns={block.columns} />;
   }
 }
 

--- a/src/components/editor/pdf/tebal-pdf-document.tsx
+++ b/src/components/editor/pdf/tebal-pdf-document.tsx
@@ -180,7 +180,7 @@ function TebalBlock(props: { block: ResumeBlock }) {
     case "skills":
       return <PdfGrid items={block.items} columns={block.columns} />;
     case "languages":
-      return <PdfGrid items={block.items} />;
+      return <PdfGrid items={block.items} columns={block.columns} />;
   }
 }
 

--- a/src/components/editor/resume-block-view.tsx
+++ b/src/components/editor/resume-block-view.tsx
@@ -30,6 +30,8 @@ export function ResumeBlockView(props: ResumeBlockViewProps) {
     case "skills":
       return <ResumeSkillsList items={block.items} columns={block.columns} />;
     case "languages":
-      return <ResumeLanguagesList items={block.items} />;
+      return (
+        <ResumeLanguagesList items={block.items} columns={block.columns} />
+      );
   }
 }

--- a/src/components/editor/resume-blocks.ts
+++ b/src/components/editor/resume-blocks.ts
@@ -39,7 +39,7 @@ export type ResumeBlock = BlockMeta &
     | { kind: "education"; item: EducationItemView }
     | { kind: "certificate"; item: CertificateItemView }
     | { kind: "skills"; items: SkillItemView[]; columns: SectionColumns }
-    | { kind: "languages"; items: LanguageItemView[] }
+    | { kind: "languages"; items: LanguageItemView[]; columns: SectionColumns }
   );
 
 const GAP = {
@@ -175,6 +175,7 @@ function skillsBlocks(
 
 function languagesBlocks(
   items: LanguageItemView[],
+  columns: SectionColumns,
   label: string,
 ): ResumeBlock[] {
   const filtered = items.filter(hasLanguage);
@@ -185,6 +186,7 @@ function languagesBlocks(
       id: "languages-body",
       kind: "languages",
       items: filtered,
+      columns,
       gapBefore: GAP.body,
       keepWithNext: false,
     },
@@ -286,7 +288,12 @@ export function buildResumeBlocks(resume: ResumePreview): ResumeBlock[] {
       certificateBlocks(resume.certificates, labels.certificates),
     skills: () =>
       skillsBlocks(resume.skills, resume.skillsColumns, labels.skills),
-    languages: () => languagesBlocks(resume.languages, labels.languages),
+    languages: () =>
+      languagesBlocks(
+        resume.languages,
+        resume.languagesColumns,
+        labels.languages,
+      ),
   };
 
   const customById = new Map(

--- a/src/components/editor/resume-languages-list.tsx
+++ b/src/components/editor/resume-languages-list.tsx
@@ -1,13 +1,21 @@
+import type { SectionColumns } from "@/lib/resume/types";
+import { cn } from "@/lib/utils";
 import { ResumeLanguageItem } from "./resume-language-item";
 import type { LanguageItemView } from "./resume-preview";
 
 interface ResumeLanguagesListProps {
   items: LanguageItemView[];
+  columns: SectionColumns;
 }
 
 export function ResumeLanguagesList(props: ResumeLanguagesListProps) {
   return (
-    <ul className="grid grid-cols-2 gap-x-8 gap-y-1">
+    <ul
+      className={cn(
+        "grid gap-x-8 gap-y-1",
+        props.columns === 1 ? "grid-cols-1" : "grid-cols-2",
+      )}
+    >
       {props.items.map((item) => (
         <ResumeLanguageItem key={item.id} {...item} />
       ))}

--- a/src/components/editor/resume-preview.ts
+++ b/src/components/editor/resume-preview.ts
@@ -136,4 +136,6 @@ export interface ResumePreview {
   /** Presentation-only column count for the skills grid; defaults to two. */
   skillsColumns: SectionColumns;
   languages: LanguageItemView[];
+  /** Presentation-only column count for the languages grid; defaults to two. */
+  languagesColumns: SectionColumns;
 }

--- a/src/components/editor/resume-to-preview.ts
+++ b/src/components/editor/resume-to-preview.ts
@@ -148,6 +148,11 @@ export function resumeToPreview(resume: Resume): ResumePreview {
       };
     });
 
+  const skillsShowProficiency =
+    sectionOfType(resume, "skills")?.showProficiency ?? true;
+  const languagesShowProficiency =
+    sectionOfType(resume, "languages")?.showProficiency ?? true;
+
   return {
     language: resume.language,
     sectionOrder,
@@ -234,18 +239,22 @@ export function resumeToPreview(resume: Resume): ResumePreview {
         };
       },
     ),
+    // Hiding proficiency is presentation-only: blank it here, the single view
+    // chokepoint, so every downstream renderer (preview, PDF, docx, plain text)
+    // drops it without threading a flag through each one.
     skills: (sectionOfType(resume, "skills")?.entries ?? []).map((entry) => ({
       id: entry.id,
       name: plain(entry.fields.name),
-      proficiency: plain(entry.fields.level),
+      proficiency: skillsShowProficiency ? plain(entry.fields.level) : "",
     })),
     skillsColumns: sectionOfType(resume, "skills")?.columns ?? 2,
     languages: (sectionOfType(resume, "languages")?.entries ?? []).map(
       (entry) => ({
         id: entry.id,
         name: plain(entry.fields.name),
-        proficiency: plain(entry.fields.level),
+        proficiency: languagesShowProficiency ? plain(entry.fields.level) : "",
       }),
     ),
+    languagesColumns: sectionOfType(resume, "languages")?.columns ?? 2,
   };
 }

--- a/src/components/editor/templates/ketat/ketat-block-view.tsx
+++ b/src/components/editor/templates/ketat/ketat-block-view.tsx
@@ -31,6 +31,8 @@ export function KetatBlockView(props: KetatBlockViewProps) {
     case "skills":
       return <ResumeSkillsList items={block.items} columns={block.columns} />;
     case "languages":
-      return <ResumeLanguagesList items={block.items} />;
+      return (
+        <ResumeLanguagesList items={block.items} columns={block.columns} />
+      );
   }
 }

--- a/src/components/editor/templates/ketik/ketik-block-view.tsx
+++ b/src/components/editor/templates/ketik/ketik-block-view.tsx
@@ -31,6 +31,8 @@ export function KetikBlockView(props: KetikBlockViewProps) {
     case "skills":
       return <ResumeSkillsList items={block.items} columns={block.columns} />;
     case "languages":
-      return <ResumeLanguagesList items={block.items} />;
+      return (
+        <ResumeLanguagesList items={block.items} columns={block.columns} />
+      );
   }
 }

--- a/src/components/editor/templates/klasik/klasik-block-view.tsx
+++ b/src/components/editor/templates/klasik/klasik-block-view.tsx
@@ -37,7 +37,7 @@ export function KlasikBlockView(props: KlasikBlockViewProps) {
     case "languages":
       return (
         <div className="font-serif">
-          <ResumeLanguagesList items={block.items} />
+          <ResumeLanguagesList items={block.items} columns={block.columns} />
         </div>
       );
   }

--- a/src/components/editor/templates/luasa/luasa-block-view.tsx
+++ b/src/components/editor/templates/luasa/luasa-block-view.tsx
@@ -31,6 +31,8 @@ export function LuasaBlockView(props: LuasaBlockViewProps) {
     case "skills":
       return <ResumeSkillsList items={block.items} columns={block.columns} />;
     case "languages":
-      return <ResumeLanguagesList items={block.items} />;
+      return (
+        <ResumeLanguagesList items={block.items} columns={block.columns} />
+      );
   }
 }

--- a/src/components/editor/templates/tebal/tebal-block-view.tsx
+++ b/src/components/editor/templates/tebal/tebal-block-view.tsx
@@ -31,6 +31,8 @@ export function TebalBlockView(props: TebalBlockViewProps) {
     case "skills":
       return <ResumeSkillsList items={block.items} columns={block.columns} />;
     case "languages":
-      return <ResumeLanguagesList items={block.items} />;
+      return (
+        <ResumeLanguagesList items={block.items} columns={block.columns} />
+      );
   }
 }

--- a/src/lib/resume/factory.ts
+++ b/src/lib/resume/factory.ts
@@ -55,8 +55,18 @@ export function createEmptySection(type: SectionType): Section {
     title: schema.defaultTitle,
     entries: [],
   };
-  // The Skills grid is column-toggleable; new sections start two-column.
-  if (type === "skills") section.columns = 2;
+  // The Skills grid is column-toggleable; new sections start two-column and
+  // show per-skill proficiency until the user hides it.
+  if (type === "skills") {
+    section.columns = 2;
+    section.showProficiency = true;
+  }
+  // Languages share the Skills grid controls: column-toggleable and proficiency
+  // shown until the user hides it. New sections start two-column.
+  if (type === "languages") {
+    section.columns = 2;
+    section.showProficiency = true;
+  }
   return section;
 }
 

--- a/src/lib/resume/migrations.ts
+++ b/src/lib/resume/migrations.ts
@@ -444,6 +444,48 @@ const migrateV11toV12: Migration = (doc) => {
 };
 
 /**
+ * v12→v13: adds the presentation-only `showProficiency` toggle to the Skills and
+ * Languages sections so per-entry levels can be hidden. Existing documents default
+ * to true, preserving their current output. Bail-safe: a missing section is a
+ * no-op, and a section already carrying the flag is left as-is.
+ */
+const migrateV12toV13: Migration = (doc) => {
+  const next = structuredClone(doc);
+  const sections = Array.isArray(next.sections)
+    ? (next.sections as Array<Record<string, unknown>>)
+    : [];
+
+  for (const section of sections) {
+    if (section.type !== "skills" && section.type !== "languages") continue;
+    if (typeof section.showProficiency !== "boolean") {
+      section.showProficiency = true;
+    }
+  }
+
+  return next;
+};
+
+/**
+ * v13→v14: adds the presentation-only `columns` count to the Languages section so
+ * its grid can be toggled between one and two columns, matching Skills. Existing
+ * documents default to two, preserving their current layout. Bail-safe: no
+ * Languages section means no-op.
+ */
+const migrateV13toV14: Migration = (doc) => {
+  const next = structuredClone(doc);
+  const sections = Array.isArray(next.sections)
+    ? (next.sections as Array<Record<string, unknown>>)
+    : [];
+
+  const languages = sections.find((s) => s.type === "languages");
+  if (languages && languages.columns !== 1 && languages.columns !== 2) {
+    languages.columns = 2;
+  }
+
+  return next;
+};
+
+/**
  * The migration ladder. Each key N is a forward-only step from version N to N+1.
  */
 const LADDER: Record<number, Migration> = {
@@ -458,6 +500,8 @@ const LADDER: Record<number, Migration> = {
   9: migrateV9toV10,
   10: migrateV10toV11,
   11: migrateV11toV12,
+  12: migrateV12toV13,
+  13: migrateV13toV14,
 };
 
 /** The persisted schemaVersion of a raw document; 0 when absent or malformed. */

--- a/src/lib/resume/seed.ts
+++ b/src/lib/resume/seed.ts
@@ -425,6 +425,7 @@ export const SEED_RESUME: Resume = {
       type: "skills",
       title: "Skills",
       columns: 2,
+      showProficiency: true,
       entries: [
         {
           id: "seed-skills-1",
@@ -490,6 +491,8 @@ export const SEED_RESUME: Resume = {
       id: "seed-languages",
       type: "languages",
       title: "Languages",
+      columns: 2,
+      showProficiency: true,
       entries: [
         {
           id: "seed-languages-1",

--- a/src/lib/resume/types.ts
+++ b/src/lib/resume/types.ts
@@ -5,15 +5,15 @@ import type { JSONContent } from "@tiptap/core";
  * governs object-store/index structure only. Bumped whenever a persisted field
  * shape changes; every bump gets a forward-only step in the migration ladder.
  */
-export const CURRENT_SCHEMA_VERSION = 12;
+export const CURRENT_SCHEMA_VERSION = 14;
 
 /** The language the rendered document's fixed labels (headings, dates) use. */
 export type ResumeLanguage = "en" | "id";
 
 /**
- * Presentation-only column count for grid-rendered sections (skills). Governs the
- * on-screen preview and PDF visual layout only; it never changes reading order,
- * and inherently linear exports (docx, plain text) ignore it.
+ * Presentation-only column count for grid-rendered sections (skills, languages).
+ * Governs the on-screen preview and PDF visual layout only; it never changes
+ * reading order, and inherently linear exports (docx, plain text) ignore it.
  */
 export type SectionColumns = 1 | 2;
 
@@ -74,10 +74,16 @@ export interface Section {
   title: string;
   entries: Entry[];
   /**
-   * Presentation-only column count for grid-rendered sections (skills). Absent on
-   * non-grid sections; renderers default to a two-column grid when unset.
+   * Presentation-only column count for grid-rendered sections (skills, languages).
+   * Absent on non-grid sections; renderers default to a two-column grid when unset.
    */
   columns?: SectionColumns;
+  /**
+   * Presentation-only toggle for the Skills and Languages sections: when false,
+   * per-entry proficiency is hidden from the preview and every export. Absent on
+   * other sections; renderers treat an unset value as `true` (proficiency shown).
+   */
+  showProficiency?: boolean;
   /**
    * Presentation variant for `custom` Sections only: `rich` (a single rich-text
    * body) or `list` (repeatable entries). Absent on core Sections; the custom


### PR DESCRIPTION
Adds presentation-only controls to the Skills and Languages sections, both governed by the existing two-layer split (they change how the grid renders, never the linear content or export order).

Skills and Languages each get a "Show proficiency" toggle. When off, per-entry proficiency is hidden from the editor form (the level select drops out and the name input expands to fill the row) and from every rendered output. The document/export side is gated at a single view-model chokepoint in resume-to-preview, so the preview, all templates, every PDF, docx, and plain text drop it without threading a flag through each renderer.

Languages also gains the one/two column layout control that Skills already has, threaded through the languages block, list renderer, all five template block-views, and all six PDF documents. Linear exports (docx, plain text) ignore column count by design.

Persistence: three presentation fields join the document shape behind schemaVersion bumps and forward-only, bail-safe migration rungs, all defaulting to current behavior (proficiency shown, two columns). v12 to v13 backfills showProficiency on both sections; v13 to v14 backfills the languages column count. Factory and seed set the same defaults for new documents. The editor sidebar sizing was nudged to fit the extra control rows.

Testing: verified in the editor that each toggle hides the proficiency field in both the form and the preview and that the choice survives a reload; confirmed the languages column control switches the preview grid between one and two columns; confirmed toggling proficiency back on restores the field with its value intact.