### PR TITLE
fix: tint the guided tour overlay to match the theme

### DIFF
--- a/src/components/tour/tour-provider.tsx
+++ b/src/components/tour/tour-provider.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
+import { useTheme } from "next-themes";
 import { NextStep, NextStepProvider } from "nextstepjs";
 import { type PropsWithChildren, useMemo } from "react";
 import { useSidebarStore, useTourStore } from "@/lib/store";
@@ -42,6 +43,8 @@ function handleTourEnd() {
 export function TourProvider(props: PropsWithChildren) {
   const t = useTranslations("tour");
   const tours = useMemo(() => localizeTours(t), [t]);
+  const { resolvedTheme } = useTheme();
+  const isDarkMode = resolvedTheme === "dark";
 
   return (
     <NextStepProvider>
@@ -54,6 +57,8 @@ export function TourProvider(props: PropsWithChildren) {
         onSkip={handleTourEnd}
         noInViewScroll
         disableConsoleLogs
+        shadowRgb={isDarkMode ? "255, 255, 255" : "0, 0, 0"}
+        shadowOpacity={isDarkMode ? "0.15" : "0.2"}
       >
         {props.children}
       </NextStep>


### PR DESCRIPTION
The guided tour dimmed the page behind the nextstepjs overlay with a black veil in both themes. On the dark theme that black-on-dark dim was almost invisible, so the spotlight barely stood out.

Instead of a fixed color, this keys nextstepjs's own `shadowRgb` / `shadowOpacity` to the resolved theme: a light veil (white, 0.15) in dark mode and a dark veil (black, 0.2) in light mode. The surround is now clearly separated from the spotlighted target in either theme, using the library's native props with no custom overlay CSS. `resolvedTheme` is only read to pick the colors, and the overlay only renders once a tour starts (post-hydration), so there's no flash or mismatch.

## Testing

Drove the actual tour in a headless browser in both themes and confirmed on a spotlight step that the surround is veiled while the highlighted control stays sharp: a lightening veil in dark mode, a darkening veil in light mode.