### PR TITLE
fix: add horizontal padding to the create dialog fields

### DIFF
--- a/src/components/platform/platform-resume-create-dialog.tsx
+++ b/src/components/platform/platform-resume-create-dialog.tsx
@@ -104,7 +104,7 @@ export function PlatformResumeCreateDialog(
           className="md:grid md:min-h-0 md:flex-1 md:grid-rows-[minmax(0,1fr)_auto]"
         >
           <ScrollArea className="md:-mr-2 md:min-h-0 md:pr-2">
-            <FieldGroup className="py-2">
+            <FieldGroup className="py-2 px-1">
               <Controller
                 control={form.control}
                 name="title"


### PR DESCRIPTION
Adds a small horizontal padding to the create-résumé dialog's field group so the fields no longer sit flush against the scroll area edge.

Testing: opened the create dialog and confirmed the fields have breathing room on both sides without clipping.