### PR TITLE
feat: toggle contact icon visibility from the document tab

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -176,6 +176,10 @@
           {
             "title": "Hide sections",
             "description": "Every section, Summary included, now has an eye toggle in the editor list. Hidden sections keep their content but drop out of the preview and every export until you show them again."
+          },
+          {
+            "title": "Hide contact icons",
+            "description": "A new toggle in the Document tab hides the small icons next to your contact details, for a plainer header in the preview and PDF. Your contact text always stays."
           }
         ],
         "0_9_0": [
@@ -520,7 +524,8 @@
       "add": "Add"
     },
     "layout": {
-      "documentLanguage": "Document language"
+      "documentLanguage": "Document language",
+      "documentIcons": "Show contact icons"
     },
     "chrome": {
       "edit": "Edit",

--- a/messages/id.json
+++ b/messages/id.json
@@ -176,6 +176,10 @@
           {
             "title": "Sembunyikan bagian",
             "description": "Setiap bagian, termasuk Ringkasan, sekarang punya toggle mata di daftar editor. Bagian yang disembunyikan tetap menyimpan isinya tapi hilang dari pratinjau dan semua ekspor sampai kamu tampilkan lagi."
+          },
+          {
+            "title": "Sembunyikan ikon kontak",
+            "description": "Toggle baru di tab Dokumen menyembunyikan ikon kecil di samping detail kontak kamu, biar header lebih polos di pratinjau dan PDF. Teks kontaknya selalu tetap ada."
           }
         ],
         "0_9_0": [
@@ -520,7 +524,8 @@
       "add": "Tambah"
     },
     "layout": {
-      "documentLanguage": "Bahasa dokumen"
+      "documentLanguage": "Bahasa dokumen",
+      "documentIcons": "Tampilkan ikon kontak"
     },
     "chrome": {
       "edit": "Edit",

--- a/src/components/editor/editor-document-icon.tsx
+++ b/src/components/editor/editor-document-icon.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Switch } from "@/components/ui/switch";
+import { useResumeStore } from "@/lib/store";
+import { templateHasContactIcons } from "@/lib/templates";
+
+export function EditorDocumentIcon() {
+  const templateId = useResumeStore((state) => state.open?.templateId);
+  const showIcons = useResumeStore((state) => state.open?.showIcons ?? true);
+  const updateOpen = useResumeStore((state) => state.updateOpen);
+  const t = useTranslations("editor.layout");
+
+  if (templateId === undefined) return null;
+
+  const hasIcons = templateHasContactIcons(templateId);
+
+  function handleChange(next: boolean) {
+    updateOpen((draft) => {
+      draft.showIcons = next;
+    });
+  }
+
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span id="document-icons-label" className="text-sm text-muted-foreground">
+        {t("documentIcons")}
+      </span>
+      <Switch
+        aria-labelledby="document-icons-label"
+        checked={hasIcons && showIcons}
+        disabled={!hasIcons}
+        onCheckedChange={handleChange}
+      />
+    </div>
+  );
+}

--- a/src/components/editor/editor-document-panel.tsx
+++ b/src/components/editor/editor-document-panel.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from "next-intl";
 import { EditorDocumentCopy } from "./editor-document-copy";
 import { EditorDocumentDownload } from "./editor-document-download";
+import { EditorDocumentIcon } from "./editor-document-icon";
 import { EditorDocumentImport } from "./editor-document-import";
 import { EditorDocumentLanguage } from "./editor-document-language";
 
