### PR TITLE
feat: animate preview sections as they enter and leave

### DIFF
--- a/src/components/editor/resume-animated-block.tsx
+++ b/src/components/editor/resume-animated-block.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { motion, useReducedMotion } from "motion/react";
+import type { CSSProperties, ReactNode } from "react";
+
+const EASE = [0.22, 1, 0.36, 1] as const;
+
+interface ResumeAnimatedBlockProps {
+  layoutDependency: string;
+  style?: CSSProperties;
+  children: ReactNode;
+}
+
+/**
+ * Animates a preview block entering, leaving, and shifting as sections are
+ * shown, hidden, added, or removed. `layoutDependency` is the page's block-id
+ * signature, so position FLIPs only run when the set of blocks changes and
+ * never while typing merely reflows content within existing blocks.
+ */
+export function ResumeAnimatedBlock(props: ResumeAnimatedBlockProps) {
+  const reduce = useReducedMotion();
+  return (
+    <motion.div
+      layout={reduce ? false : "position"}
+      layoutDependency={props.layoutDependency}
+      initial={reduce ? false : { opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{
+        y: 8,
+        opacity: 0,
+        transition: { duration: reduce ? 0 : 0.18, ease: "easeIn" },
+      }}
+      transition={{ duration: reduce ? 0 : 0.32, ease: EASE }}
+      style={props.style}
+    >
+      {props.children}
+    </motion.div>
+  );
+}

--- a/src/components/editor/resume-document.tsx
+++ b/src/components/editor/resume-document.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { AnimatePresence } from "motion/react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { TemplateId } from "@/lib/templates";
+import { ResumeAnimatedBlock } from "./resume-animated-block";
 import { buildResumeBlocks } from "./resume-blocks";
 import { A4, CONTENT_HEIGHT_PX, CONTENT_WIDTH_PX } from "./resume-geometry";
 import { ResumePage } from "./resume-page";
@@ -112,22 +114,30 @@ export function ResumeDocument(props: ResumeDocumentProps) {
             transformOrigin: "top left",
           }}
         >
-          {pages.map((pageBlocks, index, items) => (
-            <ResumePage
-              page={index + 1}
-              total={items.length}
-              key={pageBlocks[0].id}
-            >
-              {pageBlocks.map((block, index) => (
-                <div
-                  key={block.id}
-                  style={{ marginTop: index === 0 ? 0 : block.gapBefore }}
-                >
-                  <BlockView block={block} />
-                </div>
-              ))}
-            </ResumePage>
-          ))}
+          {pages.map((pageBlocks, index, items) => {
+            // The page's identity is its position in the stack: keying by index
+            // keeps the container stable while blocks reflow through it, so a
+            // changed first block animates instead of remounting the page.
+            const signature = pageBlocks.map((block) => block.id).join("|");
+            return (
+              // biome-ignore lint/suspicious/noArrayIndexKey: pages have no id; position is their identity
+              <ResumePage page={index + 1} total={items.length} key={index}>
+                <AnimatePresence initial={false} mode="popLayout">
+                  {pageBlocks.map((block, blockIndex) => (
+                    <ResumeAnimatedBlock
+                      key={block.id}
+                      layoutDependency={signature}
+                      style={{
+                        marginTop: blockIndex === 0 ? 0 : block.gapBefore,
+                      }}
+                    >
+                      <BlockView block={block} />
+                    </ResumeAnimatedBlock>
+                  ))}
+                </AnimatePresence>
+              </ResumePage>
+            );
+          })}
         </div>
       </div>
     </div>


### PR DESCRIPTION
The document preview now animates when sections come and go: hiding or removing a section fades its blocks out in place (with a slight downward settle) while the blocks below slide up to fill the gap, and showing or adding a section fades its blocks in with a rise while neighbors part to make room. Exiting content clips at the paper edge since each page is overflow-hidden, so ghosts never spill outside the sheet.

Implementation is deliberately narrow. Each rendered block is wrapped in a small motion component, and each page wraps its blocks in an AnimatePresence in popLayout mode. Because the preview re-renders on every keystroke, position animations are gated by a per-page block-id signature passed as layoutDependency: FLIP measurements and slides only run when the set of blocks changes (visibility toggles, adding or removing sections and entries), never when typing merely reflows content. Pages are also keyed by their position in the stack instead of their first block's id; with the old key, hiding Summary changed page one's key and would have remounted the whole page mid-animation. Reduced motion follows the existing entry-list precedent: no transforms, instant exits, everything still functions. One accepted trade-off: a block pushed across a page boundary by reflow soft-crossfades between pages rather than visibly traveling, since animating across clipped page containers isn't worth the complexity.

Verified by driving the editor: hid and re-showed a mid-document section and confirmed the fade-and-slide reflow (six elements in partial opacity mid-transition), typed into the summary and confirmed zero transform-animated elements during keystrokes, and repeated the hide/show flow under reduced motion with instant results and no console errors. Pagination, exports, and the thumbnail path are untouched; the change is presentation-only in the on-screen preview.