### PR TITLE
fix: group proficiency options and tidy the sidebar résumé menu

### DIFF
--- a/src/components/editor/editor-sections/ed-section-languages/ed-section-languages-form-item.tsx
+++ b/src/components/editor/editor-sections/ed-section-languages/ed-section-languages-form-item.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
   SelectTrigger,
   SelectValue,
@@ -82,11 +83,13 @@ export function EditorSectionLanguagesFormItem(
                   <SelectValue placeholder={t("proficiency")} />
                 </SelectTrigger>
                 <SelectContent>
-                  {LANGUAGE_LEVELS.map((level) => (
-                    <SelectItem key={level} value={level}>
-                      {level}
-                    </SelectItem>
-                  ))}
+                  <SelectGroup>
+                    {LANGUAGE_LEVELS.map((level) => (
+                      <SelectItem key={level} value={level}>
+                        {level}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
                 </SelectContent>
               </Select>
             )}

--- a/src/components/editor/editor-sections/ed-section-skills/ed-section-skills-form-item.tsx
+++ b/src/components/editor/editor-sections/ed-section-skills/ed-section-skills-form-item.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
   SelectTrigger,
   SelectValue,
@@ -81,11 +82,13 @@ export function EditorSectionSkillsFormItem(
                   <SelectValue placeholder={t("proficiency")} />
                 </SelectTrigger>
                 <SelectContent>
-                  {PROFICIENCY_LEVELS.map((level) => (
-                    <SelectItem key={level} value={level}>
-                      {level}
-                    </SelectItem>
-                  ))}
+                  <SelectGroup>
+                    {PROFICIENCY_LEVELS.map((level) => (
+                      <SelectItem key={level} value={level}>
+                        {level}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
                 </SelectContent>
               </Select>
             )}

--- a/src/components/platform/platform-sidebar-resume-item.tsx
+++ b/src/components/platform/platform-sidebar-resume-item.tsx
@@ -61,14 +61,16 @@ export function PlatformSidebarResumeItem({
       </SidebarMenuButton>
 
       <DropdownMenu>
-        <DropdownMenuTrigger render={<SidebarMenuAction />}>
+        <DropdownMenuTrigger
+          render={<SidebarMenuAction className="right-3.5" />}
+        >
           <span className="sr-only">{t("itemMenu")}</span>
           <MoreVertical />
         </DropdownMenuTrigger>
 
-        <DropdownMenuContent align="start" className="w-40">
+        <DropdownMenuContent align="start">
           <DropdownMenuGroup>
-            <DropdownMenuLabel className="text-pretty">
+            <DropdownMenuLabel className="sr-only">
               {t.rich("modify", {
                 title: resume.title,
                 b: (chunks) => <strong>{chunks}</strong>,


### PR DESCRIPTION
Small refinements to recently shipped UI.

The Skills and Languages proficiency selects now wrap their options in a SelectGroup, so the dropdown exposes proper listbox grouping semantics.

The sidebar résumé item's menu is tidied: the action trigger is nudged to line up (right-3.5), the dropdown takes its natural width instead of a fixed one, and the redundant "Modify …" heading is kept for screen readers but hidden visually.

Testing: opened both proficiency selects and the sidebar résumé menu and confirmed they render and behave correctly.