@@ -11,8 +12,9 @@ export function EditorDocumentPanel() {
   const t = useTranslations("editor.document");
   return (
     <div className="flex flex-col divide-y px-4">
-      <section className="py-4">
+      <section className="flex flex-col gap-3 py-4">
         <EditorDocumentLanguage />
+        <EditorDocumentIcon />
       </section>
 
       <section className="py-4">

--- a/src/components/editor/pdf/awal-pdf-document.tsx
+++ b/src/components/editor/pdf/awal-pdf-document.tsx
@@ -76,7 +76,9 @@ function PdfHeader(props: { header: HeaderView }) {
       <View style={styles.headerRight}>
         {props.header.contacts.map((contact) => (
           <View key={contact.kind} style={styles.contactRow}>
-            <PdfContactIcon kind={contact.kind} />
+            {props.header.showIcons ? (
+              <PdfContactIcon kind={contact.kind} />
+            ) : null}
             {contact.href ? (
               <Link src={contact.href} style={styles.linkPlain}>
                 {contact.value}

--- a/src/components/editor/pdf/ketat-pdf-document.tsx
+++ b/src/components/editor/pdf/ketat-pdf-document.tsx
@@ -102,7 +102,9 @@ function KetatHeader(props: { header: HeaderView }) {
             ) : (
               <Text>{contact.value}</Text>
             )}
-            <PdfContactIcon kind={contact.kind} />
+            {props.header.showIcons ? (
+              <PdfContactIcon kind={contact.kind} />
+            ) : null}
           </View>
         ))}
       </View>

--- a/src/components/editor/pdf/tebal-pdf-document.tsx
+++ b/src/components/editor/pdf/tebal-pdf-document.tsx
@@ -83,7 +83,9 @@ function TebalHeader(props: { header: HeaderView }) {
         <View style={styles.contactRowWrap}>
           {props.header.contacts.map((contact) => (
             <View key={contact.kind} style={styles.contactRow}>
-              <PdfContactIcon kind={contact.kind} />
+              {props.header.showIcons ? (
+                <PdfContactIcon kind={contact.kind} />
+              ) : null}
               {contact.href ? (
                 <Link src={contact.href} style={styles.linkPlain}>
                   {contact.value}

--- a/src/components/editor/resume-contact-icon.tsx
+++ b/src/components/editor/resume-contact-icon.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { Globe, Link, Mail, MapPin, Phone } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { cn } from "@/lib/utils";
+import type { ContactKind } from "./resume-preview";
+
+const EASE = [0.22, 1, 0.36, 1] as const;
+
+const CONTACT_ICON: Record<ContactKind, typeof Phone> = {
+  phone: Phone,
+  email: Mail,
+  website: Globe,
+  linkedin: Link,
+  location: MapPin,
+};
+
+interface ResumeContactIconProps {
+  kind: ContactKind;
+  show: boolean;
+  /** Which edge of the contact row the icon sits on. Defaults to "start". */
+  edge?: "start" | "end";
+  className?: string;
+}
+
+/**
+ * Header contact glyph that grows in and collapses out as the document's
+ * contact-icons toggle flips. The collapsed state also pulls back the row's
+ * gap-2 with a negative margin, so the text closes up without a jump when
+ * the element unmounts.
+ */
+export function ResumeContactIcon(props: ResumeContactIconProps) {
+  const reduce = useReducedMotion();
+  const Icon = CONTACT_ICON[props.kind];
+  const collapsed =
+    props.edge === "end"
+      ? { width: 0, opacity: 0, marginLeft: "-0.5rem" }
+      : { width: 0, opacity: 0, marginRight: "-0.5rem" };
+  const expanded =
+    props.edge === "end"
+      ? { width: "0.875rem", opacity: 1, marginLeft: "0rem" }
+      : { width: "0.875rem", opacity: 1, marginRight: "0rem" };
+
+  return (
+    <AnimatePresence initial={false} mode="wait">
+      {props.show && (
+        <motion.span
+          key="icon"
+          aria-hidden
+          className={cn(
+            "flex shrink-0 items-center overflow-hidden",
+            props.className,
+          )}
+          initial={collapsed}
+          animate={expanded}
+          exit={collapsed}
+          transition={{ duration: reduce ? 0 : 0.25, ease: EASE }}
+        >
+          <Icon className="size-3.5 shrink-0" />
+        </motion.span>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/editor/resume-header-contact.tsx
+++ b/src/components/editor/resume-header-contact.tsx
@@ -1,19 +1,16 @@
-import { Globe, Link, Mail, MapPin, Phone } from "lucide-react";
-import type { ContactKind, ContactView } from "./resume-preview";
+import { ResumeContactIcon } from "./resume-contact-icon";
+import type { ContactView } from "./resume-preview";
 
-const CONTACT_ICON: Record<ContactKind, typeof Phone> = {
-  phone: Phone,
-  email: Mail,
-  website: Globe,
-  linkedin: Link,
-  location: MapPin,
-};
-
-export function ResumeHeaderContact(props: ContactView) {
-  const Icon = CONTACT_ICON[props.kind];
+export function ResumeHeaderContact(
+  props: ContactView & { showIcons: boolean },
+) {
   return (
     <li className="flex items-center gap-2">
-      <Icon className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+      <ResumeContactIcon
+        kind={props.kind}
+        show={props.showIcons}
+        className="text-muted-foreground"
+      />
       {props.href ? (
         <a href={props.href} className="hover:underline">
           {props.value}

--- a/src/components/editor/resume-header.tsx
+++ b/src/components/editor/resume-header.tsx
@@ -11,7 +11,11 @@ export function ResumeHeader(props: HeaderView) {
 
       <ul className="space-y-1 text-xs">
         {props.contacts.map((contact) => (
-          <ResumeHeaderContact key={contact.kind} {...contact} />
+          <ResumeHeaderContact
+            key={contact.kind}
+            showIcons={props.showIcons}
+            {...contact}
+          />
         ))}
       </ul>
     </header>

--- a/src/components/editor/resume-preview.ts
+++ b/src/components/editor/resume-preview.ts
@@ -34,6 +34,8 @@ export interface HeaderView {
   fullName: string;
   headline: string;
   contacts: ContactView[];
+  /** Presentation-only: whether contact icon glyphs are drawn; defaults to true. */
+  showIcons: boolean;
 }
 
 export interface ExperienceItemView {

--- a/src/components/editor/resume-to-preview.ts
+++ b/src/components/editor/resume-to-preview.ts
@@ -91,7 +91,12 @@ function toHeaderView(resume: Resume): HeaderView {
     .join(", ");
   if (location) contacts.push({ kind: "location", value: location });
 
-  return { fullName, headline: plain(fields.jobTitle), contacts };
+  return {
+    fullName,
+    headline: plain(fields.jobTitle),
+    contacts,
+    showIcons: resume.showIcons ?? true,
+  };
 }
 
 /**

--- a/src/components/editor/templates/ketat/ketat-header.tsx
+++ b/src/components/editor/templates/ketat/ketat-header.tsx
@@ -1,20 +1,7 @@
-import { Globe, Link, Mail, MapPin, Phone } from "lucide-react";
-import type {
-  ContactKind,
-  ContactView,
-  HeaderView,
-} from "../../resume-preview";
+import { ResumeContactIcon } from "../../resume-contact-icon";
+import type { ContactView, HeaderView } from "../../resume-preview";
 
-const CONTACT_ICON: Record<ContactKind, typeof Phone> = {
-  phone: Phone,
-  email: Mail,
-  website: Globe,
-  linkedin: Link,
-  location: MapPin,
-};
-
-function KetatHeaderContact(props: ContactView) {
-  const Icon = CONTACT_ICON[props.kind];
+function KetatHeaderContact(props: ContactView & { showIcons: boolean }) {
   return (
     <li className="flex items-center justify-end gap-2">
       {props.href ? (
@@ -24,7 +11,7 @@ function KetatHeaderContact(props: ContactView) {
       ) : (
         <span>{props.value}</span>
       )}
-      <Icon className="size-3.5 shrink-0" aria-hidden />
+      <ResumeContactIcon kind={props.kind} show={props.showIcons} edge="end" />
     </li>
   );
 }
@@ -43,7 +30,11 @@ export function KetatHeader(props: HeaderView) {
 
       <ul className="space-y-1.5 text-xs">
         {props.contacts.map((contact) => (
-          <KetatHeaderContact key={contact.kind} {...contact} />
+          <KetatHeaderContact
+            key={contact.kind}
+            showIcons={props.showIcons}
+            {...contact}
+          />
         ))}
       </ul>
     </header>

--- a/src/components/editor/templates/tebal/tebal-header.tsx
+++ b/src/components/editor/templates/tebal/tebal-header.tsx
@@ -15,7 +15,11 @@ export function TebalHeader(props: HeaderView) {
       {props.contacts.length > 0 && (
         <ul className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs">
           {props.contacts.map((contact) => (
-            <ResumeHeaderContact key={contact.kind} {...contact} />
+            <ResumeHeaderContact
+              key={contact.kind}
+              showIcons={props.showIcons}
+              {...contact}
+            />
           ))}
         </ul>
       )}

--- a/src/lib/interchange/codec.ts
+++ b/src/lib/interchange/codec.ts
@@ -29,6 +29,7 @@ export interface ResumeContent {
   title?: string;
   templateId?: string;
   language?: ResumeLanguage;
+  showIcons?: boolean;
   header: Header;
   sections: Section[];
 }
@@ -111,6 +112,7 @@ export function resumeToInterchange(resume: Resume): InterchangeResume {
     title: resume.title,
     template: resume.templateId,
     language: resume.language,
+    showIcons: resume.showIcons ?? true,
     header,
     sections: resume.sections.map(sectionToInterchange),
   };
@@ -211,6 +213,7 @@ export function interchangeToContent(data: InterchangeResume): ResumeContent {
     title: data.title?.trim() || undefined,
     templateId: data.template,
     language: data.language,
+    showIcons: data.showIcons,
     header,
     sections,
   };

--- a/src/lib/interchange/import-file.ts
+++ b/src/lib/interchange/import-file.ts
@@ -23,6 +23,7 @@ function buildImportedResume(
   resume.sections = parsed.content.sections;
   resume.templateId = parsed.content.templateId ?? options.templateId;
   resume.language = parsed.content.language ?? options.language;
+  resume.showIcons = parsed.content.showIcons ?? true;
   if (parsed.content.title) resume.title = parsed.content.title;
   return { ok: true, resume, leftovers: [] };
 }

--- a/src/lib/interchange/schema.ts
+++ b/src/lib/interchange/schema.ts
@@ -88,6 +88,7 @@ export const interchangeSchema = z
     title: z.string().optional(),
     template: z.string().optional(),
     language: z.enum(["en", "id"]).optional(),
+    showIcons: z.boolean().optional(),
     header: entryShape(HEADER_SCHEMA).optional(),
     sections: z.array(sectionSchema).optional(),
   })

--- a/src/lib/resume/factory.ts
+++ b/src/lib/resume/factory.ts
@@ -111,6 +111,7 @@ export function createEmptyResume(title: string): Resume {
     title,
     templateId: "awal",
     language: "en",
+    showIcons: true,
     header: createEmptyHeader(),
     sections: [
       createEmptySection("summary"),

--- a/src/lib/resume/migrations.ts
+++ b/src/lib/resume/migrations.ts
@@ -506,6 +506,19 @@ const migrateV14toV15: Migration = (doc) => {
 };
 
 /**
+ * v15→v16: adds the presentation-only document-level `showIcons` toggle for the
+ * header's contact icons. Existing documents default to true, preserving their
+ * current output. Bail-safe: a document already carrying a boolean is left as-is.
+ */
+const migrateV15toV16: Migration = (doc) => {
+  const next = structuredClone(doc);
+  if (typeof next.showIcons !== "boolean") {
+    next.showIcons = true;
+  }
+  return next;
+};
+
+/**
  * The migration ladder. Each key N is a forward-only step from version N to N+1.
  */
 const LADDER: Record<number, Migration> = {
@@ -523,6 +536,7 @@ const LADDER: Record<number, Migration> = {
   12: migrateV12toV13,
   13: migrateV13toV14,
   14: migrateV14toV15,
+  15: migrateV15toV16,
 };
 
 /** The persisted schemaVersion of a raw document; 0 when absent or malformed. */

--- a/src/lib/resume/seed.ts
+++ b/src/lib/resume/seed.ts
@@ -51,6 +51,7 @@ export const SEED_RESUME: Resume = {
   title: "Untitled resume",
   templateId: "awal",
   language: "en",
+  showIcons: true,
   createdAt: "2026-01-01T00:00:00.000Z",
   updatedAt: "2026-01-01T00:00:00.000Z",
   header: {

--- a/src/lib/resume/types.ts
+++ b/src/lib/resume/types.ts
@@ -5,7 +5,7 @@ import type { JSONContent } from "@tiptap/core";
  * governs object-store/index structure only. Bumped whenever a persisted field
  * shape changes; every bump gets a forward-only step in the migration ladder.
  */
-export const CURRENT_SCHEMA_VERSION = 15;
+export const CURRENT_SCHEMA_VERSION = 16;
 
 /** The language the rendered document's fixed labels (headings, dates) use. */
 export type ResumeLanguage = "en" | "id";
@@ -128,6 +128,13 @@ export interface Resume {
    * of the content the user types.
    */
   language: ResumeLanguage;
+  /**
+   * Presentation-only toggle for the header's contact icons: when false, icon
+   * glyphs are omitted from the preview and PDF export. Contact text is always
+   * kept, so parsing and text exports are unaffected. Renderers treat an unset
+   * value as `true`; templates that never draw icons ignore it.
+   */
+  showIcons?: boolean;
   header: Header;
   sections: Section[];
   /** ISO 8601. */

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -28,6 +28,18 @@ export function resolveTemplateId(id: string): TemplateId {
     : DEFAULT_TEMPLATE_ID;
 }
 
+/** Templates whose headers draw contact icon glyphs; the rest render text-only contacts. */
+const TEMPLATE_IDS_WITH_CONTACT_ICONS: TemplateId[] = [
+  "awal",
+  "ketat",
+  "tebal",
+];
+
+/** Whether a persisted template id renders contact icons. Unknown ids resolve to the default template first, matching renderer fallback. */
+export function templateHasContactIcons(id: string): boolean {
+  return TEMPLATE_IDS_WITH_CONTACT_ICONS.includes(resolveTemplateId(id));
+}
+
 export type TemplateSort = "name-asc" | "name-desc" | "newest";
 
 export const TEMPLATE_SORTS: TemplateSort[] = [


### PR DESCRIPTION
Adds a document-level setting to hide the small icons next to the header contact details. The switch lives in the Document tab under Document language, follows the same label-plus-switch pattern as the proficiency toggles, and is presentation-only: contact text is never touched, so parsing and the text-based exports are unaffected.

- `showIcons` is a new optional field on the resume document, defaulting to shown. `CURRENT_SCHEMA_VERSION` bumps to 16 with a bail-safe v15 to v16 ladder rung, so existing documents keep their current output.
- The flag rides on the preview view-model's `HeaderView`, and the three templates that draw icons (awal, ketat, tebal) gate them in both the on-screen preview and the PDF export. Icons animate in and out with the same easing as the section enter/leave motion, pulling the row's gap closed so the contact text slides rather than jumps; reduced motion is honored.
- Templates that never draw icons (klasik, ketik, luasa) render the switch off and disabled. The stored preference is kept, so returning to an icon template restores the previous choice.
- JSON and YAML interchange round-trips the flag; import in place keeps the open document's setting, matching how language and template already behave.
- awal/tebal and ketat now share one animated contact icon component, dropping ketat's duplicated icon map.

Testing: created a resume and confirmed icons show by default; flipping the switch fades them out and removes them while the contact text stays, the choice survives a reload, and flipping back restores them. A document stamped at schemaVersion 15 opens, migrates to icons shown, and renders without errors. Switching to Klasik shows the plain text header with the switch off and disabled; switching back to Awal re-enables it with the prior choice intact. The changelog highlight appears under 0.10.0 in both languages.