### PR TITLE
ci: skip the open-next build on regular prs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,25 @@ jobs:
 
       - run: pnpm lint
 
+      - run: pnpm typecheck
+
       - run: pnpm validate:exports
 
-      # Same production build the release workflow runs, so open-next
-      # incompatibilities surface on the PR instead of at deploy time.
+  build:
+    # Regular PRs skip the expensive open-next build; only the release-please PR
+    # builds it, so open-next incompatibilities surface before the release deploys.
+    if: startsWith(github.head_ref, 'release-please--')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
       - run: pnpm exec opennextjs-cloudflare build

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "upload": "opennextjs-cloudflare build && opennextjs-cloudflare upload",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts",
     "lint": "biome check",
+    "typecheck": "next typegen && tsc --noEmit",
     "format": "biome format --write",
     "validate:exports": "tsx scripts/validate-exports.tsx",
     "commit": "cz",


### PR DESCRIPTION
Regular pull requests were running the full open-next production build, which is slow and rarely relevant to the change under review. This limits that build to the release-please PR, where it actually guards the deploy that follows.

`ci.yml` now has two jobs. `checks` runs on every PR and does lint, typecheck, and the exports check. `build` runs the `opennextjs-cloudflare build` only when the PR head branch is the release-please branch (`startsWith(github.head_ref, 'release-please--')`), so it is skipped on regular PRs and runs on the release PR before it merges. A `typecheck` script is added because the build was previously the only step type-checking in CI; `release.yml` is unchanged and still builds and deploys when a release is cut.

If you want the build to block the release PR from merging, add the `build` job as a required status check. That is safe for regular PRs: a job skipped via `if` reports as skipped, which branch protection treats as passing.

## Testing

Ran `pnpm typecheck` locally (passes) and confirmed the workflow gates the build job to the release-please branch.