### PR TITLE
refactor: rework the changelog and standardize resume copy

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -48,7 +48,7 @@
   },
   "closure": {
     "kicker": "04 · Apply",
-    "heading": "Lanjut. Resume. Resume.",
+    "heading": "Lanjut. Resume. Résumé.",
     "description": "The name is the pitch: lanjut means continue. Pick a template or start from a blank page; either way it's free, open source, and your resume never leaves your browser.",
     "ctaPrimary": "Create your resume",
     "ctaSecondary": "Browse templates"
@@ -97,7 +97,7 @@
         "content": "Switch between your dashboard and the template gallery from here."
       },
       "resumes": {
-        "title": "Your résumés",
+        "title": "Your resumes",
         "content": "Every resume you create shows up here; pick one to jump into the editor."
       },
       "replay": {
@@ -130,7 +130,7 @@
       },
       "document": {
         "title": "Document",
-        "content": "Export your résumé, switch its language, or import from a PDF, all from the Document tab."
+        "content": "Export your resume, switch its language, or import from a PDF, all from the Document tab."
       }
     },
     "editor-sheet": {
@@ -160,51 +160,165 @@
     },
     "changelog": {
       "whatsNew": "What's new",
-      "description": "The latest improvements to Lanjut, in plain language.",
+      "description": "The latest from Lanjut",
       "latest": "Latest",
       "fullChangelog": "Full changelog on GitHub",
       "entries": {
+        "0_9_0": [
+          {
+            "title": "Import from PDF",
+            "description": "Start a new resume from an existing PDF. Lanjut reads it in your browser and fills the sections for you to tidy up."
+          },
+          {
+            "title": "Custom sections",
+            "description": "Add your own sections beyond the built-in set, either as a rich text block or a list of entries."
+          },
+          {
+            "title": "Reorder certifications",
+            "description": "Drag certifications into the order you want, the same way skills and languages already work."
+          },
+          {
+            "title": "Hide proficiency",
+            "description": "Turn the proficiency level off on skills and languages when you would rather just list them, with a toggle in each section."
+          },
+          {
+            "title": "Language columns",
+            "description": "Show your languages in one column or two, matching the layout control already in Skills."
+          },
+          {
+            "title": "Undo a deletion",
+            "description": "Deleting a resume now waits ten seconds and shows an Undo, so an accidental delete is easy to take back."
+          },
+          {
+            "title": "Duplicate a resume",
+            "description": "Copy any resume from its menu to branch a new version without starting over."
+          }
+        ],
         "0_8_0": [
-          "Show your skills in one column or two: a new toggle in the Skills section switches the layout, and your choice carries through to the preview and every export.",
-          "The editor now lists your entries newest first, matching the order they appear in the preview, so the forms and your resume always line up.",
-          "The landing page has a new navigation bar, with a menu that opens cleanly on mobile.",
-          "Moving between pages now shows a slim progress bar at the top, so you get instant feedback while a page loads."
+          {
+            "title": "Skills column layout",
+            "description": "A toggle in the Skills section switches between one and two columns, and your choice carries through to the preview and every export."
+          },
+          {
+            "title": "Newest entries first",
+            "description": "The editor lists your entries newest first, matching the order they appear in the preview, so the forms and your resume always line up."
+          },
+          {
+            "title": "New landing navbar",
+            "description": "The landing page has a new navigation bar, with a menu that opens cleanly on mobile."
+          },
+          {
+            "title": "Page load progress",
+            "description": "Moving between pages shows a slim progress bar at the top, so you get instant feedback while a page loads."
+          }
         ],
         "0_7_0": [
-          "New Internship section: list internships as their own entries, separate from full-time roles, with the same fields as Experience.",
-          "New Projects section: give side projects, open-source work, and anything you've shipped their own space, each with a name, link, dates, and description.",
-          "A blank resume now shows a preview placeholder in your library instead of an empty white card, so a new resume looks intentional until you start writing."
+          {
+            "title": "Internship section",
+            "description": "List internships as their own entries, separate from full-time roles, with the same fields as Experience."
+          },
+          {
+            "title": "Projects section",
+            "description": "Give side projects, open-source work, and anything you have shipped their own space, each with a name, link, dates, and description."
+          },
+          {
+            "title": "Blank resume preview",
+            "description": "A blank resume shows a preview placeholder in your library instead of an empty white card, so a new resume looks intentional until you start writing."
+          }
         ],
         "0_6_0": [
-          "Lanjut now speaks Bahasa Indonesia. Switch the entire interface between English and Indonesian anytime with the language toggle in the navbar.",
-          "Give each resume its own language: pick English or Indonesian per document, and the section headings and dates in your PDF, DOCX, and TXT exports follow that choice.",
-          "Reorder your skills and languages: grab the handle next to an entry and drag it into place, or use the keyboard to move it. The new order flows straight into the preview and every export.",
-          "Empty sections now tell you so: instead of a lone button, each section without entries shows a short prompt for what to add.",
-          "The landing page hero heading has a refreshed gradient, tuned for both light and dark mode."
+          {
+            "title": "Bahasa Indonesia",
+            "description": "Switch the entire interface between English and Indonesian anytime with the language toggle in the navbar."
+          },
+          {
+            "title": "Per-resume language",
+            "description": "Pick English or Indonesian per document, and the section headings and dates in your PDF, DOCX, and TXT exports follow that choice."
+          },
+          {
+            "title": "Reorder skills and languages",
+            "description": "Grab the handle next to an entry and drag it into place, or use the keyboard to move it. The new order flows straight into the preview and every export."
+          },
+          {
+            "title": "Empty section prompts",
+            "description": "Instead of a lone button, each section without entries shows a short prompt for what to add."
+          },
+          {
+            "title": "Refreshed hero gradient",
+            "description": "The landing page hero heading has a new gradient, tuned for both light and dark mode."
+          }
         ],
         "0_5_0": [
-          "Switch templates without leaving the editor: the new Layout tab shows your resume rendered in every template, and one click applies your pick.",
-          "Start from scratch when you want to: untick \"Pre-fill with example content\" in the create dialog to begin with a blank document instead of the example resume.",
-          "Sections can now be emptied completely: every entry has a delete button, and removing the last one simply drops the section from the preview until you add another."
+          {
+            "title": "Switch templates in the editor",
+            "description": "The new Layout tab shows your resume rendered in every template, and one click applies your pick."
+          },
+          {
+            "title": "Start from a blank resume",
+            "description": "Untick “Pre-fill with example content” in the create dialog to begin with a blank document instead of the example resume."
+          },
+          {
+            "title": "Emptyable sections",
+            "description": "Every entry has a delete button, and removing the last one drops the section from the preview until you add another."
+          }
         ],
         "0_4_0": [
-          "New Organization section: showcase volunteer, student, and community roles with dates and highlights, just like work experience. It shows up in every template and export, and your existing résumés get it automatically.",
-          "Your saved résumés are safer during app updates: a backup copy is kept on your device before any data-format upgrade, and a resume the app can't read yet is flagged with a notice instead of disappearing.",
-          "A guided tour now walks you through the dashboard, the templates, and the editor on your first visit.",
-          "The landing page walks through how Lanjut works, ending with a one-click way to start a new resume.",
-          "Found a bug or missing a feature? Report it from the sidebar; we prefill the GitHub issue for you.",
-          "On your phone, dialogs now open as drawers that are easier to reach and swipe away."
+          {
+            "title": "Organization section",
+            "description": "Showcase volunteer, student, and community roles with dates and highlights, just like work experience. It shows up in every template and export, and existing resumes get it automatically."
+          },
+          {
+            "title": "Safer app updates",
+            "description": "A backup copy is kept on your device before any data-format upgrade, and a resume the app cannot read yet is flagged with a notice instead of disappearing."
+          },
+          {
+            "title": "Guided tour",
+            "description": "A guided tour walks you through the dashboard, the templates, and the editor on your first visit."
+          },
+          {
+            "title": "Landing page walkthrough",
+            "description": "The landing page walks through how Lanjut works, ending with a one-click way to start a new resume."
+          },
+          {
+            "title": "Report bugs and requests",
+            "description": "Report a bug or feature request from the sidebar; we prefill the GitHub issue for you."
+          },
+          {
+            "title": "Mobile drawers",
+            "description": "On your phone, dialogs open as drawers that are easier to reach and swipe away."
+          }
         ],
         "0_3_0": [
-          "Browse templates on their own page, with search and sorting.",
-          "Five new templates: Ketat, Luasa, Tebal, Klasik, and Ketik.",
-          "Template and resume cards now show a live thumbnail of your actual document.",
-          "The sidebar highlights where you are, and each resume gets a quick actions menu."
+          {
+            "title": "Template browser",
+            "description": "Browse templates on their own page, with search and sorting."
+          },
+          {
+            "title": "Five new templates",
+            "description": "Ketat, Luasa, Tebal, Klasik, and Ketik."
+          },
+          {
+            "title": "Live thumbnails",
+            "description": "Template and resume cards show a live thumbnail of your actual document."
+          },
+          {
+            "title": "Sidebar and quick actions",
+            "description": "The sidebar highlights where you are, and each resume gets a quick actions menu."
+          }
         ],
         "0_2_0": [
-          "Export your resume as PDF, DOCX, or plain text.",
-          "Bold, italics, links, and lists now show up in the live preview.",
-          "The editor covers the full section set: summary, experience, education, skills, certifications, and languages."
+          {
+            "title": "Export your resume",
+            "description": "Save your resume as PDF, DOCX, or plain text."
+          },
+          {
+            "title": "Rich text in the preview",
+            "description": "Bold, italics, links, and lists show up in the live preview."
+          },
+          {
+            "title": "Full editor sections",
+            "description": "The editor covers summary, experience, education, skills, certifications, and languages."
+          }
         ]
       }
     },
