### PR TITLE
feat: send bug reports and feature requests without a github account

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -11,25 +11,12 @@ body:
     id: what-happened
     attributes:
       label: What happened?
-      description: A clear description of the bug. Screenshots and screen recordings help a lot.
-      placeholder: The editor preview goes blank when...
-    validations:
-      required: true
-  - type: textarea
-    id: steps
-    attributes:
-      label: Steps to reproduce
+      description: A clear description of the bug, the steps to reproduce it (a numbered list works great), and what you expected instead. Screenshots and screen recordings help a lot.
       placeholder: |
+        The editor preview goes blank when...
         1. Create a résumé from the Ketat template
         2. Add a second experience entry
         3. Drag it above the first one
-        4. The preview...
-    validations:
-      required: true
-  - type: textarea
-    id: expected
-    attributes:
-      label: What did you expect to happen?
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -16,17 +16,10 @@ body:
     validations:
       required: true
   - type: textarea
-    id: proposal
-    attributes:
-      label: Proposed solution
-      description: How do you imagine it working?
-    validations:
-      required: true
-  - type: textarea
     id: alternatives
     attributes:
       label: Alternatives considered
-      description: Workarounds you use today, or other ways this could be solved.
+      description: Workarounds you use today, or other ways this could be solved. If you have a specific solution in mind, sketch it here.
   - type: dropdown
     id: layer
     attributes:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,10 @@ jobs:
 
       - run: pnpm validate:exports
 
+      # Public Turnstile site key, inlined at build time.
       - run: pnpm exec opennextjs-cloudflare build
+        env:
+          NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ vars.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
 
       - name: Deploy ${{ needs.release-please.outputs.tag_name }} to Cloudflare Workers
         run: pnpm exec opennextjs-cloudflare deploy

