### PR TITLE
feat: toggle section visibility from the editor list

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -172,6 +172,10 @@
           {
             "title": "JSON and YAML export and import",
             "description": "Copy or download your resume as JSON or YAML, and import either back losslessly. Rich text travels as simple markdown."
+          },
+          {
+            "title": "Hide sections",
+            "description": "Every section, Summary included, now has an eye toggle in the editor list. Hidden sections keep their content but drop out of the preview and every export until you show them again."
           }
         ],
         "0_9_0": [

--- a/messages/id.json
+++ b/messages/id.json
@@ -172,6 +172,10 @@
           {
             "title": "Ekspor dan impor JSON dan YAML",
             "description": "Salin atau unduh resume kamu sebagai JSON atau YAML, dan impor keduanya kembali tanpa kehilangan apa pun. Teks kaya dibawa sebagai markdown sederhana."
+          },
+          {
+            "title": "Sembunyikan bagian",
+            "description": "Setiap bagian, termasuk Ringkasan, sekarang punya toggle mata di daftar editor. Bagian yang disembunyikan tetap menyimpan isinya tapi hilang dari pratinjau dan semua ekspor sampai kamu tampilkan lagi."
           }
         ],
         "0_9_0": [

--- a/src/components/editor/editor-section-visibility-toggle.tsx
+++ b/src/components/editor/editor-section-visibility-toggle.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { Eye, EyeOff } from "lucide-react";
+import { Eye, EyeClosed } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { Button } from "../ui/button";
 
 interface EditorSectionVisibilityToggleProps {
   hidden: boolean;
@@ -13,20 +14,18 @@ export function EditorSectionVisibilityToggle({
   onToggle,
 }: EditorSectionVisibilityToggleProps) {
   const t = useTranslations("editor.chrome");
-  const Icon = hidden ? EyeOff : Eye;
+  const Icon = hidden ? EyeClosed : Eye;
+
   return (
-    // biome-ignore lint/a11y/useKeyWithClickEvents: ignore
-    // biome-ignore lint/a11y/useSemanticElements: ignore
-    <div
-      role="button"
-      tabIndex={0}
-      aria-roledescription="Toggle"
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      type="button"
       onClick={onToggle}
       aria-pressed={hidden}
       aria-label={hidden ? t("showSection") : t("hideSection")}
-      className="rounded p-1 text-muted-foreground/70 transition-colors hover:text-foreground"
     >
-      <Icon className="size-5" />
-    </div>
+      <Icon className="size-4 stroke-muted-foreground" />
+    </Button>
   );
 }

--- a/src/components/editor/editor-sections/ed-section-certifications/ed-section-certifications.tsx
+++ b/src/components/editor/editor-sections/ed-section-certifications/ed-section-certifications.tsx
@@ -5,16 +5,19 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import { EditorSectionVisibility } from "../ed-section-visibility";
 import { EditorSectionCertificationsForm } from "./ed-section-certifications-form";
 
 export function EditorSectionCertifications() {
   const t = useTranslations("editor.certifications");
 
   return (
-    <AccordionItem>
+    <AccordionItem className="relative">
       <AccordionTrigger className="items-center gap-3">
         <Award className="size-4" /> {t("accordionTitle")}
       </AccordionTrigger>
+
+      <EditorSectionVisibility type="certifications" />
 
       <AccordionContent>
         <EditorSectionCertificationsForm />

--- a/src/components/editor/editor-sections/ed-section-custom/ed-section-custom.tsx
+++ b/src/components/editor/editor-sections/ed-section-custom/ed-section-custom.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/accordion";
 import type { CustomVariant } from "@/lib/resume";
 import { useResumeStore } from "@/lib/store";
+import { EditorSectionVisibility } from "../ed-section-visibility";
 import { EditorSectionCustomBodyForm } from "./ed-section-custom-body-form";
 import { EditorSectionCustomListForm } from "./ed-section-custom-list-form";
 import { EditorSectionCustomMenu } from "./ed-section-custom-menu";
@@ -34,18 +35,19 @@ export function EditorSectionCustom(props: EditorSectionCustomProps) {
     <AccordionItem value={section.id} className="relative">
       <AccordionTrigger className="min-w-0 items-center gap-3">
         <Shapes className="size-4 shrink-0" />
-        {/* mr reserves room for the absolutely-positioned menu so the title
-            truncates before it, leaving order: title, menu, chevron. */}
+        {/* mr reserves room for the absolutely-positioned controls so the title
+            truncates before them, leaving order: title, toggle, menu, chevron. */}
         <TruncatedLabel
           text={label}
-          className="mr-9 min-w-0 flex-1 text-left"
+          className="mr-24 min-w-0 flex-1 text-left"
         />
       </AccordionTrigger>
 
-      {/* The menu sits in the trigger row (not nested in the trigger button, and
-          not inside the panel) so a section can be renamed or removed without
-          expanding it first. It is placed just left of the trigger's chevron. */}
-      <div className="absolute top-2.5 right-9 z-10">
+      {/* The controls sit in the trigger row (not nested in the trigger button,
+          and not inside the panel) so a section can be hidden, renamed, or
+          removed without expanding it first, just left of the trigger's chevron. */}
+      <div className="absolute top-2.5 right-9 z-10 flex items-center gap-1">
+        <EditorSectionVisibility sectionId={section.id} className="static" />
         <EditorSectionCustomMenu sectionId={section.id} title={section.title} />
       </div>
 

--- a/src/components/editor/editor-sections/ed-section-education/ed-section-education.tsx
+++ b/src/components/editor/editor-sections/ed-section-education/ed-section-education.tsx
@@ -5,16 +5,19 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import { EditorSectionVisibility } from "../ed-section-visibility";
 import { EditorSectionEducationForm } from "./ed-section-education-form";
 
 export function EditorSectionEducation() {
   const t = useTranslations("editor.education");
 
   return (
-    <AccordionItem>
+    <AccordionItem className="relative">
       <AccordionTrigger className="items-center gap-3">
         <GraduationCap className="size-4" /> {t("accordionTitle")}
       </AccordionTrigger>
+
+      <EditorSectionVisibility type="education" />
 
       <AccordionContent>
         <EditorSectionEducationForm />

--- a/src/components/editor/editor-sections/ed-section-experience/ed-section-experience.tsx
+++ b/src/components/editor/editor-sections/ed-section-experience/ed-section-experience.tsx
@@ -5,16 +5,19 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import { EditorSectionVisibility } from "../ed-section-visibility";
 import { EditorSectionExperienceForm } from "./ed-section-experience-form";
 
 export function EditorSectionExperience() {
   const t = useTranslations("editor.experience");
 
   return (
-    <AccordionItem>
+    <AccordionItem className="relative">
       <AccordionTrigger className="items-center gap-3">
         <BriefcaseBusiness className="size-4" /> {t("accordionTitle")}
       </AccordionTrigger>
+
+      <EditorSectionVisibility type="experience" />
 
       <AccordionContent>
         <EditorSectionExperienceForm />

--- a/src/components/editor/editor-sections/ed-section-internship/ed-section-internship.tsx
+++ b/src/components/editor/editor-sections/ed-section-internship/ed-section-internship.tsx
@@ -5,16 +5,19 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import { EditorSectionVisibility } from "../ed-section-visibility";
 import { EditorSectionInternshipForm } from "./ed-section-internship-form";
 
 export function EditorSectionInternship() {
   const t = useTranslations("editor.internship");
 
   return (
-    <AccordionItem>
+    <AccordionItem className="relative">
       <AccordionTrigger className="items-center gap-3">
         <Backpack className="size-4" /> {t("accordionTitle")}
       </AccordionTrigger>
+
+      <EditorSectionVisibility type="internship" />
 
       <AccordionContent>
         <EditorSectionInternshipForm />

--- a/src/components/editor/editor-sections/ed-section-languages/ed-section-languages.tsx
+++ b/src/components/editor/editor-sections/ed-section-languages/ed-section-languages.tsx
@@ -5,16 +5,19 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import { EditorSectionVisibility } from "../ed-section-visibility";
 import { EditorSectionLanguagesForm } from "./ed-section-languages-form";
 
 export function EditorSectionLanguages() {
   const t = useTranslations("editor.languages");
 
   return (
-    <AccordionItem>
+    <AccordionItem className="relative">
       <AccordionTrigger className="items-center gap-3">
         <Languages className="size-4" /> {t("accordionTitle")}
       </AccordionTrigger>
+
+      <EditorSectionVisibility type="languages" />
 
       <AccordionContent>
         <EditorSectionLanguagesForm />

--- a/src/components/editor/editor-sections/ed-section-organizations/ed-section-organizations.tsx
+++ b/src/components/editor/editor-sections/ed-section-organizations/ed-section-organizations.tsx
@@ -5,16 +5,19 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import { EditorSectionVisibility } from "../ed-section-visibility";
 import { EditorSectionOrganizationsForm } from "./ed-section-organizations-form";
 
 export function EditorSectionOrganizations() {
   const t = useTranslations("editor.organizations");
 
   return (
-    <AccordionItem>
+    <AccordionItem className="relative">
       <AccordionTrigger className="items-center gap-3">
         <Users className="size-4" /> {t("accordionTitle")}
       </AccordionTrigger>
+
+      <EditorSectionVisibility type="organizations" />
 
       <AccordionContent>
         <EditorSectionOrganizationsForm />

--- a/src/components/editor/editor-sections/ed-section-projects/ed-section-projects.tsx
+++ b/src/components/editor/editor-sections/ed-section-projects/ed-section-projects.tsx
@@ -5,16 +5,19 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import { EditorSectionVisibility } from "../ed-section-visibility";
 import { EditorSectionProjectsForm } from "./ed-section-projects-form";
 
 export function EditorSectionProjects() {
   const t = useTranslations("editor.projects");
 
   return (
-    <AccordionItem>
+    <AccordionItem className="relative">
       <AccordionTrigger className="items-center gap-3">
         <FolderGit2 className="size-4" /> {t("accordionTitle")}
       </AccordionTrigger>
+
+      <EditorSectionVisibility type="projects" />
 
       <AccordionContent>
         <EditorSectionProjectsForm />

--- a/src/components/editor/editor-sections/ed-section-skills/ed-section-skills.tsx
+++ b/src/components/editor/editor-sections/ed-section-skills/ed-section-skills.tsx
@@ -5,16 +5,19 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import { EditorSectionVisibility } from "../ed-section-visibility";
 import { EditorSectionSkillsForm } from "./ed-section-skills-form";
 
 export function EditorSectionSkills() {
   const t = useTranslations("editor.skills");
 
   return (
-    <AccordionItem>
+    <AccordionItem className="relative">
       <AccordionTrigger className="items-center gap-3">
         <Sparkles className="size-4" /> {t("accordionTitle")}
       </AccordionTrigger>
+
+      <EditorSectionVisibility type="skills" />
 
       <AccordionContent>
         <EditorSectionSkillsForm />

--- a/src/components/editor/editor-sections/ed-section-summary/ed-section-summary.tsx
+++ b/src/components/editor/editor-sections/ed-section-summary/ed-section-summary.tsx
@@ -5,16 +5,19 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import { EditorSectionVisibility } from "../ed-section-visibility";
 import { EditorSectionSummaryForm } from "./ed-section-summary-form";
 
 export function EditorSectionSummary() {
   const t = useTranslations("editor.summary");
 
   return (
-    <AccordionItem>
+    <AccordionItem className="relative">
       <AccordionTrigger className="items-center gap-3">
         <ScrollText className="size-4" /> {t("accordionTitle")}
       </AccordionTrigger>
+
+      <EditorSectionVisibility type="summary" />
 
       <AccordionContent>
         <EditorSectionSummaryForm />

--- a/src/components/editor/editor-sections/ed-section-visibility.tsx
+++ b/src/components/editor/editor-sections/ed-section-visibility.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { EditorSectionVisibilityToggle } from "@/components/editor/editor-section-visibility-toggle";
+import type { SectionType } from "@/lib/resume";
+import { useResumeStore } from "@/lib/store";
+import { cn } from "@/lib/utils";
+
+interface EditorSectionVisibilityProps {
+  /** Locates the section: by id for custom sections, by type for core ones. */
+  type?: SectionType;
+  sectionId?: string;
+  className?: string;
+}
+
+/**
+ * The per-section visibility toggle, placed in the accordion trigger row just
+ * left of the chevron. Like the custom-section menu, it sits absolutely
+ * positioned beside the trigger (never nested inside the trigger button) so
+ * toggling never expands or collapses the section.
+ */
+export function EditorSectionVisibility(props: EditorSectionVisibilityProps) {
+  const section = useResumeStore((state) =>
+    state.open?.sections.find((s) =>
+      props.sectionId ? s.id === props.sectionId : s.type === props.type,
+    ),
+  );
+  const toggleSectionVisibility = useResumeStore(
+    (state) => state.toggleSectionVisibility,
+  );
+  if (!section) return null;
+  return (
+    <div className={cn("absolute top-3 right-10 z-10", props.className)}>
+      <EditorSectionVisibilityToggle
+        hidden={section.hidden ?? false}
+        onToggle={() => toggleSectionVisibility(section.id)}
+      />
+    </div>
+  );
+}

--- a/src/components/editor/resume-to-preview.ts
+++ b/src/components/editor/resume-to-preview.ts
@@ -121,7 +121,10 @@ export function isResumePreviewEmpty(preview: ResumePreview): boolean {
  * components never read the storage schema directly.
  */
 export function resumeToPreview(resume: Resume): ResumePreview {
-  const summaryBody = sectionOfType(resume, "summary")?.entries[0]?.fields.body;
+  const summarySection = sectionOfType(resume, "summary");
+  const summaryBody = summarySection?.hidden
+    ? undefined
+    : summarySection?.entries[0]?.fields.body;
   const labels = RESUME_LABELS[resume.language];
   const localizeDates = <T extends { startDate: string; endDate: string }>(
     item: T,
@@ -131,8 +134,10 @@ export function resumeToPreview(resume: Resume): ResumePreview {
     endDate: localizeDateValue(item.endDate, labels.months, labels.present),
   });
 
+  // Hidden sections drop out of the emitted order entirely, so no renderer
+  // (preview, PDF, docx, plain text) ever sees their heading or entries.
   const sectionOrder = resume.sections
-    .filter((section) => isReorderableSection(section.type))
+    .filter((section) => isReorderableSection(section.type) && !section.hidden)
     .map((section) => ({
       type: section.type as ReorderableSectionType,
       id: section.id,

--- a/src/lib/interchange/codec.ts
+++ b/src/lib/interchange/codec.ts
@@ -57,6 +57,7 @@ function sectionToInterchange(section: Section): InterchangeSection {
     return {
       type: "summary",
       title: section.title,
+      hidden: section.hidden ?? false,
       body: fieldToString(section.entries[0]?.fields.body),
     };
   }
@@ -67,6 +68,7 @@ function sectionToInterchange(section: Section): InterchangeSection {
         type: "custom",
         variant,
         title: section.title,
+        hidden: section.hidden ?? false,
         body: fieldToString(section.entries[0]?.fields.body),
       };
     }
@@ -74,6 +76,7 @@ function sectionToInterchange(section: Section): InterchangeSection {
       type: "custom",
       variant,
       title: section.title,
+      hidden: section.hidden ?? false,
       entries: section.entries.map((entry) =>
         entryToValues(entry, CUSTOM_LIST_FIELDS),
       ),
@@ -83,6 +86,7 @@ function sectionToInterchange(section: Section): InterchangeSection {
   const base = {
     type: section.type,
     title: section.title,
+    hidden: section.hidden ?? false,
     entries: section.entries.map((entry) => entryToValues(entry, fields)),
   };
   if (section.type === "skills" || section.type === "languages") {
@@ -141,6 +145,7 @@ function interchangeToSection(item: InterchangeSection): Section {
   if (item.type === "summary") {
     const section = createEmptySection("summary");
     if (item.title) section.title = item.title;
+    if (item.hidden !== undefined) section.hidden = item.hidden;
     if (item.body !== undefined) {
       section.entries = [bodyEntry("summary", item.body)];
     }
@@ -149,6 +154,7 @@ function interchangeToSection(item: InterchangeSection): Section {
   if (item.type === "custom") {
     const variant = item.variant ?? "rich";
     const section = createCustomSection(variant, item.title || undefined);
+    if (item.hidden !== undefined) section.hidden = item.hidden;
     if (variant === "rich") {
       if (item.body !== undefined) {
         section.entries = [bodyEntry("custom", item.body)];
@@ -162,6 +168,7 @@ function interchangeToSection(item: InterchangeSection): Section {
   }
   const section = createEmptySection(item.type);
   if (item.title) section.title = item.title;
+  if (item.hidden !== undefined) section.hidden = item.hidden;
   const fields = getSectionSchema(item.type).fields;
   section.entries = (item.entries ?? []).map((values) =>
     fillEntry(createEmptyEntry(item.type), fields, values),

--- a/src/lib/interchange/schema.ts
+++ b/src/lib/interchange/schema.ts
@@ -34,6 +34,7 @@ function entryShape(fields: FieldSchema[]) {
 const summarySection = z.strictObject({
   type: z.literal("summary"),
   title: z.string().optional(),
+  hidden: z.boolean().optional(),
   body: scalarString.optional(),
 });
 
@@ -41,6 +42,7 @@ function listSection<T extends SectionType>(type: T) {
   return z.strictObject({
     type: z.literal(type),
     title: z.string().optional(),
+    hidden: z.boolean().optional(),
     entries: z.array(entryShape(SECTION_REGISTRY[type].fields)).optional(),
   });
 }
@@ -50,6 +52,7 @@ function gridSection<T extends SectionType>(type: T) {
   return z.strictObject({
     type: z.literal(type),
     title: z.string().optional(),
+    hidden: z.boolean().optional(),
     entries: z.array(entryShape(SECTION_REGISTRY[type].fields)).optional(),
     columns: z.union([z.literal(1), z.literal(2)]).optional(),
     showProficiency: z.boolean().optional(),
@@ -60,6 +63,7 @@ const customSection = z.strictObject({
   type: z.literal("custom"),
   variant: z.enum(["rich", "list"]).optional(),
   title: z.string().optional(),
+  hidden: z.boolean().optional(),
   body: scalarString.optional(),
   entries: z.array(entryShape(CUSTOM_LIST_FIELDS)).optional(),
 });

--- a/src/lib/resume/factory.ts
+++ b/src/lib/resume/factory.ts
@@ -54,6 +54,7 @@ export function createEmptySection(type: SectionType): Section {
     type,
     title: schema.defaultTitle,
     entries: [],
+    hidden: false,
   };
   // The Skills grid is column-toggleable; new sections start two-column and
   // show per-skill proficiency until the user hides it.
@@ -89,6 +90,7 @@ export function createCustomSection(
     title,
     variant,
     entries: [createCustomEntry(variant)],
+    hidden: false,
   };
 }
 

--- a/src/lib/resume/migrations.ts
+++ b/src/lib/resume/migrations.ts
@@ -486,6 +486,26 @@ const migrateV13toV14: Migration = (doc) => {
 };
 
 /**
+ * v14→v15: adds the presentation-only `hidden` visibility toggle to every
+ * section. Existing documents default to false, preserving their current
+ * output. Bail-safe: a section already carrying a boolean flag is left as-is.
+ */
+const migrateV14toV15: Migration = (doc) => {
+  const next = structuredClone(doc);
+  const sections = Array.isArray(next.sections)
+    ? (next.sections as Array<Record<string, unknown>>)
+    : [];
+
+  for (const section of sections) {
+    if (typeof section.hidden !== "boolean") {
+      section.hidden = false;
+    }
+  }
+
+  return next;
+};
+
+/**
  * The migration ladder. Each key N is a forward-only step from version N to N+1.
  */
 const LADDER: Record<number, Migration> = {
@@ -502,6 +522,7 @@ const LADDER: Record<number, Migration> = {
   11: migrateV11toV12,
   12: migrateV12toV13,
   13: migrateV13toV14,
+  14: migrateV14toV15,
 };
 
 /** The persisted schemaVersion of a raw document; 0 when absent or malformed. */

--- a/src/lib/resume/types.ts
+++ b/src/lib/resume/types.ts
@@ -5,7 +5,7 @@ import type { JSONContent } from "@tiptap/core";
  * governs object-store/index structure only. Bumped whenever a persisted field
  * shape changes; every bump gets a forward-only step in the migration ladder.
  */
-export const CURRENT_SCHEMA_VERSION = 14;
+export const CURRENT_SCHEMA_VERSION = 15;
 
 /** The language the rendered document's fixed labels (headings, dates) use. */
 export type ResumeLanguage = "en" | "id";
@@ -90,6 +90,13 @@ export interface Section {
    * factory always sets it, and renderers treat an unset value as `rich`.
    */
   variant?: CustomVariant;
+  /**
+   * Presentation-only visibility toggle: when true the Section is omitted from
+   * the preview and every export. Content and ordering are kept, so showing it
+   * again restores exactly what was there. Renderers treat an unset value as
+   * visible. The Header is not a Section and can never be hidden.
+   */
+  hidden?: boolean;
 }
 
 /**

--- a/src/lib/store/resume-store.ts
+++ b/src/lib/store/resume-store.ts
@@ -87,6 +87,12 @@ interface ResumeStoreState {
   /** Switch a custom section's variant, converting its content across. */
   setCustomVariant: (id: string, variant: CustomVariant) => void;
   /**
+   * Toggle a section's presentation-only visibility. Hidden sections keep
+   * their content and slot in the list; they are only omitted from the
+   * preview and exports.
+   */
+  toggleSectionVisibility: (id: string) => void;
+  /**
    * Overwrite the open document's content (header + sections) with a parsed PDF
    * import, keeping its id, title, template, and language, and store the import's
    * leftovers against it. For importing into an existing document in place.
@@ -314,6 +320,13 @@ export const useResumeStore = create<ResumeStoreState>()((set, get) => ({
         draft.sections[index],
         variant,
       );
+    });
+  },
+
+  toggleSectionVisibility(id) {
+    get().updateOpen((draft) => {
+      const section = draft.sections.find((s) => s.id === id);
+      if (section) section.hidden = !section.hidden;
     });
   },
 


### PR DESCRIPTION
Every section in the editor list, Summary included, now carries an eye toggle placed just left of the accordion chevron. Personal Information is the Header, not a section, and stays always visible. Hiding is presentation only: the section keeps its content and its slot in the list, and is omitted from the preview and every export until it is shown again. On custom sections the toggle sits beside the existing rename/remove menu; like that menu it lives outside the trigger button, so toggling never expands or collapses the row.

The flag is persisted per section, so the document schema bumps to v15 with a bail-safe v14 to v15 rung that stamps `hidden: false` onto existing documents, following the `showProficiency` precedent. Rendering is gated at the `resumeToPreview` seam: hidden sections drop out of the emitted section order and a hidden Summary yields no blocks, so the on-screen preview, every PDF template, DOCX, and TXT all agree without per-renderer changes. The JSON and YAML interchange formats carry `hidden` per section, so copies and downloads round-trip visibility and a hand-edited file can hide sections too. The previously unused visibility toggle component is now wired up, rebuilt on the design-system `Button`.

Verified on a fresh document that nine toggles appear with none on Personal Information; hid Skills and Summary and confirmed both vanish from the preview while their form content stays intact; showed Summary again and confirmed it returns; reloaded and confirmed hidden state persists from storage. Round-tripped hidden flags through YAML and JSON, confirmed v14 documents migrate with the stamped default, and confirmed PDF, DOCX, and TXT output still preserves reading order and every field through the parser validation script.