### PR TITLE
feat: widen section spacing from the document tab

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -180,6 +180,10 @@
           {
             "title": "Hide contact icons",
             "description": "A new toggle in the Document tab hides the small icons next to your contact details, for a plainer header in the preview and PDF. Your contact text always stays."
+          },
+          {
+            "title": "Section spacing",
+            "description": "A slider in the Document tab adds breathing room above every section, in the preview and the PDF alike. Each template's compact look stays the floor; you can only open it up, never squeeze it tighter."
           }
         ],
         "0_9_0": [
@@ -525,7 +529,8 @@
     },
     "layout": {
       "documentLanguage": "Document language",
-      "documentIcons": "Show contact icons"
+      "documentIcons": "Show contact icons",
+      "sectionSpacing": "Section spacing"
     },
     "chrome": {
       "edit": "Edit",

--- a/messages/id.json
+++ b/messages/id.json
@@ -180,6 +180,10 @@
           {
             "title": "Sembunyikan ikon kontak",
             "description": "Toggle baru di tab Dokumen menyembunyikan ikon kecil di samping detail kontak kamu, biar header lebih polos di pratinjau dan PDF. Teks kontaknya selalu tetap ada."
+          },
+          {
+            "title": "Jarak antarbagian",
+            "description": "Slider di tab Dokumen menambah ruang napas di atas setiap bagian, di pratinjau maupun PDF. Tampilan ringkas bawaan template jadi batas bawahnya; kamu hanya bisa melonggarkan, tidak bisa merapatkan."
           }
         ],
         "0_9_0": [
@@ -525,7 +529,8 @@
     },
     "layout": {
       "documentLanguage": "Bahasa dokumen",
-      "documentIcons": "Tampilkan ikon kontak"
+      "documentIcons": "Tampilkan ikon kontak",
+      "sectionSpacing": "Jarak antarbagian"
     },
     "chrome": {
       "edit": "Edit",

--- a/src/components/editor/editor-document-panel.tsx
+++ b/src/components/editor/editor-document-panel.tsx
@@ -6,6 +6,7 @@ import { EditorDocumentDownload } from "./editor-document-download";
 import { EditorDocumentIcon } from "./editor-document-icon";
 import { EditorDocumentImport } from "./editor-document-import";
 import { EditorDocumentLanguage } from "./editor-document-language";
+import { EditorDocumentSpacing } from "./editor-document-spacing";
 
 /** The Document tab: document-level actions (language, export, import). */
 export function EditorDocumentPanel() {
@@ -15,6 +16,7 @@ export function EditorDocumentPanel() {
       <section className="flex flex-col gap-3 py-4">
         <EditorDocumentLanguage />
         <EditorDocumentIcon />
+        <EditorDocumentSpacing />
       </section>
 
       <section className="py-4">

--- a/src/components/editor/editor-document-spacing.tsx
+++ b/src/components/editor/editor-document-spacing.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Slider } from "@/components/ui/slider";
+import { useResumeStore } from "@/lib/store";
+
+const SPACING_MAX = 60;
+const SPACING_STEP = 1;
+
+export function EditorDocumentSpacing() {
+  const hasOpen = useResumeStore((state) => state.open !== null);
+  const spacing = useResumeStore((state) => state.open?.sectionSpacing ?? 0);
+  const updateOpen = useResumeStore((state) => state.updateOpen);
+  const t = useTranslations("editor.layout");
+
+  if (!hasOpen) return null;
+
+  const onValueChange = (value: number | readonly number[]) => {
+    const next = Array.isArray(value) ? value[0] : (value as number);
+    updateOpen((draft) => {
+      draft.sectionSpacing = next;
+    });
+  };
+
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span
+        id="section-spacing-label"
+        className="shrink-0 text-sm text-muted-foreground"
+      >
+        {t("sectionSpacing")}
+      </span>
+      <Slider
+        aria-labelledby="section-spacing-label"
+        className="max-w-36"
+        value={spacing}
+        onValueChange={onValueChange}
+        min={0}
+        max={SPACING_MAX}
+        step={SPACING_STEP}
+      />
+    </div>
+  );
+}

--- a/src/components/editor/resume-blocks.ts
+++ b/src/components/editor/resume-blocks.ts
@@ -308,5 +308,16 @@ export function buildResumeBlocks(resume: ResumePreview): ResumeBlock[] {
     }
   }
 
