### PR TITLE
feat: duplicate a résumé from the library and sidebar menus

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -237,6 +237,8 @@
       "itemMenu": "Menu",
       "modify": "Modify <b>{title}</b>",
       "rename": "Rename",
+      "duplicate": "Duplicate",
+      "copyOf": "Copy of {title}",
       "delete": "Delete"
     },
     "toolbar": {
@@ -267,6 +269,8 @@
       "edited": "Edited",
       "menu": "Menu",
       "rename": "Rename",
+      "duplicate": "Duplicate",
+      "copyOf": "Copy of {title}",
       "download": "Download",
       "delete": "Delete",
       "newResume": "New resume"

--- a/messages/id.json
+++ b/messages/id.json
@@ -237,6 +237,8 @@
       "itemMenu": "Menu",
       "modify": "Ubah <b>{title}</b>",
       "rename": "Ganti nama",
+      "duplicate": "Duplikat",
+      "copyOf": "Salinan dari {title}",
       "delete": "Hapus"
     },
     "toolbar": {
@@ -267,6 +269,8 @@
       "edited": "Diedit",
       "menu": "Menu",
       "rename": "Ganti nama",
+      "duplicate": "Duplikat",
+      "copyOf": "Salinan dari {title}",
       "download": "Unduh",
       "delete": "Hapus",
       "newResume": "Resume baru"

--- a/src/components/platform/platform-resume-grid/platform-resume-grid-item-menu.tsx
+++ b/src/components/platform/platform-resume-grid/platform-resume-grid-item-menu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Download, MoreHorizontal, Pen, Trash } from "lucide-react";
+import { Copy, Download, MoreHorizontal, Pen, Trash } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Fragment, useState } from "react";
 import { Button } from "@/components/ui/button";
@@ -13,6 +13,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useResumeStore } from "@/lib/store";
 import { PlatformResumeActionDelete } from "../platform-resume-action-delete";
 import { PlatformResumeActionDownload } from "../platform-resume-action-download";
 import { PlatformResumeActionRename } from "../platform-resume-action-rename";
@@ -25,11 +26,16 @@ export function PlatformResumeGridItemMenu({
   resume,
 }: PlatformResumeGridItemMenuProps) {
   const t = useTranslations("platform.grid");
+  const duplicateResume = useResumeStore((state) => state.duplicateResume);
   const [open, setOpen] = useState({
     rename: false,
     remove: false,
     download: false,
   });
+
+  const onDuplicate = () => {
+    void duplicateResume(resume.id, t("copyOf", { title: resume.title }));
+  };
 
   const openRemoveDialog = () => setOpen((prev) => ({ ...prev, remove: true }));
   const onOpenRemove = (next: boolean) => {
@@ -59,6 +65,9 @@ export function PlatformResumeGridItemMenu({
             <DropdownMenuLabel>{t("menu")}</DropdownMenuLabel>
             <DropdownMenuItem onClick={openRenameDialog}>
               <Pen /> {t("rename")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={onDuplicate}>
+              <Copy /> {t("duplicate")}
             </DropdownMenuItem>
             <DropdownMenuItem onClick={openDownloadDialog}>
               <Download />

--- a/src/components/platform/platform-sidebar-resume-item.tsx
+++ b/src/components/platform/platform-sidebar-resume-item.tsx
@@ -1,10 +1,11 @@
 import type { BaseUIEvent } from "@base-ui/react";
-import { FileText, MoreVertical, Pen, Trash } from "lucide-react";
+import { Copy, FileText, MoreVertical, Pen, Trash } from "lucide-react";
 import { useParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { type MouseEvent, useState } from "react";
 import { Link } from "@/i18n/navigation";
 import type { ResumeIndexEntry } from "@/lib/resume";
+import { useResumeStore } from "@/lib/store";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -30,8 +31,13 @@ export function PlatformSidebarResumeItem({
   resume,
 }: PlatformSidebarResumeItemProps) {
   const { id } = useParams<{ id?: string }>();
+  const duplicateResume = useResumeStore((state) => state.duplicateResume);
   const [open, setOpen] = useState({ rename: false, remove: false });
   const t = useTranslations("platform.sidebar");
+
+  const onDuplicate = () => {
+    void duplicateResume(resume.id, t("copyOf", { title: resume.title }));
+  };
 
   const openRenameDialog = (e: BaseUIEvent<MouseEvent>) => {
     e.preventDefault();
@@ -79,6 +85,10 @@ export function PlatformSidebarResumeItem({
             <DropdownMenuItem onClick={openRenameDialog}>
               <Pen />
               {t("rename")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={onDuplicate}>
+              <Copy />
+              {t("duplicate")}
             </DropdownMenuItem>
 
             {id !== resume.id && (

--- a/src/lib/store/resume-store.ts
+++ b/src/lib/store/resume-store.ts
@@ -62,7 +62,7 @@ interface ResumeStoreState {
     options?: CreateResumeOptions,
   ) => Promise<Resume>;
   renameResume: (id: string, title: string) => Promise<void>;
-  duplicateResume: (id: string) => Promise<Resume | undefined>;
+  duplicateResume: (id: string, title: string) => Promise<Resume | undefined>;
   removeResume: (id: string) => Promise<void>;
   /** Drop a résumé from the index without touching disk; returns it for undo. */
   detachResume: (id: string) => ResumeIndexEntry | undefined;
@@ -184,11 +184,11 @@ export const useResumeStore = create<ResumeStoreState>()((set, get) => ({
     }));
   },
 
-  async duplicateResume(id) {
+  async duplicateResume(id, title) {
     const current = get().open;
     const source = current?.id === id ? current : await getResume(id);
     if (!source) return undefined;
-    const copy = cloneResumeAsNew(source, `${source.title} (copy)`);
+    const copy = cloneResumeAsNew(source, title);
     await putResume(copy);
     set((state) => ({ index: syncIndexEntry(state.index, copy) }));
     return copy;


### PR DESCRIPTION
Adds a Duplicate action to the résumé menu in both places it appears: the dashboard library grid and the sidebar. Clicking it clones the document into a new one that lands in the library immediately, with no dialog or navigation.

The copy is named from the source title, localized: "Copy of {name}" in English and "Salinan dari {name}" in Indonesian. The store's duplicateResume now takes the finished title so the localized string comes from the menu (which has the translations) rather than being hardcoded.

Testing: duplicated résumés from both the grid and the sidebar and confirmed a "Copy of …" entry appears in the list, and that switching the app to Indonesian names the copy "Salinan dari …".