### PR TITLE
fix: delete résumé from storage immediately with in-memory undo

### DIFF
--- a/src/components/platform/platform-resume-action-delete.tsx
+++ b/src/components/platform/platform-resume-action-delete.tsx
@@ -38,7 +38,7 @@ export function PlatformResumeActionDelete(
   const tc = useTranslations("forms.common");
 
   function handleDelete() {
-    deleteResumeWithUndo(props.resume.id, {
+    void deleteResumeWithUndo(props.resume.id, {
       deleted: t("toast", { title: props.resume.title }),
       undo: tc("undo"),
     });

--- a/src/components/platform/platform-resume-delete-undo.tsx
+++ b/src/components/platform/platform-resume-delete-undo.tsx
@@ -9,19 +9,12 @@ interface UndoMessages {
   undo: string;
 }
 
-// Runs the timer outside React so it survives the résumé card unmounting when
-// the entry leaves the index.
-export function deleteResumeWithUndo(id: string, messages: UndoMessages) {
+// The résumé is deleted from disk right away so it can never resurface, even if
+// the page is left mid-window. Undo restores the removed document.
+export async function deleteResumeWithUndo(id: string, messages: UndoMessages) {
   const store = useResumeStore.getState();
-  const entry = store.detachResume(id);
-  if (!entry) return;
-
-  let settled = false;
-  const timer = setTimeout(() => {
-    if (settled) return;
-    settled = true;
-    void store.removeResume(id);
-  }, UNDO_WINDOW_MS);
+  const removed = await store.removeResume(id);
+  if (!removed) return;
 
   toast(messages.deleted, {
     duration: UNDO_WINDOW_MS,
@@ -30,10 +23,7 @@ export function deleteResumeWithUndo(id: string, messages: UndoMessages) {
     action: {
       label: messages.undo,
       onClick: () => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        store.restoreResume(entry);
+        void store.restoreResume(removed);
       },
     },
   });

--- a/src/lib/store/resume-store.ts
+++ b/src/lib/store/resume-store.ts
@@ -63,11 +63,10 @@ interface ResumeStoreState {
   ) => Promise<Resume>;
   renameResume: (id: string, title: string) => Promise<void>;
   duplicateResume: (id: string, title: string) => Promise<Resume | undefined>;
-  removeResume: (id: string) => Promise<void>;
-  /** Drop a résumé from the index without touching disk; returns it for undo. */
-  detachResume: (id: string) => ResumeIndexEntry | undefined;
-  /** Re-insert a detached index entry, newest-first. */
-  restoreResume: (entry: ResumeIndexEntry) => void;
+  /** Delete a résumé from disk and index; returns the removed document for undo. */
+  removeResume: (id: string) => Promise<Resume | undefined>;
+  /** Re-insert a removed document (undo), writing it back to disk. */
+  restoreResume: (resume: Resume) => Promise<void>;
   openResume: (id: string) => Promise<void>;
   /** Apply an edit to the open document; schedules a debounced persist. */
   updateOpen: (recipe: (draft: Resume) => void) => void;
@@ -195,7 +194,8 @@ export const useResumeStore = create<ResumeStoreState>()((set, get) => ({
   },
 
   async removeResume(id) {
-    await dbDeleteResume(id);
+    const current = get().open;
+    const removed = current?.id === id ? current : await getResume(id);
     set((state) => {
       const isOpen = state.open?.id === id;
       return {
@@ -204,27 +204,13 @@ export const useResumeStore = create<ResumeStoreState>()((set, get) => ({
         openStatus: isOpen ? "idle" : state.openStatus,
       };
     });
+    await dbDeleteResume(id);
+    return removed;
   },
 
-  detachResume(id) {
-    const entry = get().index.find((item) => item.id === id);
-    if (!entry) return undefined;
-    set((state) => ({
-      index: A.reject(state.index, (item) => item.id === id),
-    }));
-    return entry;
-  },
-
-  restoreResume(entry) {
-    set((state) => ({
-      index: pipe(
-        state.index,
-        A.reject((item) => item.id === entry.id),
-        A.prepend(entry),
-        A.sortBy((item) => item.updatedAt),
-        A.reverse,
-      ),
-    }));
+  async restoreResume(resume) {
+    await putResume(resume);
+    set((state) => ({ index: syncIndexEntry(state.index, resume) }));
   },
 
   async openResume(id) {


### PR DESCRIPTION
Deleting a résumé only detached it from the in-memory index and deferred the IndexedDB removal until the 10s undo window elapsed. If the user left the page before then (reload, close, navigate), the deferred removal never ran, so the résumé was still on disk and reappeared on the next load.

Now the document is removed from IndexedDB the moment delete is clicked, so it can never resurface. The removed document is held by the undo toast for the window; clicking undo writes it back to disk and restores its index row, and letting the toast expire makes the deletion final. This drops the deferred-removal timer entirely, so the store's `removeResume` returns the removed document and `restoreResume` takes a full document and re-persists it; the index-only `detachResume` is gone.

## Testing

In the running app: created a résumé, deleted it, then closed and reopened the tab, and it stayed gone. Created and deleted another, clicked Undo within the window, and the full résumé returned with its content. Confirmed deleting the résumé currently open in the editor clears the editor and is still restorable via undo.