### PR TITLE
feat: undo résumé deletion with a countdown toast

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -290,6 +290,7 @@
       "cancel": "Cancel",
       "save": "Save",
       "delete": "Delete",
+      "undo": "Undo",
       "download": "Download",
       "openIssue": "Open GitHub issue"
     },
@@ -323,7 +324,8 @@
     },
     "delete": {
       "title": "Delete <b>{title}</b>?",
-      "description": "This will delete <b>{title}</b>. <b>This action cannot be undone</b>. Are you sure?"
+      "description": "This will delete <b>{title}</b>. You'll have a few seconds to undo. Are you sure?",
+      "toast": "Deleting \"{title}\"..."
     },
     "download": {
       "title": "Download {title}",

--- a/messages/id.json
+++ b/messages/id.json
@@ -290,6 +290,7 @@
       "cancel": "Batal",
       "save": "Simpan",
       "delete": "Hapus",
+      "undo": "Urungkan",
       "download": "Unduh",
       "openIssue": "Buka isu GitHub"
     },
@@ -323,7 +324,8 @@
     },
     "delete": {
       "title": "Hapus <b>{title}</b>?",
-      "description": "Ini bakal ngehapus <b>{title}</b>. <b>Nggak bisa dibatalin</b>. Yakin?"
+      "description": "Ini bakal ngehapus <b>{title}</b>. Kamu punya beberapa detik buat ngebatalin. Yakin?",
+      "toast": "Menghapus \"{title}\"..."
     },
     "download": {
       "title": "Unduh {title}",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -167,3 +167,11 @@
     height: 0;
   }
 }
+
+/* Fit sonner's fixed icon slot to the countdown ring and add a gap. Unlayered on
+   purpose: sonner injects [data-icon] unlayered, which beats any @layer rule. */
+[data-sonner-toast][data-styled="true"].resume-delete-toast [data-icon] {
+  width: auto;
+  height: auto;
+  margin-right: 0.5rem;
+}

--- a/src/components/platform/platform-resume-action-delete.tsx
+++ b/src/components/platform/platform-resume-action-delete.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { useState } from "react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -23,7 +22,7 @@ import {
   DrawerTitle,
 } from "@/components/ui/drawer";
 import { useIsMobile } from "@/hooks/use-mobile";