--- a/messages/en.json
+++ b/messages/en.json
@@ -164,6 +164,12 @@
       "latest": "Latest",
       "fullChangelog": "Full changelog on GitHub",
       "entries": {
+        "0_10_0": [
+          {
+            "title": "Feedback without a GitHub account",
+            "description": "Report a bug or request a feature right from the app; we file the GitHub issue for you under the name you provide, guarded by a quick verification."
+          }
+        ],
         "0_9_0": [
           {
             "title": "Import from PDF",
@@ -418,8 +424,18 @@
       "fileNameRequired": "Name the file before downloading.",
       "bugWhatHappened": "Describe what went wrong.",
       "featureProblem": "Describe the problem this would solve.",
-      "featureProposal": "Describe how you imagine it working.",
-      "sectionTitleRequired": "Enter a section name."
+      "sectionTitleRequired": "Enter a section name.",
+      "reporterNameRequired": "Tell us your name first.",
+      "verificationRequired": "Finish the quick verification first."
+    },
+    "direct": {
+      "name": "Your name",
+      "namePlaceholder": "e.g. Sinta",
+      "nameDescription": "Shown on the public GitHub issue so we know who it's from.",
+      "send": "Send it for me",
+      "githubAlt": "Have a GitHub account? Open a prefilled issue instead.",
+      "sentToast": "Sent! Thank you; we filed the GitHub issue for you.",
+      "errorToast": "Couldn't send it. Try again, or use the GitHub button."
     },
     "create": {
       "title": "Create a new resume",
@@ -457,23 +473,21 @@
     },
     "bug": {
       "title": "Report a bug",
-      "description": "This opens a prefilled GitHub issue for you to review and submit; a GitHub account is required, and your browser details are filled in for you.",
+      "description": "Send it right here and we'll file the GitHub issue for you; no account needed. If you have a GitHub account, you can open a prefilled issue yourself instead.",
+      "descriptionGitHubOnly": "This opens a prefilled GitHub issue for you to review and submit; a GitHub account is required, and your browser details are filled in for you.",
       "whatHappened": "What happened?",
       "whatHappenedPlaceholder": "The editor preview goes blank when...",
-      "steps": "Steps to reproduce",
-      "stepsPlaceholder": "1. Create a resume (a numbered list works great here)",
-      "stepsDescription": "Optional here; you can also fill this in on GitHub.",
+      "whatHappenedDescription": "Include the steps to reproduce it; a numbered list works great.",
       "area": "Where does the bug show up?",
       "areaPlaceholder": "Area"
     },
     "feature": {
       "title": "Request a feature",
-      "description": "This opens a prefilled GitHub issue for you to review and submit; a GitHub account is required. Note that resume structure (tables, columns, images) is out of scope by design; presentation is fair game.",
+      "description": "Send it right here and we'll file the GitHub issue for you; no account needed. Note that resume structure (tables, columns, images) is out of scope by design; presentation is fair game.",
+      "descriptionGitHubOnly": "This opens a prefilled GitHub issue for you to review and submit; a GitHub account is required. Note that resume structure (tables, columns, images) is out of scope by design; presentation is fair game.",
       "problem": "What problem does this solve?",
       "problemPlaceholder": "When I tailor my resume for different roles, I have to...",
       "problemDescription": "Describe the situation where you needed this, rather than the solution itself.",
-      "proposal": "Proposed solution",
-      "proposalPlaceholder": "How do you imagine it working?",
       "layer": "Which layer does this touch?",
       "layerPlaceholder": "Layer"
     },

--- a/messages/id.json
+++ b/messages/id.json
@@ -164,6 +164,12 @@
       "latest": "Terbaru",
       "fullChangelog": "Changelog lengkap di GitHub",
       "entries": {
+        "0_10_0": [
+          {
+            "title": "Kirim masukan tanpa akun GitHub",
+            "description": "Laporin bug atau ajukan fitur langsung dari aplikasi; isu GitHub-nya kami buatin atas nama yang kamu isi, dijaga verifikasi singkat."
+          }
+        ],
         "0_9_0": [
           {
             "title": "Impor dari PDF",
@@ -418,8 +424,18 @@
       "fileNameRequired": "Kasih nama berkasnya dulu sebelum unduh.",
       "bugWhatHappened": "Ceritain apa yang salah.",
       "featureProblem": "Ceritain masalah yang mau diselesaikan.",
-      "featureProposal": "Ceritain gimana kamu ngebayanginnya jalan.",
-      "sectionTitleRequired": "Isi nama bagian."
+      "sectionTitleRequired": "Isi nama bagian.",
+      "reporterNameRequired": "Isi nama kamu dulu, ya.",
+      "verificationRequired": "Selesain verifikasi singkatnya dulu, ya."
+    },
+    "direct": {
+      "name": "Nama kamu",
+      "namePlaceholder": "mis. Sinta",
+      "nameDescription": "Ditampilin di isu GitHub publik biar kami tahu ini dari siapa.",
+      "send": "Kirimin buat aku",
+      "githubAlt": "Punya akun GitHub? Buka aja isu yang udah keisi.",
+      "sentToast": "Terkirim! Makasih ya; isu GitHub-nya udah kami buatin.",
+      "errorToast": "Gagal ngirim. Coba lagi, atau pakai tombol GitHub."
     },
     "create": {
       "title": "Buat resume baru",
@@ -457,23 +473,21 @@
     },
     "bug": {
       "title": "Laporin bug",
-      "description": "Ini bakal buka isu GitHub yang udah keisi buat kamu tinjau dan kirim; butuh akun GitHub, dan detail browser kamu udah diisiin otomatis.",
+      "description": "Kirim langsung dari sini dan isu GitHub-nya kami buatin; nggak perlu akun. Kalau kamu punya akun GitHub, bisa juga buka isu yang udah keisi dan kirim sendiri.",
+      "descriptionGitHubOnly": "Ini bakal buka isu GitHub yang udah keisi buat kamu tinjau dan kirim; butuh akun GitHub, dan detail browser kamu udah diisiin otomatis.",
       "whatHappened": "Apa yang terjadi?",
       "whatHappenedPlaceholder": "Pratinjau editor jadi kosong pas...",
-      "steps": "Langkah buat ngereproduksi",
-      "stepsPlaceholder": "1. Buat resume (daftar bernomor cocok banget di sini)",
-      "stepsDescription": "Opsional kok di sini; bisa juga kamu isi nanti di GitHub.",
+      "whatHappenedDescription": "Sertain juga langkah buat ngereproduksinya; daftar bernomor cocok banget.",
       "area": "Di mana bug-nya muncul?",
       "areaPlaceholder": "Area"
     },
     "feature": {
       "title": "Ajukan fitur baru",
-      "description": "Ini bakal buka GitHub Issue yang udah keisi buat kamu tinjau dan kirim; butuh akun GitHub. Oh iya, struktur resume (tabel, kolom, gambar) emang di luar cakupan; tapi presentasi bebas kamu usulin.",
+      "description": "Kirim langsung dari sini dan isu GitHub-nya kami buatin; nggak perlu akun. Oh iya, struktur resume (tabel, kolom, gambar) emang di luar cakupan; tapi presentasi bebas kamu usulin.",
+      "descriptionGitHubOnly": "Ini bakal buka GitHub Issue yang udah keisi buat kamu tinjau dan kirim; butuh akun GitHub. Oh iya, struktur resume (tabel, kolom, gambar) emang di luar cakupan; tapi presentasi bebas kamu usulin.",
       "problem": "Masalah apa yang diselesaikan ini?",
       "problemPlaceholder": "Pas nyesuaiin resume buat peran yang beda-beda, aku harus...",
       "problemDescription": "Ceritain situasi pas kamu butuh ini, bukan solusinya.",
-      "proposal": "Solusi yang diusulkan",
-      "proposalPlaceholder": "Gimana kamu ngebayanginnya jalan?",
       "layer": "Lapisan mana yang kena?",
       "layerPlaceholder": "Lapisan"
     },

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,0 +1,120 @@
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import {
+  type FeedbackPayload,
+  feedbackPayloadSchema,
+} from "@/lib/forms/feedback";
+import { GITHUB_REPO, issueTitle } from "@/lib/github-issue";
+
+declare global {
+  interface CloudflareEnv {
+    GITHUB_ISSUE_TOKEN?: string;
+    TURNSTILE_SECRET_KEY?: string;
+  }
+}
+
+const TURNSTILE_VERIFY_URL =
+  "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+const GITHUB_ISSUES_URL = `https://api.github.com/repos/${GITHUB_REPO}/issues`;
+
+async function verifyTurnstile(
+  secret: string,
+  token: string,
+  remoteIp: string | null,
+): Promise<boolean> {
+  const body = new FormData();
+  body.set("secret", secret);
+  body.set("response", token);
+  if (remoteIp) body.set("remoteip", remoteIp);
+
+  const response = await fetch(TURNSTILE_VERIFY_URL, { method: "POST", body });
+  if (!response.ok) return false;
+  const outcome = (await response.json()) as { success?: boolean };
+  return outcome.success === true;
+}
+
+interface IssueRequest {
+  title: string;
+  body: string;
+  labels: string[];
+}
+
+function reportedBy(name: string): string {
+  return `---\n\n_Reported by **${name}** from the in-app feedback form; filed on their behalf by the maintainer._`;
+}
+
+function buildIssue(
+  payload: FeedbackPayload,
+  browser: string | null,
+): IssueRequest {
+  if (payload.kind === "bug") {
+    return {
+      title: issueTitle("fix(bug,via app):", payload.summary),
+      labels: ["bug"],
+      body: [
+        "### What happened?",
+        payload.whatHappened,
+        "### Area",
+        payload.area,
+        "### Browser and OS",
+        browser ?? "_Unknown._",
+        reportedBy(payload.name),
+      ].join("\n\n"),
+    };
+  }
+
+  return {
+    title: issueTitle("feat(via app):", payload.summary),
+    labels: ["enhancement"],
+    body: [
+      "### What problem does this solve?",
+      payload.problem,
+      "### Which layer does this touch?",
+      payload.layer,
+      reportedBy(payload.name),
+    ].join("\n\n"),
+  };
+}
+
+export async function POST(request: Request) {
+  const { env } = getCloudflareContext();
+  const githubToken = env.GITHUB_ISSUE_TOKEN;
+  const turnstileSecret = env.TURNSTILE_SECRET_KEY;
+  if (!githubToken || !turnstileSecret) {
+    return Response.json({ error: "feedback-disabled" }, { status: 503 });
+  }
+
+  let payload: FeedbackPayload;
+  try {
+    payload = feedbackPayloadSchema.parse(await request.json());
+  } catch {
+    return Response.json({ error: "invalid-payload" }, { status: 400 });
+  }
+
+  const human = await verifyTurnstile(
+    turnstileSecret,
+    payload.turnstileToken,
+    request.headers.get("cf-connecting-ip"),
+  );
+  if (!human) {
+    return Response.json({ error: "verification-failed" }, { status: 403 });
+  }
+
+  const issue = buildIssue(payload, request.headers.get("user-agent"));
+  const response = await fetch(GITHUB_ISSUES_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${githubToken}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "lanjut-feedback",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(issue),
+  });
+  if (!response.ok) {
+    return Response.json({ error: "github-error" }, { status: 502 });
+  }
+
+  const created = (await response.json()) as { html_url?: string };
+  return Response.json({ url: created.html_url }, { status: 201 });
+}

--- a/src/components/platform/platform-bug-report-dialog.tsx
+++ b/src/components/platform/platform-bug-report-dialog.tsx
@@ -9,6 +9,7 @@ import {
   ResponsiveDialogHeader,
   ResponsiveDialogTitle,
 } from "../shared/responsive-dialog";
+import { TURNSTILE_SITE_KEY } from "../shared/turnstile";
 import { PlatformBugReportForm } from "./platform-bug-report-form";
 
 /**
@@ -26,11 +27,11 @@ export function PlatformBugReportDialog() {
       open={open === "bug"}
       onOpenChange={(next) => setOpen(next ? "bug" : null)}
     >
-      <ResponsiveDialogContent className="sm:max-w-lg">
-        <ResponsiveDialogHeader>
+      <ResponsiveDialogContent className="flex max-h-[min(35rem,calc(100dvh-3rem))] flex-col gap-4 overflow-hidden sm:max-w-lg">
+        <ResponsiveDialogHeader className="md:shrink-0">
           <ResponsiveDialogTitle>{t("title")}</ResponsiveDialogTitle>
           <ResponsiveDialogDescription className="text-balance">
-            {t("description")}
+            {t(TURNSTILE_SITE_KEY ? "description" : "descriptionGitHubOnly")}
           </ResponsiveDialogDescription>
         </ResponsiveDialogHeader>
 

--- a/src/components/platform/platform-bug-report-form.tsx
+++ b/src/components/platform/platform-bug-report-form.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
-import { ExternalLink, XIcon } from "lucide-react";
+import { ExternalLink, SendIcon, XIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useMemo } from "react";
+import { type FormEvent, useMemo, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
+import { toast } from "sonner";
 import { useValidationTranslator } from "@/hooks/use-validation-translator";
 import { usePathname } from "@/i18n/navigation";
 import {
@@ -16,6 +17,7 @@ import {
   areaForPathname,
   buildBugReportUrl,
   issueTitle,
+  submitFeedback,
 } from "@/lib/github-issue";
 import { emptyRichTextValue } from "@/lib/resume";
 import { PROSE_FEATURES } from "@/lib/resume/schema-registry";
@@ -29,6 +31,7 @@ import {
   ResponsiveDialogClose,
   ResponsiveDialogFooter,
 } from "../shared/responsive-dialog";
+import { TURNSTILE_SITE_KEY, Turnstile } from "../shared/turnstile";
 import { Button } from "../ui/button";
 import {
   Field,
@@ -37,6 +40,8 @@ import {
   FieldGroup,
   FieldLabel,
 } from "../ui/field";
+import { Input } from "../ui/input";
+import { ScrollArea } from "../ui/scroll-area";
 import {
   Select,
   SelectContent,
@@ -45,6 +50,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "../ui/select";
+import { Spinner } from "../ui/spinner";
 
 interface PlatformBugReportFormProps {
   onSubmitted: () => void;
@@ -54,117 +60,198 @@ export function PlatformBugReportForm(props: PlatformBugReportFormProps) {
   const pathname = usePathname();
   const t = useTranslations("forms.bug");
   const tc = useTranslations("forms.common");
+  const td = useTranslations("forms.direct");
   const tv = useValidationTranslator();
   const schema = useMemo(() => createBugReportSchema(tv), [tv]);
+  const [turnstileEpoch, setTurnstileEpoch] = useState(0);
+  const directEnabled = Boolean(TURNSTILE_SITE_KEY);
   const form = useForm<BugReportForm>({
     resolver: standardSchemaResolver(schema),
     defaultValues: {
-      whatHappened: emptyRichTextValue(),
-      steps: emptyRichTextValue(),
+      name: "",
       area: areaForPathname(pathname),
+      whatHappened: emptyRichTextValue(),
+      turnstileToken: "",
     },
     mode: "onChange",
   });
 
-  const onSubmit = form.handleSubmit((values) => {
+  const submitDirect = form.handleSubmit(async (values) => {
     const whatHappened = tiptapToRichBlocks(values.whatHappened);
-    const steps = tiptapToRichBlocks(values.steps);
-    const url = buildBugReportUrl({
-      title: issueTitle(
-        "fix(bug,via app):",
-        richBlocksToText(whatHappened)[0] ?? "",
-      ),
+    const summary = richBlocksToText(whatHappened)[0] ?? "";
+
+    const result = await submitFeedback({
+      kind: "bug",
+      name: values.name,
+      turnstileToken: values.turnstileToken,
+      summary: summary.slice(0, 120),
       whatHappened: richBlocksToMarkdown(whatHappened),
-      steps: richBlocksToMarkdown(steps),
+      area: values.area,
+    });
+    if (!result.ok) {
+      // Turnstile tokens are single-use; remount the widget for a fresh one.
+      form.setValue("turnstileToken", "");
+      setTurnstileEpoch((epoch) => epoch + 1);
+      toast.error(td("errorToast"));
+      return;
+    }
+    toast.success(td("sentToast"));
+    props.onSubmitted();
+  });
+
+  // Unvalidated: GitHub's issue template enforces its own required fields.
+  function openGitHubIssue() {
+    const values = form.getValues();
+    const whatHappened = tiptapToRichBlocks(values.whatHappened);
+    const summary = richBlocksToText(whatHappened)[0] ?? "";
+    const url = buildBugReportUrl({
+      title: summary ? issueTitle("fix(bug,via app):", summary) : "",
+      whatHappened: richBlocksToMarkdown(whatHappened),
       area: values.area,
     });
     window.open(url, "_blank", "noopener,noreferrer");
     props.onSubmitted();
-  });
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    if (directEnabled) {
+      void submitDirect(event);
+      return;
+    }
+    event.preventDefault();
+    openGitHubIssue();
+  }
 
   return (
-    <form onSubmit={onSubmit}>
-      <FieldGroup>
-        <Controller
-          control={form.control}
-          name="whatHappened"
-          render={({ field, fieldState }) => (
-            <Field data-invalid={fieldState.invalid}>
-              <FieldLabel htmlFor="bug-report-what-happened">
-                {t("whatHappened")}
-              </FieldLabel>
-              <RichTextEditor
-                id="bug-report-what-happened"
-                features={PROSE_FEATURES}
-                placeholder={t("whatHappenedPlaceholder")}
-                value={field.value}
-                onChange={field.onChange}
-                onBlur={field.onBlur}
-              />
-              <FieldError errors={[fieldState.error]} />
-            </Field>
+    <form
+      onSubmit={handleSubmit}
+      className="md:grid md:min-h-0 md:flex-1 md:grid-rows-[minmax(0,1fr)_auto]"
+    >
+      <ScrollArea className="md:-mr-2 md:min-h-0 md:pr-2">
+        <FieldGroup className="px-1 py-2">
+          {directEnabled && (
+            <Controller
+              control={form.control}
+              name="name"
+              render={({ field, fieldState }) => (
+                <Field data-invalid={fieldState.invalid}>
+                  <FieldLabel htmlFor="bug-report-name">
+                    {td("name")}
+                  </FieldLabel>
+                  <Input
+                    id="bug-report-name"
+                    placeholder={td("namePlaceholder")}
+                    value={field.value}
+                    onChange={field.onChange}
+                    onBlur={field.onBlur}
+                  />
+                  <FieldDescription>{td("nameDescription")}</FieldDescription>
+                  <FieldError errors={[fieldState.error]} />
+                </Field>
+              )}
+            />
           )}
-        />
 
-        <Controller
-          control={form.control}
-          name="steps"
-          render={({ field }) => (
-            <Field>
-              <FieldLabel htmlFor="bug-report-steps">{t("steps")}</FieldLabel>
-              <RichTextEditor
-                id="bug-report-steps"
-                features={PROSE_FEATURES}
-                placeholder={t("stepsPlaceholder")}
-                value={field.value}
-                onChange={field.onChange}
-                onBlur={field.onBlur}
-              />
-              <FieldDescription>{t("stepsDescription")}</FieldDescription>
-            </Field>
-          )}
-        />
-
-        <Controller
-          control={form.control}
-          name="area"
-          render={({ field }) => (
-            <Field>
-              <FieldLabel>{t("area")}</FieldLabel>
-              <Select
-                value={field.value}
-                onValueChange={(value) => field.onChange(value)}
-              >
-                <SelectTrigger className="w-full">
-                  <SelectValue placeholder={t("areaPlaceholder")} />
-                </SelectTrigger>
-                <SelectContent
-                  alignItemWithTrigger={false}
-                  align="start"
-                  className="w-[--anchor-width]"
+          <Controller
+            control={form.control}
+            name="area"
+            render={({ field }) => (
+              <Field>
+                <FieldLabel>{t("area")}</FieldLabel>
+                <Select
+                  value={field.value}
+                  onValueChange={(value) => field.onChange(value)}
                 >
-                  <SelectGroup>
-                    {BUG_AREAS.map((area) => (
-                      <SelectItem key={area} value={area}>
-                        {area}
-                      </SelectItem>
-                    ))}
-                  </SelectGroup>
-                </SelectContent>
-              </Select>
-            </Field>
-          )}
-        />
-      </FieldGroup>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder={t("areaPlaceholder")} />
+                  </SelectTrigger>
+                  <SelectContent
+                    alignItemWithTrigger={false}
+                    align="start"
+                    className="w-[--anchor-width]"
+                  >
+                    <SelectGroup>
+                      {BUG_AREAS.map((area) => (
+                        <SelectItem key={area} value={area}>
+                          {area}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+              </Field>
+            )}
+          />
 
-      <ResponsiveDialogFooter className="mt-6">
+          <Controller
+            control={form.control}
+            name="whatHappened"
+            render={({ field, fieldState }) => (
+              <Field data-invalid={fieldState.invalid}>
+                <FieldLabel htmlFor="bug-report-what-happened">
+                  {t("whatHappened")}
+                </FieldLabel>
+                <RichTextEditor
+                  id="bug-report-what-happened"
+                  features={PROSE_FEATURES}
+                  placeholder={t("whatHappenedPlaceholder")}
+                  value={field.value}
+                  onChange={field.onChange}
+                  onBlur={field.onBlur}
+                />
+                <FieldDescription>
+                  {t("whatHappenedDescription")}
+                </FieldDescription>
+                <FieldError errors={[fieldState.error]} />
+              </Field>
+            )}
+          />
+
+          {directEnabled && (
+            <Controller
+              control={form.control}
+              name="turnstileToken"
+              render={({ field, fieldState }) => (
+                <Field data-invalid={fieldState.invalid}>
+                  <Turnstile
+                    key={turnstileEpoch}
+                    onToken={(token) => field.onChange(token ?? "")}
+                  />
+                  <FieldError errors={[fieldState.error]} />
+                </Field>
+              )}
+            />
+          )}
+
+          {directEnabled && (
+            <Button
+              type="button"
+              variant="link"
+              className="h-auto self-start p-0"
+              disabled={form.formState.isSubmitting}
+              onClick={openGitHubIssue}
+            >
+              <ExternalLink /> {td("githubAlt")}
+            </Button>
+          )}
+        </FieldGroup>
+      </ScrollArea>
+
+      <ResponsiveDialogFooter className="mt-4 border-t pt-4 md:shrink-0">
         <ResponsiveDialogClose type="button" variant="outline">
           <XIcon /> {tc("cancel")}
         </ResponsiveDialogClose>
-        <Button type="submit">
-          <ExternalLink />
-          {tc("openIssue")}
-        </Button>
+        {directEnabled ? (
+          <Button type="submit" disabled={form.formState.isSubmitting}>
+            {form.formState.isSubmitting ? <Spinner /> : <SendIcon />}
+            {td("send")}
+          </Button>
+        ) : (
+          <Button type="submit">
+            <ExternalLink />
+            {tc("openIssue")}
+          </Button>
+        )}
       </ResponsiveDialogFooter>
     </form>
   );

--- a/src/components/platform/platform-feature-request-dialog.tsx
+++ b/src/components/platform/platform-feature-request-dialog.tsx
@@ -9,6 +9,7 @@ import {
   ResponsiveDialogHeader,
   ResponsiveDialogTitle,
 } from "../shared/responsive-dialog";
+import { TURNSTILE_SITE_KEY } from "../shared/turnstile";
 import { PlatformFeatureRequestForm } from "./platform-feature-request-form";
 
 /**
@@ -26,11 +27,11 @@ export function PlatformFeatureRequestDialog() {
       open={open === "feature"}
       onOpenChange={(next) => setOpen(next ? "feature" : null)}
     >
-      <ResponsiveDialogContent className="sm:max-w-lg">
-        <ResponsiveDialogHeader>
+      <ResponsiveDialogContent className="flex max-h-[min(35rem,calc(100dvh-3rem))] flex-col gap-4 overflow-hidden sm:max-w-lg">
+        <ResponsiveDialogHeader className="md:shrink-0">
           <ResponsiveDialogTitle>{t("title")}</ResponsiveDialogTitle>
           <ResponsiveDialogDescription className="text-balance">
-            {t("description")}
+            {t(TURNSTILE_SITE_KEY ? "description" : "descriptionGitHubOnly")}
           </ResponsiveDialogDescription>
         </ResponsiveDialogHeader>
 

--- a/src/components/platform/platform-feature-request-form.tsx
+++ b/src/components/platform/platform-feature-request-form.tsx
@@ -1,17 +1,22 @@
 "use client";
 
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
-import { ExternalLink, XIcon } from "lucide-react";
+import { ExternalLink, SendIcon, XIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useMemo } from "react";
+import { type FormEvent, useMemo, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
+import { toast } from "sonner";
 import { useValidationTranslator } from "@/hooks/use-validation-translator";
 import {
   createFeatureRequestSchema,
   FEATURE_LAYERS,
   type FeatureRequestForm,
 } from "@/lib/forms/feature-request";
-import { buildFeatureRequestUrl, issueTitle } from "@/lib/github-issue";
+import {
+  buildFeatureRequestUrl,
+  issueTitle,
+  submitFeedback,
+} from "@/lib/github-issue";
 import { emptyRichTextValue } from "@/lib/resume";
 import { PROSE_FEATURES } from "@/lib/resume/schema-registry";
 import {
@@ -24,6 +29,7 @@ import {
   ResponsiveDialogClose,
   ResponsiveDialogFooter,
 } from "../shared/responsive-dialog";
+import { TURNSTILE_SITE_KEY, Turnstile } from "../shared/turnstile";
 import { Button } from "../ui/button";
 import {
   Field,
@@ -32,6 +38,8 @@ import {
   FieldGroup,
   FieldLabel,
 } from "../ui/field";
+import { Input } from "../ui/input";
+import { ScrollArea } from "../ui/scroll-area";
 import {
   Select,
   SelectContent,
@@ -40,6 +48,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "../ui/select";
+import { Spinner } from "../ui/spinner";
 
 interface PlatformFeatureRequestFormProps {
   onSubmitted: () => void;
@@ -50,117 +59,196 @@ export function PlatformFeatureRequestForm(
 ) {
   const t = useTranslations("forms.feature");
   const tc = useTranslations("forms.common");
+  const td = useTranslations("forms.direct");
   const tv = useValidationTranslator();
   const schema = useMemo(() => createFeatureRequestSchema(tv), [tv]);
+  const [turnstileEpoch, setTurnstileEpoch] = useState(0);
+  const directEnabled = Boolean(TURNSTILE_SITE_KEY);
   const form = useForm<FeatureRequestForm>({
     resolver: standardSchemaResolver(schema),
     defaultValues: {
-      problem: emptyRichTextValue(),
-      proposal: emptyRichTextValue(),
+      name: "",
       layer: "Other / not sure",
+      problem: emptyRichTextValue(),
+      turnstileToken: "",
     },
     mode: "onChange",
   });
 
-  const onSubmit = form.handleSubmit((values) => {
+  const submitDirect = form.handleSubmit(async (values) => {
     const problem = tiptapToRichBlocks(values.problem);
-    const proposal = tiptapToRichBlocks(values.proposal);
-    const url = buildFeatureRequestUrl({
-      title: issueTitle("feat(via app):", richBlocksToText(proposal)[0] ?? ""),
+    const summary = richBlocksToText(problem)[0] ?? "";
+
+    const result = await submitFeedback({
+      kind: "feature",
+      name: values.name,
+      turnstileToken: values.turnstileToken,
+      summary: summary.slice(0, 120),
       problem: richBlocksToMarkdown(problem),
-      proposal: richBlocksToMarkdown(proposal),
+      layer: values.layer,
+    });
+    if (!result.ok) {
+      // Turnstile tokens are single-use; remount the widget for a fresh one.
+      form.setValue("turnstileToken", "");
+      setTurnstileEpoch((epoch) => epoch + 1);
+      toast.error(td("errorToast"));
+      return;
+    }
+    toast.success(td("sentToast"));
+    props.onSubmitted();
+  });
+
+  // Unvalidated: GitHub's issue template enforces its own required fields.
+  function openGitHubIssue() {
+    const values = form.getValues();
+    const problem = tiptapToRichBlocks(values.problem);
+    const summary = richBlocksToText(problem)[0] ?? "";
+    const url = buildFeatureRequestUrl({
+      title: summary ? issueTitle("feat(via app):", summary) : "",
+      problem: richBlocksToMarkdown(problem),
       layer: values.layer,
     });
     window.open(url, "_blank", "noopener,noreferrer");
     props.onSubmitted();
-  });
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    if (directEnabled) {
+      void submitDirect(event);
+      return;
+    }
+    event.preventDefault();
+    openGitHubIssue();
+  }
 
   return (
-    <form onSubmit={onSubmit}>
-      <FieldGroup>
-        <Controller
-          control={form.control}
-          name="problem"
-          render={({ field, fieldState }) => (
-            <Field data-invalid={fieldState.invalid}>
-              <FieldLabel htmlFor="feature-request-problem">
-                {t("problem")}
-              </FieldLabel>
-              <RichTextEditor
-                id="feature-request-problem"
-                features={PROSE_FEATURES}
-                placeholder={t("problemPlaceholder")}
-                value={field.value}
-                onChange={field.onChange}
-                onBlur={field.onBlur}
-              />
-              <FieldDescription>{t("problemDescription")}</FieldDescription>
-              <FieldError errors={[fieldState.error]} />
-            </Field>
+    <form
+      onSubmit={handleSubmit}
+      className="md:grid md:min-h-0 md:flex-1 md:grid-rows-[minmax(0,1fr)_auto]"
+    >
+      <ScrollArea className="md:-mr-2 md:min-h-0 md:pr-2">
+        <FieldGroup className="px-1 py-2">
+          {directEnabled && (
+            <Controller
+              control={form.control}
+              name="name"
+              render={({ field, fieldState }) => (
+                <Field data-invalid={fieldState.invalid}>
+                  <FieldLabel htmlFor="feature-request-name">
+                    {td("name")}
+                  </FieldLabel>
+                  <Input
+                    id="feature-request-name"
+                    placeholder={td("namePlaceholder")}
+                    value={field.value}
+                    onChange={field.onChange}
+                    onBlur={field.onBlur}
+                  />
+                  <FieldDescription>{td("nameDescription")}</FieldDescription>
+                  <FieldError errors={[fieldState.error]} />
+                </Field>
+              )}
+            />
           )}
-        />
 
-        <Controller
-          control={form.control}
-          name="proposal"
-          render={({ field, fieldState }) => (
-            <Field data-invalid={fieldState.invalid}>
-              <FieldLabel htmlFor="feature-request-proposal">
-                {t("proposal")}
-              </FieldLabel>
-              <RichTextEditor
-                id="feature-request-proposal"
-                features={PROSE_FEATURES}
-                placeholder={t("proposalPlaceholder")}
-                value={field.value}
-                onChange={field.onChange}
-                onBlur={field.onBlur}
-              />
-              <FieldError errors={[fieldState.error]} />
-            </Field>
-          )}
-        />
-
-        <Controller
-          control={form.control}
-          name="layer"
-          render={({ field }) => (
-            <Field>
-              <FieldLabel>{t("layer")}</FieldLabel>
-              <Select
-                value={field.value}
-                onValueChange={(value) => field.onChange(value)}
-              >
-                <SelectTrigger className="w-full">
-                  <SelectValue placeholder={t("layerPlaceholder")} />
-                </SelectTrigger>
-                <SelectContent
-                  alignItemWithTrigger={false}
-                  align="start"
-                  className="w-[--anchor-width]"
+          <Controller
+            control={form.control}
+            name="layer"
+            render={({ field }) => (
+              <Field>
+                <FieldLabel>{t("layer")}</FieldLabel>
+                <Select
+                  value={field.value}
+                  onValueChange={(value) => field.onChange(value)}
                 >
-                  <SelectGroup>
-                    {FEATURE_LAYERS.map((layer) => (
-                      <SelectItem key={layer} value={layer}>
-                        {layer}
-                      </SelectItem>
-                    ))}
-                  </SelectGroup>
-                </SelectContent>
-              </Select>
-            </Field>
-          )}
-        />
-      </FieldGroup>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder={t("layerPlaceholder")} />
+                  </SelectTrigger>
+                  <SelectContent
+                    alignItemWithTrigger={false}
+                    align="start"
+                    className="w-[--anchor-width]"
+                  >
+                    <SelectGroup>
+                      {FEATURE_LAYERS.map((layer) => (
+                        <SelectItem key={layer} value={layer}>
+                          {layer}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+              </Field>
+            )}
+          />
 
-      <ResponsiveDialogFooter className="mt-6">
+          <Controller
+            control={form.control}
+            name="problem"
+            render={({ field, fieldState }) => (
+              <Field data-invalid={fieldState.invalid}>
+                <FieldLabel htmlFor="feature-request-problem">
+                  {t("problem")}
+                </FieldLabel>
+                <RichTextEditor
+                  id="feature-request-problem"
+                  features={PROSE_FEATURES}
+                  placeholder={t("problemPlaceholder")}
+                  value={field.value}
+                  onChange={field.onChange}
+                  onBlur={field.onBlur}
+                />
+                <FieldDescription>{t("problemDescription")}</FieldDescription>
+                <FieldError errors={[fieldState.error]} />
+              </Field>
+            )}
+          />
+
+          {directEnabled && (
+            <Controller
+              control={form.control}
+              name="turnstileToken"
+              render={({ field, fieldState }) => (
+                <Field data-invalid={fieldState.invalid}>
+                  <Turnstile
+                    key={turnstileEpoch}
+                    onToken={(token) => field.onChange(token ?? "")}
+                  />
+                  <FieldError errors={[fieldState.error]} />
+                </Field>
+              )}
+            />
+          )}
+
+          {directEnabled && (
+            <Button
+              type="button"
+              variant="link"
+              className="h-auto self-start p-0"
+              disabled={form.formState.isSubmitting}
+              onClick={openGitHubIssue}
+            >
+              <ExternalLink /> {td("githubAlt")}
+            </Button>
+          )}
+        </FieldGroup>
+      </ScrollArea>
+
+      <ResponsiveDialogFooter className="mt-4 border-t pt-4 md:shrink-0">
         <ResponsiveDialogClose type="button" variant="outline">
           <XIcon /> {tc("cancel")}
         </ResponsiveDialogClose>
-        <Button type="submit">
-          <ExternalLink />
-          {tc("openIssue")}
-        </Button>
+        {directEnabled ? (
+          <Button type="submit" disabled={form.formState.isSubmitting}>
+            {form.formState.isSubmitting ? <Spinner /> : <SendIcon />}
+            {td("send")}
+          </Button>
+        ) : (
+          <Button type="submit">
+            <ExternalLink />
+            {tc("openIssue")}
+          </Button>
+        )}
       </ResponsiveDialogFooter>
     </form>
   );

--- a/src/components/shared/turnstile.tsx
+++ b/src/components/shared/turnstile.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useLocale } from "next-intl";
+import { useTheme } from "next-themes";
+import { useEffect, useRef } from "react";
+
+/** Inlined at build time; when absent, direct feedback submission is disabled. */
+export const TURNSTILE_SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
+
+const SCRIPT_SRC =
+  "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+
+interface TurnstileApi {
+  render: (container: HTMLElement, params: Record<string, unknown>) => string;
+  remove: (widgetId: string) => void;
+}
+
+declare global {
+  interface Window {
+    turnstile?: TurnstileApi;
+  }
+}
+
+let scriptPromise: Promise<void> | null = null;
+
+function loadTurnstileScript(): Promise<void> {
+  if (window.turnstile) return Promise.resolve();
+  if (scriptPromise) return scriptPromise;
+  scriptPromise = new Promise((resolve, reject) => {
+    const script = document.createElement("script");
+    script.src = SCRIPT_SRC;
+    script.async = true;
+    script.onload = () => resolve();
+    script.onerror = () => {
+      scriptPromise = null;
+      reject(new Error("Failed to load the Turnstile script"));
+    };
+    document.head.append(script);
+  });
+  return scriptPromise;
+}
+
+interface TurnstileProps {
+  onToken: (token: string | null) => void;
+}
+
+export function Turnstile(props: TurnstileProps) {
+  const locale = useLocale();
+  const { resolvedTheme } = useTheme();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const onTokenRef = useRef(props.onToken);
+
+  useEffect(() => {
+    onTokenRef.current = props.onToken;
+  });
+
+  useEffect(() => {
+    if (!TURNSTILE_SITE_KEY) return;
+    let widgetId: string | undefined;
+    let cancelled = false;
+
+    loadTurnstileScript()
+      .then(() => {
+        if (cancelled || !containerRef.current || !window.turnstile) return;
+        widgetId = window.turnstile.render(containerRef.current, {
+          sitekey: TURNSTILE_SITE_KEY,
+          size: "flexible",
+          theme: resolvedTheme === "dark" ? "dark" : "light",
+          language: locale,
+          callback: (token: string) => onTokenRef.current(token),
+          "expired-callback": () => onTokenRef.current(null),
+          "error-callback": () => onTokenRef.current(null),
+        });
+      })
+      .catch(() => onTokenRef.current(null));
+
+    return () => {
+      cancelled = true;
+      if (widgetId !== undefined) window.turnstile?.remove(widgetId);
+    };
+  }, [locale, resolvedTheme]);
+
+  return <div ref={containerRef} className="min-h-[65px]" />;
+}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -9,6 +9,7 @@ export interface ChangelogEntry {
  * with dots replaced by underscores, as a list of { title, description }.
  */
 export const CHANGELOG: ChangelogEntry[] = [
+  { version: "0.10.0", date: "2026-07-17" },
   { version: "0.9.0", date: "2026-07-14" },
   { version: "0.8.0", date: "2026-07-11" },
   { version: "0.7.0", date: "2026-07-10" },

--- a/src/lib/forms/bug-report.ts
+++ b/src/lib/forms/bug-report.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { requiredRichTextDoc, richTextDoc } from "./rich-text";
+import { requiredRichTextDoc } from "./rich-text";
 
 type Translator = (key: string) => string;
 
@@ -16,9 +16,10 @@ export const BUG_AREAS = [
 
 export function createBugReportSchema(t: Translator) {
   return z.object({
-    whatHappened: requiredRichTextDoc(t("bugWhatHappened")),
-    steps: richTextDoc,
+    name: z.string().trim().min(1, t("reporterNameRequired")).max(80),
     area: z.enum(BUG_AREAS),
+    whatHappened: requiredRichTextDoc(t("bugWhatHappened")),
+    turnstileToken: z.string().min(1, t("verificationRequired")),
   });
 }
 

--- a/src/lib/forms/feature-request.ts
+++ b/src/lib/forms/feature-request.ts
@@ -13,9 +13,10 @@ export const FEATURE_LAYERS = [
 
 export function createFeatureRequestSchema(t: Translator) {
   return z.object({
-    problem: requiredRichTextDoc(t("featureProblem")),
-    proposal: requiredRichTextDoc(t("featureProposal")),
+    name: z.string().trim().min(1, t("reporterNameRequired")).max(80),
     layer: z.enum(FEATURE_LAYERS),
+    problem: requiredRichTextDoc(t("featureProblem")),
+    turnstileToken: z.string().min(1, t("verificationRequired")),
   });
 }
 

--- a/src/lib/forms/feedback.ts
+++ b/src/lib/forms/feedback.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { BUG_AREAS } from "./bug-report";
+import { FEATURE_LAYERS } from "./feature-request";
+
+const reporterName = z.string().trim().min(1).max(80);
+const summary = z.string().trim().min(1).max(120);
+const requiredMarkdown = z.string().trim().min(1).max(8000);
+
+/** Wire format for POST /api/feedback; validated again on the server. */
+export const feedbackPayloadSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("bug"),
+    name: reporterName,
+    turnstileToken: z.string().min(1),
+    summary,
+    whatHappened: requiredMarkdown,
+    area: z.enum(BUG_AREAS),
+  }),
+  z.object({
+    kind: z.literal("feature"),
+    name: reporterName,
+    turnstileToken: z.string().min(1),
+    summary,
+    problem: requiredMarkdown,
+    layer: z.enum(FEATURE_LAYERS),
+  }),
+]);
+
+export type FeedbackPayload = z.infer<typeof feedbackPayloadSchema>;

--- a/src/lib/github-issue.ts
+++ b/src/lib/github-issue.ts
@@ -1,20 +1,21 @@
 import type { BUG_AREAS } from "./forms/bug-report";
 import type { FEATURE_LAYERS } from "./forms/feature-request";
+import type { FeedbackPayload } from "./forms/feedback";
 
-const NEW_ISSUE_URL = "https://github.com/rimzzlabs/lanjut/issues/new";
+export const GITHUB_REPO = "rimzzlabs/lanjut";
+
+const NEW_ISSUE_URL = `https://github.com/${GITHUB_REPO}/issues/new`;
 const TITLE_SUBJECT_MAX_LENGTH = 72;
 
 export interface BugReportIssue {
   title: string;
   whatHappened: string;
-  steps: string;
   area: (typeof BUG_AREAS)[number];
 }
 
 export interface FeatureRequestIssue {
   title: string;
   problem: string;
-  proposal: string;
   layer: (typeof FEATURE_LAYERS)[number];
 }
 
@@ -53,7 +54,6 @@ export function buildBugReportUrl(issue: BugReportIssue): string {
     template: "bug-report.yml",
     title: issue.title,
     "what-happened": issue.whatHappened,
-    steps: issue.steps,
     area: issue.area,
     browser: navigator.userAgent,
   });
@@ -64,7 +64,29 @@ export function buildFeatureRequestUrl(issue: FeatureRequestIssue): string {
     template: "feature-request.yml",
     title: issue.title,
     problem: issue.problem,
-    proposal: issue.proposal,
     layer: issue.layer,
   });
+}
+
+export interface FeedbackResult {
+  ok: boolean;
+  url?: string;
+}
+
+/** Files the issue server-side on behalf of the reporter; no GitHub account needed. */
+export async function submitFeedback(
+  payload: FeedbackPayload,
+): Promise<FeedbackResult> {
+  try {
+    const response = await fetch("/api/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) return { ok: false };
+    const data = (await response.json()) as { url?: string };
+    return { ok: true, url: data.url };
+  } catch {
+    return { ok: false };
+  }
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,5 +6,5 @@ import { routing } from "@/i18n/routing";
 export default createMiddleware(routing);
 
 export const config = {
-  matcher: ["/((?!_next|.*\\..*).*)"],
+  matcher: ["/((?!api|_next|.*\\..*).*)"],
 };


### PR DESCRIPTION
The "Report a bug" and "Request a feature" dialogs previously only opened a prefilled GitHub issue, which dead-ends for anyone without a GitHub account. They now submit directly: a new `POST /api/feedback` route on the worker verifies a Cloudflare Turnstile token, then files the issue via the GitHub API on the reporter's behalf, attributed to the name they provide. The prefilled-issue flow remains as an unvalidated link for people who prefer their own account, and the whole direct path disappears gracefully when the Turnstile site key is absent (forks, contributor dev).

Form and template changes along the way: the bug form's steps field merged into "What happened?", name and dropdowns render before the rich text editor, the dialogs cap at a fixed height with the fields in a ScrollArea and a pinned footer, and both issue templates were slimmed to mirror the forms so prefilled drafts land cleanly.

Per the data-flow rule: only the feedback text, reporter name, and Turnstile token are posted; no resume content is sent anywhere. The i18n middleware matcher now excludes `/api`.

Deploy needs three bindings, all documented in the route: `GITHUB_ISSUE_TOKEN` and `TURNSTILE_SECRET_KEY` as worker secrets, and `NEXT_PUBLIC_TURNSTILE_SITE_KEY` as a repo Actions variable consumed by the release build.

Tested by driving both dialogs end to end: validation blocks an empty direct send with per-field messages, a verified send reaches the GitHub call (exercised against a placeholder token returning an error, which surfaces the retry toast and a fresh Turnstile widget), the empty-form GitHub link opens the prefilled template, and the dialogs stay within short viewports with the fields scrolling behind the pinned footer in both locales.