### PR TITLE
fix: align the layout tab template order with the other grids

### DIFF
--- a/src/components/editor/editor-layout/ed-layout-template-list.tsx
+++ b/src/components/editor/editor-layout/ed-layout-template-list.tsx
@@ -5,7 +5,7 @@ import { RadioGroup } from "@/components/ui/radio-group";
 import { Skeleton } from "@/components/ui/skeleton";
 import { SEED_RESUME } from "@/lib/resume";
 import { useResumeStore } from "@/lib/store";
-import { resolveTemplateId, TEMPLATES } from "@/lib/templates";
+import { resolveTemplateId, SORTED_TEMPLATES } from "@/lib/templates";
 import { buildResumeBlocks } from "../resume-blocks";
 import { resumeToPreview } from "../resume-to-preview";
 import { EditorLayoutTemplateItem } from "./ed-layout-template-item";
@@ -53,7 +53,7 @@ export function EditorLayoutTemplateList() {
         }}
         className="grid grid-cols-2 gap-3 px-4"
       >
-        {TEMPLATES.map((template) => (
+        {SORTED_TEMPLATES.map((template) => (
           <EditorLayoutTemplateItem
             key={template.id}
             template={template}

--- a/src/components/platform/platform-template-radio-group.tsx
+++ b/src/components/platform/platform-template-radio-group.tsx
@@ -7,15 +7,12 @@ import { resumeToPreview } from "@/components/editor/resume-to-preview";
 import { RadioGroup } from "@/components/ui/radio-group";
 import { SEED_RESUME } from "@/lib/resume";
 import {
-  DEFAULT_TEMPLATE_SORT,
-  sortTemplates,
-  TEMPLATES,
+  SORTED_TEMPLATES,
   type TemplateId,
   type TemplateSummary,
 } from "@/lib/templates";
 
 const SEED_PREVIEW = resumeToPreview(SEED_RESUME);
-const SORTED_TEMPLATES = sortTemplates(TEMPLATES, DEFAULT_TEMPLATE_SORT);
 
 const DOTTED_SURFACE =
   "bg-[radial-gradient(color-mix(in_oklab,var(--color-foreground)_7%,transparent)_1px,transparent_1px)] bg-size-[0.5rem_0.5rem]";

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -88,6 +88,17 @@ export function filterTemplates(
   );
 }
 
+/**
+ * The catalog in the default browse order. Every template grid (browse page's
+ * default sort, create dialog, editor Layout tab) renders this list so the
+ * surfaces can never drift apart; only the browse page re-sorts, and only when
+ * the user picks another sort.
+ */
+export const SORTED_TEMPLATES: TemplateSummary[] = sortTemplates(
+  TEMPLATES,
+  DEFAULT_TEMPLATE_SORT,
+);
+
 export function sortTemplates(
   templates: TemplateSummary[],
   sort: TemplateSort,


### PR DESCRIPTION
Three surfaces render a template grid: the browse page, the create dialog, and the editor's Layout tab. The earlier alignment fix (#107) sorted the create dialog to match the browse page's default order but did it with a local copy of the sort, and the Layout tab was missed entirely; it still rendered the catalog's declaration order (Awal, Ketat, Luasa, Tebal, Klasik, Ketik).

The ordering now lives once in the catalog: `SORTED_TEMPLATES` in `src/lib/templates.ts`, pre-sorted by the default browse sort. The Layout tab and the create dialog both render it, and the dialog's local sorting is gone. The browse page keeps its user-controlled sort toolbar, whose default already produces the same list, so a fourth surface added tomorrow has one obvious import to reach for.

Testing: read the rendered tile names in order from all three surfaces and confirmed they match exactly (Awal, Ketat, Ketik, Klasik, Luasa, Tebal); the browse page's sort toolbar still re-sorts on demand.