-import { useResumeStore } from "@/lib/store";
+import { deleteResumeWithUndo } from "./platform-resume-delete-undo";
 
 interface PlatformResumeActionDeleteProps {
   open: boolean;
@@ -35,15 +34,14 @@ export function PlatformResumeActionDelete(
   props: PlatformResumeActionDeleteProps,
 ) {
   const isMobile = useIsMobile();
-  const removeResume = useResumeStore((state) => state.removeResume);
-  const [pending, setPending] = useState(false);
   const t = useTranslations("forms.delete");
   const tc = useTranslations("forms.common");
 
-  async function handleDelete() {
-    setPending(true);
-    await removeResume(props.resume.id);
-    setPending(false);
+  function handleDelete() {
+    deleteResumeWithUndo(props.resume.id, {
+      deleted: t("toast", { title: props.resume.title }),
+      undo: tc("undo"),
+    });
     props.onOpenChange(false);
   }
 
@@ -68,11 +66,7 @@ export function PlatformResumeActionDelete(
           </DrawerHeader>
 
           <DrawerFooter>
-            <Button
-              variant="destructive"
-              onClick={handleDelete}
-              disabled={pending}
-            >
+            <Button variant="destructive" onClick={handleDelete}>
               {tc("delete")}
             </Button>
             <DrawerClose render={<Button variant="outline" />}>
@@ -94,11 +88,7 @@ export function PlatformResumeActionDelete(
 
         <AlertDialogFooter>
           <AlertDialogCancel>{tc("cancel")}</AlertDialogCancel>
-          <AlertDialogAction
-            variant="destructive"
-            onClick={handleDelete}
-            disabled={pending}
-          >
+          <AlertDialogAction variant="destructive" onClick={handleDelete}>
             {tc("delete")}
           </AlertDialogAction>
         </AlertDialogFooter>

--- a/src/components/platform/platform-resume-delete-countdown.tsx
+++ b/src/components/platform/platform-resume-delete-countdown.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const SIZE = 24;
+const STROKE = 2;
+const RADIUS = (SIZE - STROKE) / 2;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+export function ResumeDeleteCountdown(props: { seconds: number }) {
+  const [remaining, setRemaining] = useState(props.seconds);
+  const [offset, setOffset] = useState(0);
+
+  useEffect(() => {
+    const started = Date.now();
+    // next frame so the ring transitions from full to empty
+    const frame = requestAnimationFrame(() => setOffset(CIRCUMFERENCE));
+    const tick = setInterval(() => {
+      const elapsed = Math.floor((Date.now() - started) / 1000);
+      const left = Math.max(0, props.seconds - elapsed);
+      setRemaining(left);
+      if (left <= 0) clearInterval(tick);
+    }, 200);
+    return () => {
+      cancelAnimationFrame(frame);
+      clearInterval(tick);
+    };
+  }, [props.seconds]);
+
+  return (
+    <span
+      className="relative inline-flex shrink-0 items-center justify-center"
+      style={{ width: SIZE, height: SIZE }}
+    >
+      <svg aria-hidden="true" width={SIZE} height={SIZE} className="-rotate-90">
+        <circle
+          cx={SIZE / 2}
+          cy={SIZE / 2}
+          r={RADIUS}
+          fill="none"
+          strokeWidth={STROKE}
+          className="stroke-border"
+        />
+        <circle
+          cx={SIZE / 2}
+          cy={SIZE / 2}
+          r={RADIUS}
+          fill="none"
+          strokeWidth={STROKE}
+          strokeLinecap="round"
+          className="stroke-primary"
+          strokeDasharray={CIRCUMFERENCE}
+          strokeDashoffset={offset}
+          style={{ transition: `stroke-dashoffset ${props.seconds}s linear` }}
+        />
+      </svg>
+      <span className="absolute text-[0.625rem] font-medium tabular-nums">
+        {remaining}
+      </span>
+    </span>
+  );
+}

--- a/src/components/platform/platform-resume-delete-undo.tsx
+++ b/src/components/platform/platform-resume-delete-undo.tsx
@@ -1,0 +1,40 @@
+import { toast } from "sonner";
+import { useResumeStore } from "@/lib/store";
+import { ResumeDeleteCountdown } from "./platform-resume-delete-countdown";
+
+const UNDO_WINDOW_MS = 10_000;
+
+interface UndoMessages {
+  deleted: string;
+  undo: string;
+}
+
+// Runs the timer outside React so it survives the résumé card unmounting when
+// the entry leaves the index.
+export function deleteResumeWithUndo(id: string, messages: UndoMessages) {
+  const store = useResumeStore.getState();
+  const entry = store.detachResume(id);
+  if (!entry) return;
+
+  let settled = false;
+  const timer = setTimeout(() => {
+    if (settled) return;
+    settled = true;
+    void store.removeResume(id);
+  }, UNDO_WINDOW_MS);
+
+  toast(messages.deleted, {
+    duration: UNDO_WINDOW_MS,
+    className: "resume-delete-toast",
+    icon: <ResumeDeleteCountdown seconds={UNDO_WINDOW_MS / 1000} />,
+    action: {
+      label: messages.undo,
+      onClick: () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        store.restoreResume(entry);
+      },
+    },
+  });
+}

--- a/src/components/platform/platform-sidebar-resume-item.tsx
+++ b/src/components/platform/platform-sidebar-resume-item.tsx
@@ -5,7 +5,6 @@ import { useTranslations } from "next-intl";
 import { type MouseEvent, useState } from "react";
 import { Link } from "@/i18n/navigation";
 import type { ResumeIndexEntry } from "@/lib/resume";
-import { Button } from "../ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -15,7 +14,11 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "../ui/dropdown-menu";
-import { SidebarMenuButton, SidebarMenuItem } from "../ui/sidebar";
+import {
+  SidebarMenuAction,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "../ui/sidebar";
 import { PlatformResumeActionDelete } from "./platform-resume-action-delete";
 import { PlatformResumeActionRename } from "./platform-resume-action-rename";
 
@@ -55,49 +58,42 @@ export function PlatformSidebarResumeItem({
       >
         <FileText />
         <span className="truncate">{resume.title}</span>
-
-        <DropdownMenu>
-          <DropdownMenuTrigger
-            onClick={(e) => {
-              e.preventDefault();
-            }}
-            render={
-              <Button size="icon-xs" className="ml-auto" variant="ghost" />
-            }
-          >
-            <span className="sr-only">{t("itemMenu")}</span>
-            <MoreVertical />
-          </DropdownMenuTrigger>
-
-          <DropdownMenuContent align="start" className="w-40">
-            <DropdownMenuGroup>
-              <DropdownMenuLabel className="text-pretty">
-                {t.rich("modify", {
-                  title: resume.title,
-                  b: (chunks) => <strong>{chunks}</strong>,
-                })}
-              </DropdownMenuLabel>
-              <DropdownMenuItem onClick={openRenameDialog}>
-                <Pen />
-                {t("rename")}
-              </DropdownMenuItem>
-
-              {id !== resume.id && (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    variant="destructive"
-                    onClick={openRemoveDialog}
-                  >
-                    <Trash />
-                    {t("delete")}
-                  </DropdownMenuItem>
-                </>
-              )}
-            </DropdownMenuGroup>
-          </DropdownMenuContent>
-        </DropdownMenu>
       </SidebarMenuButton>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger render={<SidebarMenuAction />}>
+          <span className="sr-only">{t("itemMenu")}</span>
+          <MoreVertical />
+        </DropdownMenuTrigger>
+
+        <DropdownMenuContent align="start" className="w-40">
+          <DropdownMenuGroup>
+            <DropdownMenuLabel className="text-pretty">
+              {t.rich("modify", {
+                title: resume.title,
+                b: (chunks) => <strong>{chunks}</strong>,
+              })}
+            </DropdownMenuLabel>
+            <DropdownMenuItem onClick={openRenameDialog}>
+              <Pen />
+              {t("rename")}
+            </DropdownMenuItem>
+
+            {id !== resume.id && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  variant="destructive"
+                  onClick={openRemoveDialog}
+                >
+                  <Trash />
+                  {t("delete")}
+                </DropdownMenuItem>
+              </>
+            )}
+          </DropdownMenuGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
 
       <PlatformResumeActionRename
         key={resume.title}

--- a/src/components/shared/providers.tsx
+++ b/src/components/shared/providers.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from "next-themes";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { type PropsWithChildren, useEffect } from "react";
 import { registerResumeFlushListeners } from "@/lib/store";
+import { Toaster } from "../ui/sonner";
 import { TooltipProvider } from "../ui/tooltip";
 
 export function Providers({ children }: PropsWithChildren) {
@@ -25,6 +26,7 @@ export function Providers({ children }: PropsWithChildren) {
           options={{ showSpinner: false }}
         >
           <TooltipProvider>{children}</TooltipProvider>
+          <Toaster />
         </ProgressProvider>
       </ThemeProvider>
     </NuqsAdapter>

--- a/src/lib/store/resume-store.ts
+++ b/src/lib/store/resume-store.ts
@@ -64,6 +64,10 @@ interface ResumeStoreState {
   renameResume: (id: string, title: string) => Promise<void>;
   duplicateResume: (id: string) => Promise<Resume | undefined>;
   removeResume: (id: string) => Promise<void>;
+  /** Drop a résumé from the index without touching disk; returns it for undo. */
+  detachResume: (id: string) => ResumeIndexEntry | undefined;
+  /** Re-insert a detached index entry, newest-first. */
+  restoreResume: (entry: ResumeIndexEntry) => void;
   openResume: (id: string) => Promise<void>;
   /** Apply an edit to the open document; schedules a debounced persist. */
   updateOpen: (recipe: (draft: Resume) => void) => void;
@@ -200,6 +204,27 @@ export const useResumeStore = create<ResumeStoreState>()((set, get) => ({
         openStatus: isOpen ? "idle" : state.openStatus,
       };
     });
+  },
+
+  detachResume(id) {
+    const entry = get().index.find((item) => item.id === id);
+    if (!entry) return undefined;
+    set((state) => ({
+      index: A.reject(state.index, (item) => item.id === id),
+    }));
+    return entry;
+  },
+
+  restoreResume(entry) {
+    set((state) => ({
+      index: pipe(
+        state.index,
+        A.reject((item) => item.id === entry.id),
+        A.prepend(entry),
+        A.sortBy((item) => item.updatedAt),
+        A.reverse,
+      ),
+    }));
   },
 
   async openResume(id) {


### PR DESCRIPTION
Deleting a résumé now soft-deletes with a grace period instead of removing it outright. Confirming in the existing dialog drops the résumé from the Library immediately and shows a toast with a countdown ring and an Undo action; the actual IndexedDB delete only commits after the 10-second window. Clicking Undo restores the entry and cancels the commit.

The timer and toast are driven outside React (an imperative sonner call plus a plain setTimeout), because the résumé card and its delete dialog unmount the moment the entry leaves the index, so a component-scoped timer would not survive. The store gains two small index-only primitives, detach and restore, with the existing removeResume reused as the disk commit. This is the app's first toast, so the Toaster is now mounted in Providers.

Also fixes an unrelated issue found along the way: opening the menu on a sidebar résumé item kicked off the route progress bar. The menu trigger was a button nested inside the item's Link, so its click bubbled to the anchor; it now renders as a sidebar action sibling, outside the link.

Testing: confirmed delete removes the item and shows the toast, Undo restores it, and letting the window elapse commits the delete so it stays gone after a reload; confirmed the sidebar menu no longer triggers the progress bar.