+  // Document-level section spacing widens only the gap above headings; the
+  // paginator and every PDF template consume `gapBefore`, so this single
+  // adjustment reaches all of them.
+  if (resume.sectionSpacing > 0) {
+    return blocks.map((block) =>
+      block.kind === "heading"
+        ? { ...block, gapBefore: block.gapBefore + resume.sectionSpacing }
+        : block,
+    );
+  }
+
   return blocks;
 }

--- a/src/components/editor/resume-preview.ts
+++ b/src/components/editor/resume-preview.ts
@@ -111,6 +111,11 @@ export type SectionHeadings = Record<
 export interface ResumePreview {
   /** Document language for fixed labels (headings, dates); drives localization. */
   language: ResumeLanguage;
+  /**
+   * Presentation-only extra space above each section heading (px on screen,
+   * pt in PDF), on top of the template's baseline rhythm; 0 = baseline.
+   */
+  sectionSpacing: number;
   headings: SectionHeadings;
   /**
    * The reorderable sections in document (reading) order. Drives the order blocks

--- a/src/components/editor/resume-to-preview.ts
+++ b/src/components/editor/resume-to-preview.ts
@@ -203,6 +203,9 @@ export function resumeToPreview(resume: Resume): ResumePreview {
 
   return {
     language: resume.language,
+    // Clamped so a hand-edited document can widen spacing but never collapse
+    // a template below its baseline or blow up pagination.
+    sectionSpacing: Math.min(60, Math.max(0, resume.sectionSpacing ?? 0)),
     headings,
     sectionOrder,
     customSections,

--- a/src/lib/interchange/codec.ts
+++ b/src/lib/interchange/codec.ts
@@ -30,6 +30,7 @@ export interface ResumeContent {
   templateId?: string;
   language?: ResumeLanguage;
   showIcons?: boolean;
+  sectionSpacing?: number;
   header: Header;
   sections: Section[];
 }
@@ -113,6 +114,7 @@ export function resumeToInterchange(resume: Resume): InterchangeResume {
     template: resume.templateId,
     language: resume.language,
     showIcons: resume.showIcons ?? true,
+    sectionSpacing: resume.sectionSpacing ?? 0,
     header,
     sections: resume.sections.map(sectionToInterchange),
   };
@@ -214,6 +216,7 @@ export function interchangeToContent(data: InterchangeResume): ResumeContent {
     templateId: data.template,
     language: data.language,
     showIcons: data.showIcons,
+    sectionSpacing: data.sectionSpacing,
     header,
     sections,
   };

--- a/src/lib/interchange/import-file.ts
+++ b/src/lib/interchange/import-file.ts
@@ -24,6 +24,7 @@ function buildImportedResume(
   resume.templateId = parsed.content.templateId ?? options.templateId;
   resume.language = parsed.content.language ?? options.language;
   resume.showIcons = parsed.content.showIcons ?? true;
+  resume.sectionSpacing = parsed.content.sectionSpacing ?? 0;
   if (parsed.content.title) resume.title = parsed.content.title;
   return { ok: true, resume, leftovers: [] };
 }

--- a/src/lib/interchange/schema.ts
+++ b/src/lib/interchange/schema.ts
@@ -89,6 +89,7 @@ export const interchangeSchema = z
     template: z.string().optional(),
     language: z.enum(["en", "id"]).optional(),
     showIcons: z.boolean().optional(),
+    sectionSpacing: z.number().int().min(0).max(60).optional(),
     header: entryShape(HEADER_SCHEMA).optional(),
     sections: z.array(sectionSchema).optional(),
   })

--- a/src/lib/resume/factory.ts
+++ b/src/lib/resume/factory.ts
@@ -112,6 +112,7 @@ export function createEmptyResume(title: string): Resume {
     templateId: "awal",
     language: "en",
     showIcons: true,
+    sectionSpacing: 0,
     header: createEmptyHeader(),
     sections: [
       createEmptySection("summary"),

--- a/src/lib/resume/migrations.ts
+++ b/src/lib/resume/migrations.ts
@@ -519,6 +519,20 @@ const migrateV15toV16: Migration = (doc) => {
 };
 
 /**
+ * v16→v17: adds the presentation-only document-level `sectionSpacing` (extra
+ * space above section headings). Existing documents default to 0, preserving
+ * their current output. Bail-safe: a document already carrying a number is
+ * left as-is.
+ */
+const migrateV16toV17: Migration = (doc) => {
+  const next = structuredClone(doc);
+  if (typeof next.sectionSpacing !== "number") {
+    next.sectionSpacing = 0;
+  }
+  return next;
+};
+
+/**
  * The migration ladder. Each key N is a forward-only step from version N to N+1.
  */
 const LADDER: Record<number, Migration> = {
@@ -537,6 +551,7 @@ const LADDER: Record<number, Migration> = {
   13: migrateV13toV14,
   14: migrateV14toV15,
   15: migrateV15toV16,
+  16: migrateV16toV17,
 };
 
 /** The persisted schemaVersion of a raw document; 0 when absent or malformed. */

--- a/src/lib/resume/seed.ts
+++ b/src/lib/resume/seed.ts
@@ -52,6 +52,7 @@ export const SEED_RESUME: Resume = {
   templateId: "awal",
   language: "en",
   showIcons: true,
+  sectionSpacing: 0,
   createdAt: "2026-01-01T00:00:00.000Z",
   updatedAt: "2026-01-01T00:00:00.000Z",
   header: {

--- a/src/lib/resume/types.ts
+++ b/src/lib/resume/types.ts
@@ -5,7 +5,7 @@ import type { JSONContent } from "@tiptap/core";
  * governs object-store/index structure only. Bumped whenever a persisted field
  * shape changes; every bump gets a forward-only step in the migration ladder.
  */
-export const CURRENT_SCHEMA_VERSION = 16;
+export const CURRENT_SCHEMA_VERSION = 17;
 
 /** The language the rendered document's fixed labels (headings, dates) use. */
 export type ResumeLanguage = "en" | "id";
@@ -135,6 +135,13 @@ export interface Resume {
    * value as `true`; templates that never draw icons ignore it.
    */
   showIcons?: boolean;
+  /**
+   * Presentation-only extra vertical space above each section heading, in
+   * rendering units (px on screen, pt in PDF), added on top of the template's
+   * baseline rhythm. 0 or unset keeps the template's current spacing; the
+   * editor only offers increases, never a value below the baseline.
+   */
+  sectionSpacing?: number;
   header: Header;
   sections: Section[];
   /** ISO 8601. */


### PR DESCRIPTION
Adds a Section spacing slider to the Document tab. It widens the vertical gap above every section heading, from 0 to 60 in steps of 1, on top of each template's baseline rhythm; the floor is exactly the current layout, so spacing can only ever increase.

The change hangs off a single seam: the block builder adds the document's `sectionSpacing` to each heading's `gapBefore`, and everything downstream already consumes that value, so the paginated preview reflows correctly and all six PDF templates pick it up with no per-template work. Spacing between entries inside a section is untouched, and the plain text and docx exports never read gaps, so linear structure is unaffected.

Around the seam, the usual document-setting recipe: `sectionSpacing` on the resume document with `CURRENT_SCHEMA_VERSION` bumped to 17 and a bail-safe v16 to v17 ladder rung defaulting existing documents to 0; the JSON and YAML interchange validates the value (integer 0 to 60) and round-trips it; the view-model clamps it so a hand-edited file can never collapse a template below its baseline. English and Indonesian labels, plus a changelog highlight under 0.10.0.

Testing: baseline heading gaps measure 24px on a fresh resume; dragging the slider to the maximum grows them to 84px while entry gaps inside Experience stay at 16px, arrow keys step the value by exactly 1, and the setting survives a reload. A document saved at schemaVersion 16 opens at baseline with the slider at 0 and no errors. Because spacing feeds the PDF margins, the exported PDF was run through a text extractor: name, Summary, Experience, and entry text all extract in linear reading order.