@@ -250,19 +364,19 @@
       "sortNewest": "Newest"
     },
     "emptyState": {
-      "title": "No résumés yet",
+      "title": "No resumes yet",
       "description": "Nothing is saved on this device yet. Start from a template, or create a blank resume.",
       "browseTemplates": "Browse templates",
       "newResume": "New resume"
     },
     "unreadable": {
-      "title": "Some résumés need a newer version of the app",
-      "description": "{count, plural, one {# resume was} other {# résumés were}} saved by a newer version of Lanjut than the one this tab is running. They are still stored safely on this device. Refresh the page to update the app and see them again."
+      "title": "Some resumes need a newer version of the app",
+      "description": "{count, plural, one {# resume was} other {# resumes were}} saved by a newer version of Lanjut than the one this tab is running. They are still stored safely on this device. Refresh the page to update the app and see them again."
     },
     "grid": {
-      "emptyTitle": "No résumés match",
+      "emptyTitle": "No resumes match",
       "create": "Create “{query}”",
-      "errorTitle": "Couldn't load your résumés",
+      "errorTitle": "Couldn't load your resumes",
       "errorDescription": "Nothing was deleted. The library just failed to load from this browser's storage. Refresh the page to try again.",
       "open": "Open {title}",
       "emptyDocument": "Blank resume, nothing added yet",
@@ -308,16 +422,16 @@
       "sectionTitleRequired": "Enter a section name."
     },
     "create": {
-      "title": "Create a new résumé",
+      "title": "Create a new resume",
       "description": "Name it, choose where to start, and pick a template.",
-      "label": "Résumé name",
+      "label": "Resume name",
       "placeholder": "Software Engineer",
       "template": "Template",
       "sourceLabel": "Start from",
       "sourceSample": "Sample",
       "sourceEmpty": "Blank",
       "sourceImport": "Import PDF",
-      "submit": "Create résumé"
+      "submit": "Create resume"
     },
     "rename": {
       "title": "Rename",
@@ -366,7 +480,7 @@
     "import": {
       "dropPrompt": "Drop a PDF here, or click to browse",
       "hint": "Your file is read on your device and never uploaded.",
-      "parsing": "Reading your résumé…",
+      "parsing": "Reading your resume…",
       "parsed": "Ready to import",
       "remove": "Remove file",
       "errorNotPdf": "Only PDF files are supported.",
@@ -644,9 +758,9 @@
     },
     "document": {
       "downloadHeading": "Download",
-      "importHeading": "Import résumé",
-      "importHint": "Bring in details from an existing PDF résumé. It's read on your device and never uploaded.",
-      "replacePrompt": "This résumé already has content. Replace it, or keep it and create a new one?",
+      "importHeading": "Import resume",
+      "importHint": "Bring in details from an existing PDF resume. It's read on your device and never uploaded.",
+      "replacePrompt": "This resume already has content. Replace it, or keep it and create a new one?",
       "replace": "Replace this one",
       "createNew": "Create new"
     }

--- a/messages/id.json
+++ b/messages/id.json
@@ -48,7 +48,7 @@
   },
   "closure": {
     "kicker": "04 · Lamar",
-    "heading": "Lanjut. Resume. Resume.",
+    "heading": "Lanjut. Resume. Résumé.",
     "description": "Namanya udah jadi janjinya: lanjut artinya terus maju. Pilih template atau mulai dari halaman kosong; dua-duanya gratis, open source, dan resume kamu nggak pernah keluar dari browser.",
     "ctaPrimary": "Buat resume kamu",
     "ctaSecondary": "Intip template"
@@ -160,51 +160,165 @@
     },
     "changelog": {
       "whatsNew": "Apa yang baru",
-      "description": "Peningkatan terbaru untuk Lanjut, dijelaskan dengan bahasa yang mudah.",
+      "description": "Yang terbaru dari Lanjut",
       "latest": "Terbaru",
       "fullChangelog": "Changelog lengkap di GitHub",
       "entries": {
+        "0_9_0": [
+          {
+            "title": "Impor dari PDF",
+            "description": "Mulai resume baru dari PDF yang sudah ada. Lanjut membacanya di browser kamu dan mengisi bagian-bagiannya untuk kamu rapikan."
+          },
+          {
+            "title": "Bagian kustom",
+            "description": "Tambahkan bagianmu sendiri di luar set bawaan, bisa berupa blok teks kaya atau daftar entri."
+          },
+          {
+            "title": "Atur ulang sertifikat",
+            "description": "Seret sertifikat ke urutan yang kamu mau, sama seperti keahlian dan bahasa."
+          },
+          {
+            "title": "Sembunyikan tingkat",
+            "description": "Matikan tingkat kemahiran di keahlian dan bahasa kalau kamu cukup ingin menampilkan daftarnya saja, lewat tombol di tiap bagian."
+          },
+          {
+            "title": "Kolom bahasa",
+            "description": "Tampilkan bahasa dalam satu kolom atau dua, sama seperti kontrol tata letak yang sudah ada di Keahlian."
+          },
+          {
+            "title": "Urungkan penghapusan",
+            "description": "Menghapus resume kini menunggu sepuluh detik dan menampilkan Urungkan, jadi salah hapus gampang dibatalkan."
+          },
+          {
+            "title": "Duplikat resume",
+            "description": "Salin resume mana pun dari menunya untuk membuat versi baru tanpa mulai dari awal."
+          }
+        ],
         "0_8_0": [
-          "Tampilkan keahlianmu dalam satu kolom atau dua: tombol baru di bagian Keahlian mengganti tata letaknya, dan pilihanmu ikut terbawa ke pratinjau dan semua ekspor.",
-          "Editor kini menampilkan entri dari yang terbaru lebih dulu, sesuai urutannya di pratinjau, jadi formulir dan resume kamu selalu sejalan.",
-          "Halaman depan punya bilah navigasi baru, lengkap dengan menu yang rapi saat dibuka di ponsel.",
-          "Berpindah antar halaman kini menampilkan bilah progres tipis di bagian atas, jadi kamu langsung dapat feedback saat halaman dimuat."
+          {
+            "title": "Tata letak kolom keahlian",
+            "description": "Tombol di bagian Keahlian mengganti antara satu dan dua kolom, dan pilihanmu ikut terbawa ke pratinjau dan semua ekspor."
+          },
+          {
+            "title": "Entri terbaru lebih dulu",
+            "description": "Editor menampilkan entri dari yang terbaru lebih dulu, sesuai urutannya di pratinjau, jadi formulir dan resume kamu selalu sejalan."
+          },
+          {
+            "title": "Bilah navigasi baru",
+            "description": "Halaman depan punya bilah navigasi baru, lengkap dengan menu yang rapi saat dibuka di ponsel."
+          },
+          {
+            "title": "Progres pemuatan halaman",
+            "description": "Berpindah antar halaman menampilkan bilah progres tipis di bagian atas, jadi kamu langsung dapat feedback saat halaman dimuat."
+          }
         ],
         "0_7_0": [
-          "Ada bagian Magang baru: tulis pengalaman magang sebagai entri terpisah dari pekerjaan tetap, dengan kolom yang sama seperti Pengalaman.",
-          "Ada bagian Proyek baru: pamerkan proyek sampingan, kontribusi open-source, atau apa pun yang pernah kamu rilis, lengkap dengan nama, tautan, tanggal, dan deskripsi.",
-          "Resume yang masih kosong kini menampilkan pratinjau samar di pustaka, bukan kartu putih polos, jadi resume baru tetap terlihat rapi sebelum kamu mulai mengisinya."
+          {
+            "title": "Bagian Magang",
+            "description": "Tulis pengalaman magang sebagai entri terpisah dari pekerjaan tetap, dengan kolom yang sama seperti Pengalaman."
+          },
+          {
+            "title": "Bagian Proyek",
+            "description": "Pamerkan proyek sampingan, kontribusi open-source, atau apa pun yang pernah kamu rilis, lengkap dengan nama, tautan, tanggal, dan deskripsi."
+          },
+          {
+            "title": "Pratinjau resume kosong",
+            "description": "Resume yang masih kosong menampilkan pratinjau samar di pustaka, bukan kartu putih polos, jadi resume baru tetap terlihat rapi sebelum kamu mulai mengisinya."
+          }
         ],
         "0_6_0": [
-          "Lanjut sekarang bisa Bahasa Indonesia. Ganti seluruh tampilan antara Bahasa Inggris dan Indonesia kapan saja lewat tombol bahasa di bilah navigasi.",
-          "Tiap resume bisa punya bahasanya sendiri: pilih Bahasa Inggris atau Indonesia per dokumen, dan judul bagian serta tanggal di ekspor PDF, DOCX, dan TXT kamu mengikuti pilihan itu.",
-          "Atur ulang urutan keahlian dan bahasa: tahan pegangan di samping entri lalu geser ke posisinya, atau pindahkan pakai keyboard. Urutan barunya langsung diterapkan ke pratinjau dan semua ekspor.",
-          "Bagian yang masih kosong kini ada keterangannya: daripada cuma tombol, tiap bagian tanpa isi menampilkan petunjuk singkat tentang apa yang bisa kamu tambahkan.",
-          "Judul utama di halaman depan punya gradien warna baru yang lebih segar, cocok untuk mode terang maupun gelap."
+          {
+            "title": "Bahasa Indonesia",
+            "description": "Ganti seluruh tampilan antara Bahasa Inggris dan Indonesia kapan saja lewat tombol bahasa di bilah navigasi."
+          },
+          {
+            "title": "Bahasa per resume",
+            "description": "Pilih Bahasa Inggris atau Indonesia per dokumen, dan judul bagian serta tanggal di ekspor PDF, DOCX, dan TXT kamu mengikuti pilihan itu."
+          },
+          {
+            "title": "Atur ulang keahlian dan bahasa",
+            "description": "Tahan pegangan di samping entri lalu geser ke posisinya, atau pindahkan pakai keyboard. Urutan barunya langsung diterapkan ke pratinjau dan semua ekspor."
+          },
+          {
+            "title": "Petunjuk bagian kosong",
+            "description": "Daripada cuma tombol, tiap bagian tanpa isi menampilkan petunjuk singkat tentang apa yang bisa kamu tambahkan."
+          },
+          {
+            "title": "Gradien hero baru",
+            "description": "Judul utama di halaman depan punya gradien warna baru yang lebih segar, cocok untuk mode terang maupun gelap."
+          }
         ],
         "0_5_0": [
-          "Ganti template tanpa keluar dari editor: tab Tata Letak yang baru menampilkan resume kamu dalam setiap template, dan satu klik langsung menerapkan pilihanmu.",
-          "Mau mulai dari nol? Hilangkan centang \"Isi otomatis dengan contoh konten\" saat membuat resume, supaya kamu mulai dari dokumen kosong, bukan contoh.",
-          "Sekarang bagian bisa dikosongkan sepenuhnya: tiap entri punya tombol hapus, dan saat entri terakhir dihapus, bagian itu otomatis hilang dari pratinjau sampai kamu menambah lagi."
+          {
+            "title": "Ganti template di editor",
+            "description": "Tab Tata Letak yang baru menampilkan resume kamu dalam setiap template, dan satu klik langsung menerapkan pilihanmu."
+          },
+          {
+            "title": "Mulai dari resume kosong",
+            "description": "Hilangkan centang “Isi otomatis dengan contoh konten” saat membuat resume, supaya kamu mulai dari dokumen kosong, bukan contoh."
+          },
+          {
+            "title": "Bagian bisa dikosongkan",
+            "description": "Tiap entri punya tombol hapus, dan saat entri terakhir dihapus, bagian itu otomatis hilang dari pratinjau sampai kamu menambah lagi."
+          }
         ],
         "0_4_0": [
-          "Bagian Pengalaman Organisasi yang baru: tampilkan peran sukarelawan, mahasiswa, dan komunitas lengkap dengan tanggal dan poin pentingnya, sama seperti pengalaman kerja. Muncul di setiap template dan ekspor, dan resume lama kamu mendapatkannya secara otomatis.",
-          "Resume yang tersimpan lebih aman saat aplikasi diperbarui: salinan cadangan disimpan di perangkatmu sebelum setiap perubahan format data, dan resume yang belum bisa dibaca aplikasi diberi tanda pemberitahuan, bukannya hilang.",
-          "Tur berpemandu kini menuntun kamu mengelilingi dasbor, template, dan editor saat pertama kali berkunjung.",
-          "Halaman depan menjelaskan cara kerja Lanjut, dan ditutup dengan tombol satu klik untuk mulai membuat resume baru.",
-          "Menemukan bug atau butuh fitur? Laporkan dari bilah sisi; kami sudah menyiapkan isu GitHub-nya untuk kamu.",
-          "Di ponsel, dialog kini terbuka sebagai laci yang lebih mudah dijangkau dan bisa digeser untuk menutup."
+          {
+            "title": "Bagian Organisasi",
+            "description": "Tampilkan peran sukarelawan, mahasiswa, dan komunitas lengkap dengan tanggal dan poin pentingnya, sama seperti pengalaman kerja. Muncul di setiap template dan ekspor, dan resume lama kamu mendapatkannya secara otomatis."
+          },
+          {
+            "title": "Pembaruan aplikasi lebih aman",
+            "description": "Salinan cadangan disimpan di perangkatmu sebelum setiap perubahan format data, dan resume yang belum bisa dibaca aplikasi diberi tanda pemberitahuan, bukannya hilang."
+          },
+          {
+            "title": "Tur berpemandu",
+            "description": "Tur berpemandu menuntun kamu mengelilingi dasbor, template, dan editor saat pertama kali berkunjung."
+          },
+          {
+            "title": "Panduan halaman depan",
+            "description": "Halaman depan menjelaskan cara kerja Lanjut, dan ditutup dengan tombol satu klik untuk mulai membuat resume baru."
+          },
+          {
+            "title": "Laporkan bug dan permintaan",
+            "description": "Laporkan bug atau permintaan fitur dari bilah sisi; kami sudah menyiapkan isu GitHub-nya untuk kamu."
+          },
+          {
+            "title": "Laci di ponsel",
+            "description": "Di ponsel, dialog terbuka sebagai laci yang lebih mudah dijangkau dan bisa digeser untuk menutup."
+          }
         ],
         "0_3_0": [
-          "Jelajahi template di halaman tersendiri, lengkap dengan pencarian dan pengurutan.",
-          "Lima template baru: Ketat, Luasa, Tebal, Klasik, dan Ketik.",
-          "Kartu template dan resume kini menampilkan gambar kecil langsung dari dokumen asli kamu.",
-          "Bilah sisi menyorot posisi kamu, dan tiap resume punya menu aksi cepat."
+          {
+            "title": "Penjelajah template",
+            "description": "Jelajahi template di halaman tersendiri, lengkap dengan pencarian dan pengurutan."
+          },
+          {
+            "title": "Lima template baru",
+            "description": "Ketat, Luasa, Tebal, Klasik, dan Ketik."
+          },
+          {
+            "title": "Gambar kecil langsung",
+            "description": "Kartu template dan resume menampilkan gambar kecil langsung dari dokumen asli kamu."
+          },
+          {
+            "title": "Bilah sisi dan aksi cepat",
+            "description": "Bilah sisi menyorot posisi kamu, dan tiap resume punya menu aksi cepat."
+          }
         ],
         "0_2_0": [
-          "Ekspor resume kamu ke PDF, DOCX, atau teks biasa.",
-          "Teks tebal, miring, tautan, dan daftar kini tampil di pratinjau langsung.",
-          "Editor mencakup semua bagian: ringkasan, pengalaman, pendidikan, keahlian, sertifikat, dan bahasa."
+          {
+            "title": "Ekspor resume",
+            "description": "Simpan resume kamu ke PDF, DOCX, atau teks biasa."
+          },
+          {
+            "title": "Teks kaya di pratinjau",
+            "description": "Teks tebal, miring, tautan, dan daftar tampil di pratinjau langsung."
+          },
+          {
+            "title": "Semua bagian editor",
+            "description": "Editor mencakup ringkasan, pengalaman, pendidikan, keahlian, sertifikat, dan bahasa."
+          }
         ]
       }
     },

