### PR TITLE
refactor: move the section order reset into the editor tab

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -564,6 +564,7 @@
       "hideSection": "Hide section",
       "reorderSection": "Reorder section",
       "resetOrder": "Reset section order",
+      "sectionsHeading": "Sections",
       "addSection": "Custom Section",
       "tabDocument": "Document"
     },

--- a/messages/id.json
+++ b/messages/id.json
@@ -564,6 +564,7 @@
       "hideSection": "Sembunyikan bagian",
       "reorderSection": "Ubah urutan bagian",
       "resetOrder": "Setel ulang urutan bagian",
+      "sectionsHeading": "Bagian",
       "addSection": "Bagian Khusus",
       "tabDocument": "Dokumen"
     },

--- a/src/components/editor/editor-sections/ed-section-order-reset.tsx
+++ b/src/components/editor/editor-sections/ed-section-order-reset.tsx
@@ -33,9 +33,8 @@ export function EditorSectionOrderReset() {
       <TooltipTrigger
         render={
           <Button
-            size="icon-xs"
+            size="icon-sm"
             variant="ghost"
-            className="ml-auto"
             disabled={disabled}
             onClick={() => resetSectionOrder()}
           />

--- a/src/components/editor/editor-sidebar-content.tsx
+++ b/src/components/editor/editor-sidebar-content.tsx
@@ -40,11 +40,16 @@ export function EditorSidebarContent() {
               </TabsTrigger>
             ))}
           </TabsList>
-          <EditorSectionOrderReset />
         </div>
 
         <TabsContent value="editor">
           <ScrollArea id="tour-editor-sections" className={PANEL_HEIGHT}>
+            <div className="flex items-center justify-end px-4 pt-4">
+              <h3 className="text-sm font-medium sr-only">
+                {t("sectionsHeading")}
+              </h3>
+              <EditorSectionOrderReset />
+            </div>
             <EditorSectionList />
           </ScrollArea>
         </TabsContent>


### PR DESCRIPTION
The undo-reordering button used to sit in the tab bar next to the tab list, visible on every tab even though it only acts on the Editor tab's section list. It now lives inside the Editor tab content, right-aligned above the list, so the control sits in the scope it affects and the tab bar goes back to being pure navigation. This mirrors the Document tab's styling-reset placement, giving both panels the same idiom.

The row carries a screen-reader-only "Sections" heading for context, and the button matches the Document tab's reset sizing. New heading strings land in both locales.

Testing: on the Editor tab the reset renders above the section list and stays disabled while the order is canonical; on the Layout and Document tabs it does not render at all; the tab bar contains only the three tabs.