### PR TITLE
feat: typography controls and styling reset in the document tab

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -183,11 +183,15 @@
           },
           {
             "title": "Section spacing",
-            "description": "A slider in the Document tab adds breathing room above every section, in the preview and the PDF alike. Each template's compact look stays the floor; you can only open it up, never squeeze it tighter."
+            "description": "A slider in the Document tab adjusts the room above every section, in the preview and the PDF alike. Open it up for an airy layout, or tighten it below each template's default until sections sit flush."
           },
           {
             "title": "Choose your font",
             "description": "Pick from fifteen resume-safe fonts, grouped as sans, serif, and mono, and the whole document follows in the preview and the PDF. Every template keeps its own default until you choose, and the preview now renders the exact same font files the PDF embeds."
+          },
+          {
+            "title": "Line height and letter spacing",
+            "description": "Two more sliders in the Document tab, resting at each template's real values: tighten or loosen line height and letter spacing either way, both bounded to the range where PDF text still extracts cleanly, so your styling never costs you ATS parsing."
           }
         ],
         "0_9_0": [
@@ -536,10 +540,12 @@
       "documentIcons": "Show contact icons",
       "sectionSpacing": "Section spacing",
       "documentFont": "Font",
-      "fontTemplateDefault": "Default",
+      "templateDefault": "Default",
       "fontSans": "Sans",
       "fontSerif": "Serif",
-      "fontMono": "Mono"
+      "fontMono": "Mono",
+      "lineHeight": "Line height",
+      "letterSpacing": "Letter spacing"
     },
     "chrome": {
       "edit": "Edit",
@@ -805,6 +811,9 @@
       "replacePrompt": "This resume already has content. Replace it, or keep it and create a new one?",
       "replace": "Replace this one",
       "createNew": "Create new",
+      "stylingHeading": "Document styling",
+      "resetStyling": "Reset to defaults",
+      "resetStylingHint": "Reset document styling to default",
       "copyHeading": "Copy",
       "copyHint": "Copy this resume to the clipboard as structured text. Rich text travels as simple markdown, and pasting it into an import restores it exactly.",
       "copyAs": "Copy as",

--- a/messages/id.json
+++ b/messages/id.json
@@ -183,11 +183,15 @@
           },
           {
             "title": "Jarak antarbagian",
-            "description": "Slider di tab Dokumen menambah ruang napas di atas setiap bagian, di pratinjau maupun PDF. Tampilan ringkas bawaan template jadi batas bawahnya; kamu hanya bisa melonggarkan, tidak bisa merapatkan."
+            "description": "Slider di tab Dokumen mengatur ruang di atas setiap bagian, di pratinjau maupun PDF. Longgarkan biar tampilannya lega, atau rapatkan di bawah bawaan template sampai antarbagian saling menempel."
           },
           {
             "title": "Pilih font kamu",
             "description": "Pilih dari lima belas font yang aman untuk resume, dikelompokkan jadi sans, serif, dan mono, dan seluruh dokumen mengikutinya di pratinjau maupun PDF. Setiap template tetap pakai bawaannya sampai kamu memilih, dan pratinjau sekarang merender berkas font yang persis sama dengan yang disematkan di PDF."
+          },
+          {
+            "title": "Tinggi baris dan jarak antarhuruf",
+            "description": "Dua slider baru di tab Dokumen yang berangkat dari nilai asli tiap template: rapatkan atau longgarkan tinggi baris dan jarak antarhuruf ke dua arah, keduanya dibatasi pada rentang di mana teks PDF masih terekstrak bersih, jadi gaya kamu nggak pernah mengorbankan parsing ATS."
           }
         ],
         "0_9_0": [
@@ -536,10 +540,12 @@
       "documentIcons": "Tampilkan ikon kontak",
       "sectionSpacing": "Jarak antarbagian",
       "documentFont": "Font",
-      "fontTemplateDefault": "Bawaan",
+      "templateDefault": "Bawaan",
       "fontSans": "Sans",
       "fontSerif": "Serif",
-      "fontMono": "Mono"
+      "fontMono": "Mono",
+      "lineHeight": "Tinggi baris",
+      "letterSpacing": "Jarak antarhuruf"
     },
     "chrome": {
       "edit": "Edit",
@@ -805,6 +811,9 @@
       "replacePrompt": "Resume ini sudah ada isinya. Ganti isinya, atau simpan lalu buat yang baru?",
       "replace": "Ganti yang ini",
       "createNew": "Buat baru",
+      "stylingHeading": "Gaya dokumen",
+      "resetStyling": "Kembalikan ke bawaan",
+      "resetStylingHint": "Kembalikan gaya dokumen ke bawaan",
       "copyHeading": "Salin",
       "copyHint": "Salin resume ini ke clipboard sebagai teks terstruktur. Teks kaya dibawa sebagai markdown sederhana, dan menempelkannya ke impor akan memulihkannya persis.",
       "copyAs": "Salin sebagai",

--- a/src/components/editor/editor-document-font.tsx
+++ b/src/components/editor/editor-document-font.tsx
@@ -34,7 +34,7 @@ export function EditorDocumentFont() {
   // base-ui's Select.Value renders the raw value unless the root gets a
   // value-to-label mapping.
   const items = {
-    [TEMPLATE_DEFAULT]: t("fontTemplateDefault"),
+    [TEMPLATE_DEFAULT]: t("templateDefault"),
     ...FONT_LABELS,
   };
 
@@ -58,13 +58,13 @@ export function EditorDocumentFont() {
         {t("documentFont")}
       </span>
       <Select value={font} onValueChange={onValueChange} items={items}>
-        <SelectTrigger aria-labelledby="document-font-label" className="w-44">
+        <SelectTrigger aria-labelledby="document-font-label">
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
           <SelectGroup>
             <SelectItem value={TEMPLATE_DEFAULT}>
-              {t("fontTemplateDefault")}
+              {t("templateDefault")}
             </SelectItem>
           </SelectGroup>
           {CATEGORIES.map((category) => (

--- a/src/components/editor/editor-document-letter-spacing.tsx
+++ b/src/components/editor/editor-document-letter-spacing.tsx
@@ -4,14 +4,16 @@ import { useTranslations } from "next-intl";
 import { Slider } from "@/components/ui/slider";
 import { useResumeStore } from "@/lib/store";
 
-// -24 cancels the 24px baseline gap above headings exactly (sections flush).
-const SPACING_MIN = -24;
-const SPACING_MAX = 60;
-const SPACING_STEP = 1;
+// Hard bounds: outside -0.5..0.5 at the 8-9pt PDF body sizes, text extraction
+// stops recovering word boundaries (words split when too wide, merge when too
+// tight), which would defeat ATS parsing.
+const TRACKING_MIN = -0.5;
+const TRACKING_MAX = 0.5;
+const TRACKING_STEP = 0.05;
 
-export function EditorDocumentSpacing() {
+export function EditorDocumentLetterSpacing() {
   const hasOpen = useResumeStore((state) => state.open !== null);
-  const spacing = useResumeStore((state) => state.open?.sectionSpacing ?? 0);
+  const tracking = useResumeStore((state) => state.open?.letterSpacing ?? 0);
   const updateOpen = useResumeStore((state) => state.updateOpen);
   const t = useTranslations("editor.layout");
 
@@ -20,26 +22,26 @@ export function EditorDocumentSpacing() {
   const onValueChange = (value: number | readonly number[]) => {
     const next = Array.isArray(value) ? value[0] : (value as number);
     updateOpen((draft) => {
-      draft.sectionSpacing = next;
+      draft.letterSpacing = Math.round(next * 100) / 100;
     });
   };
 
   return (
     <div className="flex items-center justify-between gap-3">
       <span
-        id="section-spacing-label"
+        id="letter-spacing-label"
         className="shrink-0 text-sm text-muted-foreground"
       >
-        {t("sectionSpacing")}
+        {t("letterSpacing")}
       </span>
       <Slider
-        aria-labelledby="section-spacing-label"
+        aria-labelledby="letter-spacing-label"
         className="max-w-36"
-        value={spacing}
+        value={tracking}
         onValueChange={onValueChange}
-        min={SPACING_MIN}
-        max={SPACING_MAX}
-        step={SPACING_STEP}
+        min={TRACKING_MIN}
+        max={TRACKING_MAX}
+        step={TRACKING_STEP}
       />
     </div>
   );

--- a/src/components/editor/editor-document-line-height.tsx
+++ b/src/components/editor/editor-document-line-height.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Slider } from "@/components/ui/slider";
+import { useResumeStore } from "@/lib/store";
+import { resolveTemplateId, TEMPLATE_LINE_HEIGHT } from "@/lib/templates";
+
+const LINE_HEIGHT_MIN = 1.2;
+const LINE_HEIGHT_MAX = 2;
+const LINE_HEIGHT_STEP = 0.05;
+
+export function EditorDocumentLineHeight() {
+  const templateId = useResumeStore((state) => state.open?.templateId);
+  const lineHeight = useResumeStore((state) => state.open?.lineHeight);
+  const updateOpen = useResumeStore((state) => state.updateOpen);
+  const t = useTranslations("editor.layout");
+
+  if (templateId === undefined) return null;
+
+  // Until the user moves it, the slider rests at the open template's actual
+  // baseline, so tightening and loosening both start from the truth.
+  const value =
+    lineHeight ?? TEMPLATE_LINE_HEIGHT[resolveTemplateId(templateId)];
+
+  const onValueChange = (next: number | readonly number[]) => {
+    const raw = Array.isArray(next) ? next[0] : (next as number);
+    updateOpen((draft) => {
+      draft.lineHeight = Math.round(raw * 100) / 100;
+    });
+  };
+
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span
+        id="line-height-label"
+        className="shrink-0 text-sm text-muted-foreground"
+      >
+        {t("lineHeight")}
+      </span>
+      <Slider
+        aria-labelledby="line-height-label"
+        className="max-w-36"
+        value={value}
+        onValueChange={onValueChange}
+        min={LINE_HEIGHT_MIN}
+        max={LINE_HEIGHT_MAX}
+        step={LINE_HEIGHT_STEP}
+      />
+    </div>
+  );
+}

--- a/src/components/editor/editor-document-panel.tsx
+++ b/src/components/editor/editor-document-panel.tsx
@@ -7,7 +7,10 @@ import { EditorDocumentFont } from "./editor-document-font";
 import { EditorDocumentIcon } from "./editor-document-icon";
 import { EditorDocumentImport } from "./editor-document-import";
 import { EditorDocumentLanguage } from "./editor-document-language";
+import { EditorDocumentLetterSpacing } from "./editor-document-letter-spacing";
+import { EditorDocumentLineHeight } from "./editor-document-line-height";
 import { EditorDocumentSpacing } from "./editor-document-spacing";
+import { EditorDocumentStyleReset } from "./editor-document-style-reset";
 
 /** The Document tab: document-level actions (language, export, import). */
 export function EditorDocumentPanel() {
@@ -15,10 +18,16 @@ export function EditorDocumentPanel() {
   return (
     <div className="flex flex-col divide-y px-4">
       <section className="flex flex-col gap-3 py-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-medium">{t("stylingHeading")}</h3>
+          <EditorDocumentStyleReset />
+        </div>
+        <EditorDocumentIcon />
         <EditorDocumentLanguage />
         <EditorDocumentFont />
-        <EditorDocumentIcon />
         <EditorDocumentSpacing />
+        <EditorDocumentLineHeight />
+        <EditorDocumentLetterSpacing />
       </section>
 
       <section className="py-4">

--- a/src/components/editor/editor-document-style-reset.tsx
+++ b/src/components/editor/editor-document-style-reset.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { Undo2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useResumeStore } from "@/lib/store";
+
+/**
+ * Restores every document styling setting to its default: contact icons shown,
+ * template font, template line height, no tracking, baseline section spacing.
+ * Document language is content (headings, dates), not styling, so it is
+ * deliberately left untouched.
+ */
+export function EditorDocumentStyleReset() {
+  const pristine = useResumeStore((state) => {
+    const open = state.open;
+    if (!open) return true;
+    return (
+      (open.showIcons ?? true) &&
+      !open.font &&
+      (open.sectionSpacing ?? 0) === 0 &&
+      (open.letterSpacing ?? 0) === 0 &&
+      open.lineHeight == null
+    );
+  });
+  const hasOpen = useResumeStore((state) => state.open !== null);
+  const updateOpen = useResumeStore((state) => state.updateOpen);
+  const t = useTranslations("editor.document");
+
+  if (!hasOpen) return null;
+
+  const onReset = () => {
+    updateOpen((draft) => {
+      draft.showIcons = true;
+      draft.sectionSpacing = 0;
+      draft.letterSpacing = 0;
+      delete draft.font;
+      delete draft.lineHeight;
+    });
+  };
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            disabled={pristine}
+            onClick={onReset}
+          />
+        }
+      >
+        <span className="sr-only">{t("resetStyling")}</span>
+        <Undo2 />
+      </TooltipTrigger>
+      <TooltipContent>
+        <span>{t("resetStylingHint")}</span>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/components/editor/pdf/awal-pdf-document.tsx
+++ b/src/components/editor/pdf/awal-pdf-document.tsx
@@ -6,7 +6,6 @@ import {
   Text,
   View,
 } from "@react-pdf/renderer";
-import { resolveFont } from "@/lib/fonts";
 import { buildResumeBlocks, type ResumeBlock } from "../resume-blocks";
 import type {
   CertificateItemView,
@@ -16,6 +15,7 @@ import type {
   ResumePreview,
 } from "../resume-preview";
 import { PdfContactIcon } from "./pdf-contact-icon";
+import { pdfTypography } from "./pdf-font";
 import { PDF_COLORS } from "./pdf-fonts";
 import { dateRange, PdfGrid } from "./pdf-grid";
 import { PdfRichText } from "./pdf-rich-text";
@@ -184,12 +184,12 @@ function PdfBlock(props: { block: ResumeBlock }) {
  */
 export function AwalPdfDocument(props: { preview: ResumePreview }) {
   const blocks = buildResumeBlocks(props.preview);
-  const family = resolveFont(props.preview.font ?? undefined)?.family;
+  const typography = pdfTypography(props.preview);
   return (
     <Document>
       <Page
         size="A4"
-        style={family ? [styles.page, { fontFamily: family }] : styles.page}
+        style={typography.page ? [styles.page, typography.page] : styles.page}
       >
         {blocks.map((block) => (
           <View

--- a/src/components/editor/pdf/ketat-pdf-document.tsx
+++ b/src/components/editor/pdf/ketat-pdf-document.tsx
@@ -6,7 +6,6 @@ import {
   Text,
   View,
 } from "@react-pdf/renderer";
-import { resolveFont } from "@/lib/fonts";
 import { buildResumeBlocks, type ResumeBlock } from "../resume-blocks";
 import type {
   CertificateItemView,
@@ -16,7 +15,7 @@ import type {
   ResumePreview,
 } from "../resume-preview";
 import { PdfContactIcon } from "./pdf-contact-icon";
-import { PdfFontContext, usePdfFontFamily } from "./pdf-font";
+import { PdfFontContext, pdfTypography, usePdfFontFamily } from "./pdf-font";
 import { PDF_COLORS } from "./pdf-fonts";
 import { dateRange, PdfGrid } from "./pdf-grid";
 import { PdfRichText } from "./pdf-rich-text";
@@ -214,13 +213,13 @@ function KetatBlock(props: { block: ResumeBlock }) {
  */
 export function KetatPdfDocument(props: { preview: ResumePreview }) {
   const blocks = buildResumeBlocks(props.preview);
-  const family = resolveFont(props.preview.font ?? undefined)?.family ?? null;
+  const typography = pdfTypography(props.preview);
   return (
-    <PdfFontContext.Provider value={family}>
+    <PdfFontContext.Provider value={typography.family}>
       <Document>
         <Page
           size="A4"
-          style={family ? [styles.page, { fontFamily: family }] : styles.page}
+          style={typography.page ? [styles.page, typography.page] : styles.page}
         >
           {blocks.map((block) => (
             <View

--- a/src/components/editor/pdf/ketik-pdf-document.tsx
+++ b/src/components/editor/pdf/ketik-pdf-document.tsx
@@ -6,7 +6,6 @@ import {
   Text,
   View,
 } from "@react-pdf/renderer";
-import { resolveFont } from "@/lib/fonts";
 import { buildResumeBlocks, type ResumeBlock } from "../resume-blocks";
 import type {
   CertificateItemView,
@@ -16,7 +15,7 @@ import type {
   HeaderView,
   ResumePreview,
 } from "../resume-preview";
-import { PdfFontContext, usePdfFontFamily } from "./pdf-font";
+import { PdfFontContext, pdfTypography, usePdfFontFamily } from "./pdf-font";
 import { PDF_COLORS } from "./pdf-fonts";
 import { dateRange, PdfGrid } from "./pdf-grid";
 import { PdfRichText } from "./pdf-rich-text";
@@ -218,13 +217,13 @@ function KetikBlock(props: { block: ResumeBlock }) {
  */
 export function KetikPdfDocument(props: { preview: ResumePreview }) {
   const blocks = buildResumeBlocks(props.preview);
-  const family = resolveFont(props.preview.font ?? undefined)?.family ?? null;
+  const typography = pdfTypography(props.preview);
   return (
-    <PdfFontContext.Provider value={family}>
+    <PdfFontContext.Provider value={typography.family}>
       <Document>
         <Page
           size="A4"
-          style={family ? [styles.page, { fontFamily: family }] : styles.page}
+          style={typography.page ? [styles.page, typography.page] : styles.page}
         >
           {blocks.map((block) => (
             <View

--- a/src/components/editor/pdf/klasik-pdf-document.tsx
+++ b/src/components/editor/pdf/klasik-pdf-document.tsx
@@ -6,7 +6,6 @@ import {
   Text,
   View,
 } from "@react-pdf/renderer";
-import { resolveFont } from "@/lib/fonts";
 import { buildResumeBlocks, type ResumeBlock } from "../resume-blocks";
 import type {
   CertificateItemView,
@@ -16,6 +15,7 @@ import type {
   HeaderView,
   ResumePreview,
 } from "../resume-preview";
+import { pdfTypography } from "./pdf-font";
 import { PDF_COLORS } from "./pdf-fonts";
 import { dateRange, PdfGrid } from "./pdf-grid";
 import { PdfRichText } from "./pdf-rich-text";
@@ -197,12 +197,12 @@ function KlasikBlock(props: { block: ResumeBlock }) {
  */
 export function KlasikPdfDocument(props: { preview: ResumePreview }) {
   const blocks = buildResumeBlocks(props.preview);
-  const family = resolveFont(props.preview.font ?? undefined)?.family;
+  const typography = pdfTypography(props.preview);
   return (
     <Document>
       <Page
         size="A4"
-        style={family ? [styles.page, { fontFamily: family }] : styles.page}
+        style={typography.page ? [styles.page, typography.page] : styles.page}
       >
         {blocks.map((block) => (
           <View

--- a/src/components/editor/pdf/luasa-pdf-document.tsx
+++ b/src/components/editor/pdf/luasa-pdf-document.tsx
@@ -6,7 +6,6 @@ import {
   Text,
   View,
 } from "@react-pdf/renderer";
-import { resolveFont } from "@/lib/fonts";
 import { buildResumeBlocks, type ResumeBlock } from "../resume-blocks";
 import type {
   CertificateItemView,
@@ -16,7 +15,7 @@ import type {
   HeaderView,
   ResumePreview,
 } from "../resume-preview";
-import { PdfFontContext, usePdfFontFamily } from "./pdf-font";
+import { PdfFontContext, pdfTypography, usePdfFontFamily } from "./pdf-font";
 import { PDF_COLORS } from "./pdf-fonts";
 import { dateRange, PdfGrid } from "./pdf-grid";
 import { PdfRichText } from "./pdf-rich-text";
@@ -209,13 +208,13 @@ function LuasaBlock(props: { block: ResumeBlock }) {
  */
 export function LuasaPdfDocument(props: { preview: ResumePreview }) {
   const blocks = buildResumeBlocks(props.preview);
-  const family = resolveFont(props.preview.font ?? undefined)?.family ?? null;
+  const typography = pdfTypography(props.preview);
   return (
-    <PdfFontContext.Provider value={family}>
+    <PdfFontContext.Provider value={typography.family}>
       <Document>
         <Page
           size="A4"
-          style={family ? [styles.page, { fontFamily: family }] : styles.page}
+          style={typography.page ? [styles.page, typography.page] : styles.page}
         >
           {blocks.map((block) => (
             <View

--- a/src/components/editor/pdf/pdf-font.ts
+++ b/src/components/editor/pdf/pdf-font.ts
@@ -1,4 +1,9 @@
+import type { Styles } from "@react-pdf/renderer";
 import { createContext, useContext } from "react";
+import { resolveFont } from "@/lib/fonts";
+import type { ResumePreview } from "../resume-preview";
+
+type PdfStyle = Styles[string];
 
 /**
  * Document-level font family override for a PDF render; null means the
@@ -13,4 +18,28 @@ export const PdfFontContext = createContext<string | null>(null);
  */
 export function usePdfFontFamily(fallback: string): string {
   return useContext(PdfFontContext) ?? fallback;
+}
+
+interface PdfTypography {
+  /** Override family for PdfFontContext, or null for template families. */
+  family: string | null;
+  /** Page-level style overrides, or null when template defaults fully apply. */
+  page: PdfStyle | null;
+}
+
+/**
+ * The document-level typography overrides a PDF template applies at its Page:
+ * font family, tracking, and line height all inherit from the Page in
+ * react-pdf, so one style array entry covers the whole document (explicit
+ * per-element styles, e.g. a serif accent or a name's tight leading, still
+ * win, matching the preview's behavior). An absent line height keeps the
+ * template's own page baseline.
+ */
+export function pdfTypography(preview: ResumePreview): PdfTypography {
+  const family = resolveFont(preview.font ?? undefined)?.family ?? null;
+  const page: PdfStyle = {};
+  if (family) page.fontFamily = family;
+  if (preview.letterSpacing !== 0) page.letterSpacing = preview.letterSpacing;
+  if (preview.lineHeight != null) page.lineHeight = preview.lineHeight;
+  return { family, page: Object.keys(page).length > 0 ? page : null };
 }

--- a/src/components/editor/pdf/tebal-pdf-document.tsx
+++ b/src/components/editor/pdf/tebal-pdf-document.tsx
@@ -6,7 +6,6 @@ import {
   Text,
   View,
 } from "@react-pdf/renderer";
-import { resolveFont } from "@/lib/fonts";
 import { buildResumeBlocks, type ResumeBlock } from "../resume-blocks";
 import type {
   CertificateItemView,
@@ -16,6 +15,7 @@ import type {
   ResumePreview,
 } from "../resume-preview";
 import { PdfContactIcon } from "./pdf-contact-icon";
+import { pdfTypography } from "./pdf-font";
 import { PDF_COLORS } from "./pdf-fonts";
 import { dateRange, PdfGrid } from "./pdf-grid";
 import { PdfRichText } from "./pdf-rich-text";
@@ -194,12 +194,12 @@ function TebalBlock(props: { block: ResumeBlock }) {
  */
 export function TebalPdfDocument(props: { preview: ResumePreview }) {
   const blocks = buildResumeBlocks(props.preview);
-  const family = resolveFont(props.preview.font ?? undefined)?.family;
+  const typography = pdfTypography(props.preview);
   return (
     <Document>
       <Page
         size="A4"
-        style={family ? [styles.page, { fontFamily: family }] : styles.page}
+        style={typography.page ? [styles.page, typography.page] : styles.page}
       >
         {blocks.map((block) => (
           <View

--- a/src/components/editor/resume-blocks.ts
+++ b/src/components/editor/resume-blocks.ts
@@ -308,13 +308,17 @@ export function buildResumeBlocks(resume: ResumePreview): ResumeBlock[] {
     }
   }
 
-  // Document-level section spacing widens only the gap above headings; the
+  // Document-level section spacing adjusts only the gap above headings; the
   // paginator and every PDF template consume `gapBefore`, so this single
-  // adjustment reaches all of them.
-  if (resume.sectionSpacing > 0) {
+  // adjustment reaches all of them. Floored at zero so a tightened document
+  // collapses sections to flush instead of overlapping them.
+  if (resume.sectionSpacing !== 0) {
     return blocks.map((block) =>
       block.kind === "heading"
-        ? { ...block, gapBefore: block.gapBefore + resume.sectionSpacing }
+        ? {
+            ...block,
+            gapBefore: Math.max(0, block.gapBefore + resume.sectionSpacing),
+          }
         : block,
     );
   }

--- a/src/components/editor/resume-document.tsx
+++ b/src/components/editor/resume-document.tsx
@@ -5,7 +5,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import type { TemplateId } from "@/lib/templates";
 import { ResumeAnimatedBlock } from "./resume-animated-block";
 import { buildResumeBlocks } from "./resume-blocks";
-import { ResumeFontFaces, resumeFontVars } from "./resume-fonts";
+import { ResumeFontFaces, resumeTypographyStyle } from "./resume-fonts";
 import { A4, CONTENT_HEIGHT_PX, CONTENT_WIDTH_PX } from "./resume-geometry";
 import { ResumePage } from "./resume-page";
 import { paginate } from "./resume-paginate";
@@ -92,7 +92,7 @@ export function ResumeDocument(props: ResumeDocumentProps) {
     <div
       ref={containerRef}
       className="w-full font-sans"
-      style={resumeFontVars(props.resume.font)}
+      style={resumeTypographyStyle(props.resume, props.template)}
     >
       <ResumeFontFaces />
       <div

--- a/src/components/editor/resume-fonts.tsx
+++ b/src/components/editor/resume-fonts.tsx
@@ -1,20 +1,47 @@
 import type { CSSProperties } from "react";
 import { FONTS, resolveFont } from "@/lib/fonts";
+import { TEMPLATE_LINE_HEIGHT, type TemplateId } from "@/lib/templates";
+import type { ResumePreview } from "./resume-preview";
+
+type TypographySlice = Pick<
+  ResumePreview,
+  "font" | "letterSpacing" | "lineHeight"
+>;
 
 /**
- * CSS variables scoping the résumé's fonts to a preview subtree. With no
- * override the template defaults apply (Inter sans, Lora serif, GeistMono
- * mono, matching the PDF registrations); an override points all three slots at
- * the chosen family so the whole document renders in it. Always set from the
+ * Inline style scoping the résumé's typography to a preview subtree.
+ *
+ * Fonts are CSS variables: with no override the template defaults apply (Inter
+ * sans, Lora serif, GeistMono mono, matching the PDF registrations); an
+ * override points all three slots at the chosen family. Always set from the
  * self-hosted faces so the preview matches the PDF export exactly.
+ *
+ * Letter spacing inherits natively. Line height is always resolved (the
+ * document value, else the template baseline) and carried by the inheriting
+ * `--resume-line-height` variable that the rich-text body's leading consumes
+ * (Tailwind's `--tw-leading` is registered non-inheriting, so it can't carry
+ * a document-wide value); this keeps the on-screen body rhythm identical to
+ * the PDF page's. Single-line accents (names, headings, dates) keep their
+ * size-specific leading, mirroring the PDF's explicit per-element styles.
  */
-export function resumeFontVars(fontId: string | null): CSSProperties {
-  const override = resolveFont(fontId ?? undefined);
-  return {
+export function resumeTypographyStyle(
+  resume: TypographySlice,
+  template: TemplateId,
+): CSSProperties {
+  const override = resolveFont(resume.font ?? undefined);
+  const lineHeight = resume.lineHeight ?? TEMPLATE_LINE_HEIGHT[template];
+  const style: CSSProperties = {
     "--font-sans": `${override?.family ?? "Inter"}, ui-sans-serif, system-ui, sans-serif`,
     "--font-serif": `${override?.family ?? "Lora"}, ui-serif, Georgia, serif`,
     "--font-geist-mono": `${override?.family ?? "GeistMono"}, ui-monospace, monospace`,
+    lineHeight,
   } as CSSProperties;
+  (style as Record<string, unknown>)["--resume-line-height"] =
+    String(lineHeight);
+  if (resume.letterSpacing !== 0) {
+    style.letterSpacing = `${resume.letterSpacing}px`;
+  }
+  return style;
 }
 
 const FONT_FACE_CSS = FONTS.flatMap((font) =>

--- a/src/components/editor/resume-preview.ts
+++ b/src/components/editor/resume-preview.ts
@@ -112,8 +112,10 @@ export interface ResumePreview {
   /** Document language for fixed labels (headings, dates); drives localization. */
   language: ResumeLanguage;
   /**
-   * Presentation-only extra space above each section heading (px on screen,
-   * pt in PDF), on top of the template's baseline rhythm; 0 = baseline.
+   * Presentation-only space adjustment above each section heading (px on
+   * screen, pt in PDF), on top of the template's baseline rhythm; 0 =
+   * baseline, clamped to -24..60 so the gap can reach flush but never
+   * negative.
    */
   sectionSpacing: number;
   /**
@@ -121,6 +123,16 @@ export interface ResumePreview {
    * shipped families. Applies to the whole document in preview and PDF.
    */
   font: string | null;
+  /**
+   * Document-wide tracking (px on screen, pt in PDF), clamped to the
+   * extraction-safe -0.5..0.5 range; 0 = template default (no tracking).
+   */
+  letterSpacing: number;
+  /**
+   * Document-wide unitless line height (clamped 1.2..2), or null for the
+   * template's baseline (TEMPLATE_LINE_HEIGHT).
+   */
+  lineHeight: number | null;
   headings: SectionHeadings;
   /**
    * The reorderable sections in document (reading) order. Drives the order blocks

--- a/src/components/editor/resume-rich-text.tsx
+++ b/src/components/editor/resume-rich-text.tsx
@@ -44,7 +44,9 @@ export function ResumeRichText(props: ResumeRichTextProps) {
   return (
     <div
       className={cn(
-        "space-y-1 text-xs leading-relaxed text-muted-foreground",
+        // The document's resolved line height (see resumeTypographyStyle), so
+        // the on-screen body rhythm matches the PDF page's.
+        "space-y-1 text-xs leading-(--resume-line-height,1.4) text-muted-foreground",
         props.className,
       )}
     >

--- a/src/components/editor/resume-thumbnail.tsx
+++ b/src/components/editor/resume-thumbnail.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { TemplateId } from "@/lib/templates";
 import { buildResumeBlocks } from "./resume-blocks";
-import { ResumeFontFaces, resumeFontVars } from "./resume-fonts";
+import { ResumeFontFaces, resumeTypographyStyle } from "./resume-fonts";
 import { A4 } from "./resume-geometry";
 import { ResumePage } from "./resume-page";
 import type { ResumePreview } from "./resume-preview";
@@ -48,7 +48,7 @@ export function ResumeThumbnail(props: ResumeThumbnailProps) {
       aria-hidden
       data-template={props.template}
       className="pointer-events-none w-full select-none font-sans"
-      style={resumeFontVars(props.resume.font)}
+      style={resumeTypographyStyle(props.resume, props.template)}
     >
       <ResumeFontFaces />
       {scale > 0 && (

--- a/src/components/editor/resume-to-preview.ts
+++ b/src/components/editor/resume-to-preview.ts
@@ -204,10 +204,18 @@ export function resumeToPreview(resume: Resume): ResumePreview {
 
   return {
     language: resume.language,
-    // Clamped so a hand-edited document can widen spacing but never collapse
-    // a template below its baseline or blow up pagination.
-    sectionSpacing: Math.min(60, Math.max(0, resume.sectionSpacing ?? 0)),
+    // Clamped so a hand-edited document can adjust spacing but never push a
+    // heading gap negative (-24 cancels the 24-unit baseline exactly).
+    sectionSpacing: Math.min(60, Math.max(-24, resume.sectionSpacing ?? 0)),
     font: resolveFont(resume.font)?.id ?? null,
+    // Clamps guard hand-edited documents: tracking outside -0.5..0.5 breaks
+    // PDF text extraction (word boundaries merge or split), and out-of-range
+    // line heights break layout.
+    letterSpacing: Math.min(0.5, Math.max(-0.5, resume.letterSpacing ?? 0)),
+    lineHeight:
+      resume.lineHeight != null
+        ? Math.min(2, Math.max(1.2, resume.lineHeight))
+        : null,
     headings,
     sectionOrder,
     customSections,

--- a/src/lib/interchange/codec.ts
+++ b/src/lib/interchange/codec.ts
@@ -32,6 +32,8 @@ export interface ResumeContent {
   showIcons?: boolean;
   sectionSpacing?: number;
   font?: string;
+  letterSpacing?: number;
+  lineHeight?: number;
   header: Header;
   sections: Section[];
 }
@@ -117,6 +119,8 @@ export function resumeToInterchange(resume: Resume): InterchangeResume {
     showIcons: resume.showIcons ?? true,
     sectionSpacing: resume.sectionSpacing ?? 0,
     font: resume.font,
+    letterSpacing: resume.letterSpacing ?? 0,
+    lineHeight: resume.lineHeight,
     header,
     sections: resume.sections.map(sectionToInterchange),
   };
@@ -220,6 +224,8 @@ export function interchangeToContent(data: InterchangeResume): ResumeContent {
     showIcons: data.showIcons,
     sectionSpacing: data.sectionSpacing,
     font: data.font,
+    letterSpacing: data.letterSpacing,
+    lineHeight: data.lineHeight,
     header,
     sections,
   };

--- a/src/lib/interchange/import-file.ts
+++ b/src/lib/interchange/import-file.ts
@@ -26,6 +26,10 @@ function buildImportedResume(
   resume.showIcons = parsed.content.showIcons ?? true;
   resume.sectionSpacing = parsed.content.sectionSpacing ?? 0;
   if (parsed.content.font !== undefined) resume.font = parsed.content.font;
+  resume.letterSpacing = parsed.content.letterSpacing ?? 0;
+  if (parsed.content.lineHeight !== undefined) {
+    resume.lineHeight = parsed.content.lineHeight;
+  }
   if (parsed.content.title) resume.title = parsed.content.title;
   return { ok: true, resume, leftovers: [] };
 }

--- a/src/lib/interchange/schema.ts
+++ b/src/lib/interchange/schema.ts
@@ -89,8 +89,10 @@ export const interchangeSchema = z
     template: z.string().optional(),
     language: z.enum(["en", "id"]).optional(),
     showIcons: z.boolean().optional(),
-    sectionSpacing: z.number().int().min(0).max(60).optional(),
+    sectionSpacing: z.number().int().min(-24).max(60).optional(),
     font: z.string().optional(),
+    letterSpacing: z.number().min(-0.5).max(0.5).optional(),
+    lineHeight: z.number().min(1.2).max(2).optional(),
     header: entryShape(HEADER_SCHEMA).optional(),
     sections: z.array(sectionSchema).optional(),
   })

--- a/src/lib/resume/factory.ts
+++ b/src/lib/resume/factory.ts
@@ -113,6 +113,7 @@ export function createEmptyResume(title: string): Resume {
     language: "en",
     showIcons: true,
     sectionSpacing: 0,
+    letterSpacing: 0,
     header: createEmptyHeader(),
     sections: [
       createEmptySection("summary"),

--- a/src/lib/resume/migrations.ts
+++ b/src/lib/resume/migrations.ts
@@ -547,6 +547,24 @@ const migrateV17toV18: Migration = (doc) => {
 };
 
 /**
+ * v18→v19: adds the presentation-only document-wide typography settings.
+ * `letterSpacing` is stamped to 0 (no tracking), preserving current output;
+ * `lineHeight` stays absent because absence means "template default".
+ * Bail-safe: existing numbers are left as-is and a malformed `lineHeight` is
+ * cleared.
+ */
+const migrateV18toV19: Migration = (doc) => {
+  const next = structuredClone(doc);
+  if (typeof next.letterSpacing !== "number") {
+    next.letterSpacing = 0;
+  }
+  if (next.lineHeight !== undefined && !G.isNumber(next.lineHeight)) {
+    delete next.lineHeight;
+  }
+  return next;
+};
+
+/**
  * The migration ladder. Each key N is a forward-only step from version N to N+1.
  */
 const LADDER: Record<number, Migration> = {
@@ -567,6 +585,7 @@ const LADDER: Record<number, Migration> = {
   15: migrateV15toV16,
   16: migrateV16toV17,
   17: migrateV17toV18,
+  18: migrateV18toV19,
 };
 
 /** The persisted schemaVersion of a raw document; 0 when absent or malformed. */

--- a/src/lib/resume/seed.ts
+++ b/src/lib/resume/seed.ts
@@ -53,6 +53,7 @@ export const SEED_RESUME: Resume = {
   language: "en",
   showIcons: true,
   sectionSpacing: 0,
+  letterSpacing: 0,
   createdAt: "2026-01-01T00:00:00.000Z",
   updatedAt: "2026-01-01T00:00:00.000Z",
   header: {

--- a/src/lib/resume/types.ts
+++ b/src/lib/resume/types.ts
@@ -5,7 +5,7 @@ import type { JSONContent } from "@tiptap/core";
  * governs object-store/index structure only. Bumped whenever a persisted field
  * shape changes; every bump gets a forward-only step in the migration ladder.
  */
-export const CURRENT_SCHEMA_VERSION = 18;
+export const CURRENT_SCHEMA_VERSION = 19;
 
 /** The language the rendered document's fixed labels (headings, dates) use. */
 export type ResumeLanguage = "en" | "id";
@@ -136,10 +136,11 @@ export interface Resume {
    */
   showIcons?: boolean;
   /**
-   * Presentation-only extra vertical space above each section heading, in
-   * rendering units (px on screen, pt in PDF), added on top of the template's
-   * baseline rhythm. 0 or unset keeps the template's current spacing; the
-   * editor only offers increases, never a value below the baseline.
+   * Presentation-only vertical space adjustment above each section heading, in
+   * rendering units (px on screen, pt in PDF), applied on top of the
+   * template's baseline gap. 0 or unset keeps the template's current spacing.
+   * Bounded to -24..60: -24 cancels the 24-unit baseline exactly, so sections
+   * can collapse to flush but the gap never goes negative.
    */
   sectionSpacing?: number;
   /**
@@ -149,6 +150,22 @@ export interface Resume {
    * mean "template default" (the families the template ships with).
    */
   font?: string;
+  /**
+   * Presentation-only letter spacing (tracking) applied document-wide, in
+   * rendering units (px on screen, pt in PDF). Hard-bounded to -0.5..0.5:
+   * react-pdf places letter-spaced glyphs individually, and outside that range
+   * at the 8-9pt body sizes text extractors stop recovering word boundaries
+   * (splitting words when too wide, merging them when too tight), which would
+   * break ATS parsing. 0 or unset means the template default (no tracking).
+   */
+  letterSpacing?: number;
+  /**
+   * Presentation-only unitless line height applied document-wide, replacing
+   * the template's baseline (TEMPLATE_LINE_HEIGHT). Absent means "template
+   * default". Bounded to 1.2..2. Per-element accents (e.g. a name's tight
+   * leading) still win over the document value.
+   */
+  lineHeight?: number;
   header: Header;
   sections: Section[];
   /** ISO 8601. */

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -28,6 +28,21 @@ export function resolveTemplateId(id: string): TemplateId {
     : DEFAULT_TEMPLATE_ID;
 }
 
+/**
+ * Each template's baseline body line height. Mirrors the `lineHeight` in the
+ * template's PDF page style (src/components/editor/pdf/<id>-pdf-document.tsx);
+ * keep the two in sync. The editor's line-height slider rests here, and the
+ * preview body renders it so the on-screen rhythm matches the PDF.
+ */
+export const TEMPLATE_LINE_HEIGHT: Record<TemplateId, number> = {
+  awal: 1.4,
+  ketat: 1.4,
+  luasa: 1.45,
+  tebal: 1.4,
+  klasik: 1.45,
+  ketik: 1.4,
+};
+
 /** Templates whose headers draw contact icon glyphs; the rest render text-only contacts. */
 const TEMPLATE_IDS_WITH_CONTACT_ICONS: TemplateId[] = [
   "awal",


### PR DESCRIPTION
Adds line height and letter spacing controls to the Document tab, makes section spacing bidirectional to match, and adds a one-tap reset for all document styling. Every slider rests at the document's true current value and moves both ways, so tightening is as much a first-class action as loosening.

- Line height (1.2 to 2.0) rests at the open template's actual baseline, 1.4 for most templates and 1.45 for Klasik and Luasa, from a new `TEMPLATE_LINE_HEIGHT` map that mirrors each PDF page style. Fixing the slider's resting position also fixed a real parity gap: the preview body rendered 1.625 leading while the PDF used 1.4/1.45, so on-screen rhythm and export never quite matched. The preview body now follows the template baseline; the exported PDF is unchanged.
- Letter spacing spans -0.5 to +0.5. The bounds come from measured extraction behavior: react-pdf places letter-spaced glyphs individually, and outside that range at the 8-9pt body sizes text extractors stop recovering word boundaries, splitting words when too wide ("Cor p") and merging them when too tight. Every shippable value was verified to extract intact, and the bounds are enforced three times over: slider, interchange validation, and a view-model clamp, so even a hand-edited YAML cannot break ATS parsing.
- Section spacing now runs -24 to +60. The floor cancels the 24-unit baseline gap above headings exactly, so sections can sit flush but never overlap; entry spacing inside sections is untouched either way.
- The Document styling section header gains a reset button that restores icons, font, section spacing, line height, and letter spacing to their defaults in one write. It disables itself while everything is already pristine. Document language is deliberately excluded, since it relabels content rather than styling.
- Schema: `letterSpacing` and `lineHeight` on the document with `CURRENT_SCHEMA_VERSION` bumped to 19 and a bail-safe rung (letter spacing stamped to 0, absent line height meaning template default). JSON and YAML interchange round-trips both with the same bounds.

Testing: a fresh resume's preview body measures exactly the template's 1.4 baseline; tightening both typography sliders to their minimums compacts the page visibly, persists a reload, and reads back in the controls; the tightest possible PDF still extracts every word whole and in linear reading order, as does the widest. Section spacing at -24 renders headings flush with the previous section while entry gaps hold, and +60 still paginates correctly. The reset button starts disabled, enables after any change, restores every control and the preview in one click, disables again, and the reset state survives a reload. Documents saved at schema versions 16 and 18 open at their baselines with all controls at rest and no errors.