### PR TITLE
fix: align create-dialog template order with the browse page

### DIFF
--- a/src/components/platform/platform-template-radio-group.tsx
+++ b/src/components/platform/platform-template-radio-group.tsx
@@ -7,12 +7,15 @@ import { resumeToPreview } from "@/components/editor/resume-to-preview";
 import { RadioGroup } from "@/components/ui/radio-group";
 import { SEED_RESUME } from "@/lib/resume";
 import {
+  DEFAULT_TEMPLATE_SORT,
+  sortTemplates,
   TEMPLATES,
   type TemplateId,
   type TemplateSummary,
 } from "@/lib/templates";
 
 const SEED_PREVIEW = resumeToPreview(SEED_RESUME);
+const SORTED_TEMPLATES = sortTemplates(TEMPLATES, DEFAULT_TEMPLATE_SORT);
 
 const DOTTED_SURFACE =
   "bg-[radial-gradient(color-mix(in_oklab,var(--color-foreground)_7%,transparent)_1px,transparent_1px)] bg-size-[0.5rem_0.5rem]";
@@ -31,7 +34,7 @@ export function PlatformTemplateRadioGroup(
       onValueChange={(value) => props.onValueChange(value as TemplateId)}
       className="grid grid-cols-2 gap-2.5 sm:grid-cols-3"
     >
-      {TEMPLATES.map((template) => (
+      {SORTED_TEMPLATES.map((template) => (
         <PlatformTemplateRadioCard key={template.id} template={template} />
       ))}
     </RadioGroup>

--- a/src/hooks/use-template-search.ts
+++ b/src/hooks/use-template-search.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { parseAsString, parseAsStringLiteral, useQueryState } from "nuqs";
-import { TEMPLATE_SORTS } from "@/lib/templates";
+import { DEFAULT_TEMPLATE_SORT, TEMPLATE_SORTS } from "@/lib/templates";
 
 /**
  * Browse-Templates search query, held in the `q` URL param so it survives reload
@@ -21,7 +21,7 @@ export function useTemplateSort() {
   return useQueryState(
     "sort",
     parseAsStringLiteral(TEMPLATE_SORTS)
-      .withDefault("name-asc")
+      .withDefault(DEFAULT_TEMPLATE_SORT)
       .withOptions({ clearOnDefault: true }),
   );
 }

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -36,6 +36,9 @@ export const TEMPLATE_SORTS: TemplateSort[] = [
   "newest",
 ];
 
+/** Shared by the Browse Templates page and the create dialog, so both list templates in the same order. */
+export const DEFAULT_TEMPLATE_SORT: TemplateSort = "name-asc";
+
 export const TEMPLATES: TemplateSummary[] = [
   { id: "awal", name: "Awal", addedAt: "2026-01-01T00:00:00.000Z" },
   { id: "ketat", name: "Ketat", addedAt: "2026-07-04T00:00:00.000Z" },


### PR DESCRIPTION
The create dialog rendered the raw `TEMPLATES` catalog while the Browse Templates page sorts by name (A to Z) by default, so the same six templates appeared in two different orders. The default sort now lives in a single `DEFAULT_TEMPLATE_SORT` constant in the templates lib, consumed by both the page's sort param and the dialog's radio group, so the two surfaces cannot drift again.

Tested by opening the Browse Templates page and the create dialog side by side and confirming both list Awal, Ketat, Ketik, Klasik, Luasa, Tebal in that order.