--- a/src/components/platform/platform-navbar-changelog.tsx
+++ b/src/components/platform/platform-navbar-changelog.tsx
@@ -128,7 +128,7 @@ function PlatformNavbarChangelogEntry(props: {
   const panelId = useId();
   const highlights = t.raw(
     `entries.${props.entry.version.replace(/\./g, "_")}`,
-  ) as string[];
+  ) as Array<{ title: string; description: string }>;
 
   const itemVariants = {
     hidden: reduceMotion ? { opacity: 0 } : { opacity: 0, y: 16 },
@@ -212,11 +212,18 @@ function PlatformNavbarChangelogEntry(props: {
               variants={listVariants}
               initial="hidden"
               animate="visible"
-              className="space-y-4 pb-4 text-sm text-foreground/80"
+              className="space-y-3.5 pb-4 text-sm"
             >
               {highlights.map((highlight) => (
-                <motion.li key={highlight} variants={itemVariants}>
-                  {highlight}
+                <motion.li
+                  key={highlight.title}
+                  variants={itemVariants}
+                  className="space-y-0.5"
+                >
+                  <p className="font-medium text-foreground">
+                    {highlight.title}
+                  </p>
+                  <p className="text-foreground/70">{highlight.description}</p>
                 </motion.li>
               ))}
             </motion.ul>

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -4,12 +4,12 @@ export interface ChangelogEntry {
 }
 
 /**
- * Release metadata for the "What's new" sheet, newest first. The per-version
- * highlight text lives in the `platform.changelog.entries` messages, keyed by
- * version with dots replaced by underscores. Add an entry here plus its
- * highlights in both locale files as part of each release PR.
+ * Release metadata for the "What's new" sheet, newest first. Each version's
+ * highlights live in the `platform.changelog.entries` messages, keyed by version
+ * with dots replaced by underscores, as a list of { title, description }.
  */
 export const CHANGELOG: ChangelogEntry[] = [
+  { version: "0.9.0", date: "2026-07-14" },
   { version: "0.8.0", date: "2026-07-11" },
   { version: "0.7.0", date: "2026-07-10" },
   { version: "0.6.0", date: "2026-07-08" },

--- a/src/lib/resume/seed.ts
+++ b/src/lib/resume/seed.ts
@@ -48,7 +48,7 @@ function prose(...blocks: JSONContent[]): Field {
 export const SEED_RESUME: Resume = {
   id: "seed",
   schemaVersion: CURRENT_SCHEMA_VERSION,
-  title: "Untitled résumé",
+  title: "Untitled resume",
   templateId: "awal",
   language: "en",
   createdAt: "2026-01-01T00:00:00.000Z",

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -2,7 +2,7 @@
 export const SITE = {
   name: "Lanjut",
   url: "https://lanjut.rimzzlabs.com",
-  title: "Lanjut: Free, local-first ATS résumé builder",
+  title: "Lanjut: Free, local-first ATS resume builder",
   description:
-    "Lanjut is a free, open-source résumé builder that stays entirely in your browser; no account, nothing uploaded. Style it freely; every export is structured to sail through applicant tracking systems.",
+    "Lanjut is a free, open-source resume builder that stays entirely in your browser; no account, nothing uploaded. Style it freely; every export is structured to sail through applicant tracking systems.",
 } as const;


### PR DESCRIPTION
Reworks the in-app "What's new" changelog and cleans up the wording it and the rest of the app use.

Changelog highlights move from a single run-on string per item to a title plus a description, rendered as a bold heading over a muted line. This drops the awkward "lead-in: elaboration" colon phrasing that every older entry used. All existing versions (0.2.0 through 0.8.0) are rewritten into the new shape in both English and Indonesian, and a new 0.9.0 entry covers what shipped since 0.8.0: PDF import, custom sections, certification reordering, hiding proficiency, language columns, undo on delete, and duplicating a résumé. The sheet subtitle also changes from "The latest improvements to Lanjut, in plain language" to "The latest from Lanjut".

Separately, the user-facing copy now uses plain "resume" everywhere instead of the accented "résumé", across the message catalog, the SEO metadata, and the default document title. Code comments keep their existing spelling.

Testing: opened the What's new sheet and confirmed each entry renders as a title over a description with no colons, the 0.9.0 entry appears at the top, and the landing and platform copy reads "resume" throughout.