### PR TITLE
fix: right-size landing images and correct language toggle a11y

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -58,7 +58,7 @@
   --secondary: oklch(0.967 0.001 286.375);
   --secondary-foreground: oklch(0.21 0.006 285.885);
   --muted: oklch(0.96 0.002 17.2);
-  --muted-foreground: oklch(0.547 0.021 43.1);
+  --muted-foreground: oklch(0.52 0.021 43.1);
   --accent: oklch(0.96 0.002 17.2);
   --accent-foreground: oklch(0.214 0.009 43.1);
   --destructive: oklch(0.577 0.245 27.325);

--- a/src/components/landing/landing-how-it-works.tsx
+++ b/src/components/landing/landing-how-it-works.tsx
@@ -137,6 +137,7 @@ function HowItWorksScreenshot(props: {
         alt={props.alt}
         width={props.width}
         height={props.height}
+        sizes="(max-width: 768px) 100vw, 600px"
         className="w-full rounded-lg border object-cover object-top"
       />
       <figcaption className="sr-only">{props.alt}</figcaption>

--- a/src/components/landing/landing-preview-editor.tsx
+++ b/src/components/landing/landing-preview-editor.tsx
@@ -43,6 +43,7 @@ export function LandingPreviewEditor() {
           title={t("imageAlt")}
           width={1437}
           height={871}
+          sizes="(max-width: 1024px) 100vw, 1024px"
           className="w-full aspect-video rounded-lg border object-cover"
         />
         <figcaption className="sr-only">{t("caption")}</figcaption>

--- a/src/components/shared/segmented-control.tsx
+++ b/src/components/shared/segmented-control.tsx
@@ -48,11 +48,17 @@ export function SegmentedControl(props: SegmentedControlProps) {
     >
       {props.items.map((item) => {
         const active = item.value === props.value;
+        // The accessible name must contain the visible label (WCAG 2.5.3), so
+        // fold the short label into the fuller aria label rather than replacing it.
+        const accessibleName =
+          item.ariaLabel && item.ariaLabel !== item.label
+            ? `${item.ariaLabel} (${item.label})`
+            : item.label;
         return (
           <Toggle
             key={item.value}
             value={item.value}
-            aria-label={item.ariaLabel ?? item.label}
+            aria-label={accessibleName}
             className={cn(
               "relative inline-flex h-6 min-w-9 cursor-pointer items-center justify-center rounded-xl px-2.5 text-xs font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring/50",
               active


### PR DESCRIPTION
Lighthouse on the live site scored desktop 96 but mobile performance 73, with mobile LCP at 7.0s. The cause was the landing hero and how-it-works screenshots: with no `sizes` hint on the `next/image` elements, the browser fell back to the 2x-of-intrinsic candidate and downloaded both images at `w=3840` on mobile while displaying them at roughly 360px, wasting about 985 KiB and dominating LCP render delay.

Adding a `sizes` hint lets the browser pick a small candidate from the responsive srcset (mobile now selects around `w=750` instead of `w=3840`), which should bring mobile LCP and the performance score back up without affecting desktop.

This also clears the two accessibility findings, both in the segmented control used by the language toggle. The accessible name now folds the short label into the fuller label (for example "Indonesia (ID)") so it contains the visible text, satisfying WCAG 2.5.3. And the light `muted-foreground` token is nudged from L 0.547 to 0.52 so muted text sitting on the muted track meets the 4.5:1 contrast minimum; the ratio goes from 4.4 to 4.9 and dark mode is untouched.

## Testing

Rendered the landing page and confirmed both images now carry a `sizes` attribute and expose the full responsive srcset down to `w=640`, so small viewports no longer pull the 3840-wide asset. Verified the language buttons announce "English (EN)" and "Indonesia (ID)", and confirmed the new muted-foreground value computes to a 4.9:1 contrast ratio against the muted background.