### PR TITLE
feat: scale name, heading, and body font sizes from the document tab

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -192,6 +192,10 @@
           {
             "title": "Line height and letter spacing",
             "description": "Two more sliders in the Document tab, resting at each template's real values: tighten or loosen line height and letter spacing either way, both bounded to the range where PDF text still extracts cleanly, so your styling never costs you ATS parsing."
+          },
+          {
+            "title": "Font size controls",
+            "description": "Resize your name, section headings, and body text independently from the Document tab. Each slider scales its group on top of the template's proportions, so a bigger name never flattens the rest, and the preview and PDF stay in step."
           }
         ],
         "0_9_0": [
@@ -545,7 +549,10 @@
       "fontSerif": "Serif",
       "fontMono": "Mono",
       "lineHeight": "Line height",
-      "letterSpacing": "Letter spacing"
+      "letterSpacing": "Letter spacing",
+      "fontSizeName": "Name size",
+      "fontSizeTitle": "Heading size",
+      "fontSizeBody": "Body size"
     },
     "chrome": {
       "edit": "Edit",

--- a/messages/id.json
+++ b/messages/id.json
@@ -192,6 +192,10 @@
           {
             "title": "Tinggi baris dan jarak antarhuruf",
             "description": "Dua slider baru di tab Dokumen yang berangkat dari nilai asli tiap template: rapatkan atau longgarkan tinggi baris dan jarak antarhuruf ke dua arah, keduanya dibatasi pada rentang di mana teks PDF masih terekstrak bersih, jadi gaya kamu nggak pernah mengorbankan parsing ATS."
+          },
+          {
+            "title": "Kontrol ukuran font",
+            "description": "Ubah ukuran nama, judul bagian, dan teks isi secara terpisah dari tab Dokumen. Tiap slider menskalakan kelompoknya di atas proporsi template, jadi nama yang lebih besar nggak pernah meratakan sisanya, dan pratinjau serta PDF tetap selaras."
           }
         ],
         "0_9_0": [
@@ -545,7 +549,10 @@
       "fontSerif": "Serif",
       "fontMono": "Mono",
       "lineHeight": "Tinggi baris",
-      "letterSpacing": "Jarak antarhuruf"
+      "letterSpacing": "Jarak antarhuruf",
+      "fontSizeName": "Ukuran nama",
+      "fontSizeTitle": "Ukuran judul",
+      "fontSizeBody": "Ukuran isi"
     },
     "chrome": {
       "edit": "Edit",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -126,6 +126,41 @@
   --sidebar-ring: oklch(0.58 0.031 107.3);
 }
 
+/* Résumé font-size scaling. Each utility multiplies a fixed baseline size by
+   the document's per-group scale variable (default 1 via the fallback), so the
+   Name / Section title / Body sliders resize their group while keeping every
+   template's built-in proportions. See resumeTypographyStyle. */
+@utility resume-name-xl {
+  font-size: calc(1.25rem * var(--resume-name-scale, 1));
+}
+@utility resume-name-2xl {
+  font-size: calc(1.5rem * var(--resume-name-scale, 1));
+}
+@utility resume-name-3xl {
+  font-size: calc(1.875rem * var(--resume-name-scale, 1));
+}
+@utility resume-name-sm {
+  font-size: calc(0.875rem * var(--resume-name-scale, 1));
+}
+@utility resume-name-base {
+  font-size: calc(1rem * var(--resume-name-scale, 1));
+}
+@utility resume-title-base {
+  font-size: calc(1rem * var(--resume-title-scale, 1));
+}
+@utility resume-title-sm {
+  font-size: calc(0.875rem * var(--resume-title-scale, 1));
+}
+@utility resume-title-xs {
+  font-size: calc(0.75rem * var(--resume-title-scale, 1));
+}
+@utility resume-body-sm {
+  font-size: calc(0.875rem * var(--resume-body-scale, 1));
+}
+@utility resume-body-xs {
+  font-size: calc(0.75rem * var(--resume-body-scale, 1));
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/src/components/editor/editor-document-font-size.tsx
+++ b/src/components/editor/editor-document-font-size.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Slider } from "@/components/ui/slider";
+import type { Resume } from "@/lib/resume";
+import { useResumeStore } from "@/lib/store";
+
+const SCALE_MIN = 0.8;
+const SCALE_MAX = 1.2;
+const SCALE_STEP = 0.05;
+
+type ScaleField = "nameScale" | "titleScale" | "bodyScale";
+
+const ROWS: { field: ScaleField; labelKey: string }[] = [
+  { field: "nameScale", labelKey: "fontSizeName" },
+  { field: "titleScale", labelKey: "fontSizeTitle" },
+  { field: "bodyScale", labelKey: "fontSizeBody" },
+];
+
+/** One labeled font-size scale slider; rests at 100% and adjusts both ways. */
+function FontSizeRow(props: { field: ScaleField; labelKey: string }) {
+  const value = useResumeStore((state) => state.open?.[props.field] ?? 1);
+  const updateOpen = useResumeStore((state) => state.updateOpen);
+  const t = useTranslations("editor.layout");
+  const id = `font-size-${props.field}`;
+
+  const onValueChange = (next: number | readonly number[]) => {
+    const raw = Array.isArray(next) ? next[0] : (next as number);
+    updateOpen((draft: Resume) => {
+      draft[props.field] = Math.round(raw * 100) / 100;
+    });
+  };
+
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span id={id} className="shrink-0 text-sm text-muted-foreground">
+        {t(props.labelKey)}
+      </span>
+      <Slider
+        aria-labelledby={id}
+        className="max-w-36"
+        value={value}
+        onValueChange={onValueChange}
+        min={SCALE_MIN}
+        max={SCALE_MAX}
+        step={SCALE_STEP}
+      />
+    </div>
+  );
+}
+
+export function EditorDocumentFontSize() {
+  const hasOpen = useResumeStore((state) => state.open !== null);
+  if (!hasOpen) return null;
+  return (
+    <>
+      {ROWS.map((row) => (
+        <FontSizeRow
+          key={row.field}
+          field={row.field}
+          labelKey={row.labelKey}
+        />
+      ))}
+    </>
+  );
+}

--- a/src/components/editor/editor-document-panel.tsx
+++ b/src/components/editor/editor-document-panel.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from "next-intl";
 import { EditorDocumentCopy } from "./editor-document-copy";
 import { EditorDocumentDownload } from "./editor-document-download";
 import { EditorDocumentFont } from "./editor-document-font";
+import { EditorDocumentFontSize } from "./editor-document-font-size";
 import { EditorDocumentIcon } from "./editor-document-icon";
 import { EditorDocumentImport } from "./editor-document-import";
 import { EditorDocumentLanguage } from "./editor-document-language";
@@ -25,6 +26,7 @@ export function EditorDocumentPanel() {
         <EditorDocumentIcon />
         <EditorDocumentLanguage />
         <EditorDocumentFont />
+        <EditorDocumentFontSize />
         <EditorDocumentSpacing />
         <EditorDocumentLineHeight />
         <EditorDocumentLetterSpacing />

--- a/src/components/editor/editor-document-style-reset.tsx
+++ b/src/components/editor/editor-document-style-reset.tsx
@@ -25,7 +25,10 @@ export function EditorDocumentStyleReset() {
       !open.font &&
       (open.sectionSpacing ?? 0) === 0 &&
       (open.letterSpacing ?? 0) === 0 &&
-      open.lineHeight == null
+      open.lineHeight == null &&
+      (open.nameScale ?? 1) === 1 &&
+      (open.titleScale ?? 1) === 1 &&
+      (open.bodyScale ?? 1) === 1
     );
   });
   const hasOpen = useResumeStore((state) => state.open !== null);
@@ -41,6 +44,9 @@ export function EditorDocumentStyleReset() {
       draft.letterSpacing = 0;
       delete draft.font;
       delete draft.lineHeight;
+      delete draft.nameScale;
+      delete draft.titleScale;
+      delete draft.bodyScale;
     });
   };
 

--- a/src/components/editor/pdf/awal-pdf-document.tsx
+++ b/src/components/editor/pdf/awal-pdf-document.tsx
@@ -15,57 +15,74 @@ import type {
   ResumePreview,
 } from "../resume-preview";
 import { PdfContactIcon } from "./pdf-contact-icon";
-import { pdfTypography } from "./pdf-font";
+import {
+  type FontScales,
+  fontScales,
+  NO_SCALE,
+  PdfStylesContext,
+  pdfTypography,
+  usePdfStyles,
+} from "./pdf-font";
 import { PDF_COLORS } from "./pdf-fonts";
 import { dateRange, PdfGrid } from "./pdf-grid";
 import { PdfRichText } from "./pdf-rich-text";
 
-const styles = StyleSheet.create({
-  page: {
-    paddingVertical: 40,
-    paddingHorizontal: 44,
-    fontFamily: "Inter",
-    fontSize: 9,
-    color: PDF_COLORS.foreground,
-    lineHeight: 1.4,
-  },
-  header: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "flex-start",
-    gap: 16,
-  },
-  headerLeft: { flexShrink: 1 },
-  name: { fontSize: 18, fontWeight: 700, lineHeight: 1.25 },
-  headline: { marginTop: 2, fontSize: 10.5, color: PDF_COLORS.muted },
-  headerRight: { alignItems: "flex-start", gap: 3 },
-  contactRow: { flexDirection: "row", alignItems: "center", gap: 4 },
-  linkPlain: { color: PDF_COLORS.foreground, textDecoration: "none" },
-  heading: {
-    fontSize: 10,
-    fontWeight: 600,
-    textTransform: "uppercase",
-    letterSpacing: 0.5,
-    paddingBottom: 2,
-    borderBottomWidth: 0.75,
-    borderBottomStyle: "dotted",
-    borderBottomColor: PDF_COLORS.border,
-    marginBottom: 4,
-  },
-  entryRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "baseline",
-    gap: 8,
-  },
-  entryTitle: { fontSize: 9.5, fontWeight: 600 },
-  entryDate: { fontSize: 9, color: PDF_COLORS.muted, flexShrink: 0 },
-  subtitle: { fontSize: 9, color: PDF_COLORS.muted },
-  subtitleLink: { color: PDF_COLORS.muted, textDecoration: "none" },
-  body: { marginTop: 3 },
-});
+// Font sizes are multiplied by the document's per-group scales (name, title,
+// body); every other value is fixed. At NO_SCALE this is the baseline sheet.
+const makeStyles = (s: FontScales) =>
+  StyleSheet.create({
+    page: {
+      paddingVertical: 40,
+      paddingHorizontal: 44,
+      fontFamily: "Inter",
+      fontSize: 9 * s.body,
+      color: PDF_COLORS.foreground,
+      lineHeight: 1.4,
+    },
+    header: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "flex-start",
+      gap: 16,
+    },
+    headerLeft: { flexShrink: 1 },
+    name: { fontSize: 18 * s.name, fontWeight: 700, lineHeight: 1.25 },
+    headline: {
+      marginTop: 2,
+      fontSize: 10.5 * s.name,
+      color: PDF_COLORS.muted,
+    },
+    headerRight: { alignItems: "flex-start", gap: 3 },
+    contactRow: { flexDirection: "row", alignItems: "center", gap: 4 },
+    linkPlain: { color: PDF_COLORS.foreground, textDecoration: "none" },
+    heading: {
+      fontSize: 10 * s.title,
+      fontWeight: 600,
+      textTransform: "uppercase",
+      letterSpacing: 0.5,
+      paddingBottom: 2,
+      borderBottomWidth: 0.75,
+      borderBottomStyle: "dotted",
+      borderBottomColor: PDF_COLORS.border,
+      marginBottom: 4,
+    },
+    entryRow: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "baseline",
+      gap: 8,
+    },
+    entryTitle: { fontSize: 9.5 * s.body, fontWeight: 600 },
+    entryDate: { fontSize: 9 * s.body, color: PDF_COLORS.muted, flexShrink: 0 },
+    subtitle: { fontSize: 9 * s.body, color: PDF_COLORS.muted },
+    subtitleLink: { color: PDF_COLORS.muted, textDecoration: "none" },
+    body: { marginTop: 3 },
+  });
+
+const baseStyles = makeStyles(NO_SCALE);
 
 function PdfHeader(props: { header: HeaderView }) {
+  const styles = usePdfStyles(baseStyles);
   return (
     <View style={styles.header}>
       <View style={styles.headerLeft}>
@@ -95,6 +112,7 @@ function PdfHeader(props: { header: HeaderView }) {
 }
 
 function PdfExperience(props: { item: ExperienceItemView }) {
+  const styles = usePdfStyles(baseStyles);
   return (
     <View>
       <View style={styles.entryRow}>
@@ -118,6 +136,7 @@ function PdfExperience(props: { item: ExperienceItemView }) {
 }
 
 function PdfEducation(props: { item: EducationItemView }) {
+  const styles = usePdfStyles(baseStyles);
   return (
     <View>
       <View style={styles.entryRow}>
@@ -133,6 +152,7 @@ function PdfEducation(props: { item: EducationItemView }) {
 }
 
 function PdfCertificate(props: { item: CertificateItemView }) {
+  const styles = usePdfStyles(baseStyles);
   const range = dateRange(props.item.startDate, props.item.endDate);
   return (
     <View>
@@ -154,6 +174,7 @@ function PdfCertificate(props: { item: CertificateItemView }) {
 }
 
 function PdfBlock(props: { block: ResumeBlock }) {
+  const styles = usePdfStyles(baseStyles);
   const { block } = props;
   switch (block.kind) {
     case "header":
@@ -185,22 +206,25 @@ function PdfBlock(props: { block: ResumeBlock }) {
 export function AwalPdfDocument(props: { preview: ResumePreview }) {
   const blocks = buildResumeBlocks(props.preview);
   const typography = pdfTypography(props.preview);
+  const styles = makeStyles(fontScales(props.preview));
   return (
-    <Document>
-      <Page
-        size="A4"
-        style={typography.page ? [styles.page, typography.page] : styles.page}
-      >
-        {blocks.map((block) => (
-          <View
-            key={block.id}
-            style={{ marginTop: block.gapBefore }}
-            minPresenceAhead={block.keepWithNext ? 48 : 0}
-          >
-            <PdfBlock block={block} />
-          </View>
-        ))}
-      </Page>
-    </Document>
+    <PdfStylesContext.Provider value={styles}>
+      <Document>
+        <Page
+          size="A4"
+          style={typography.page ? [styles.page, typography.page] : styles.page}
+        >
+          {blocks.map((block) => (
+            <View
+              key={block.id}
+              style={{ marginTop: block.gapBefore }}
+              minPresenceAhead={block.keepWithNext ? 48 : 0}
+            >
+              <PdfBlock block={block} />
+            </View>
+          ))}
+        </Page>
+      </Document>
+    </PdfStylesContext.Provider>
   );
 }

--- a/src/components/editor/pdf/ketat-pdf-document.tsx
+++ b/src/components/editor/pdf/ketat-pdf-document.tsx
@@ -15,76 +15,91 @@ import type {
   ResumePreview,
 } from "../resume-preview";
 import { PdfContactIcon } from "./pdf-contact-icon";
-import { PdfFontContext, pdfTypography, usePdfFontFamily } from "./pdf-font";
+import {
+  type FontScales,
+  fontScales,
+  NO_SCALE,
+  PdfFontContext,
+  PdfStylesContext,
+  pdfTypography,
+  usePdfFontFamily,
+  usePdfStyles,
+} from "./pdf-font";
 import { PDF_COLORS } from "./pdf-fonts";
 import { dateRange, PdfGrid } from "./pdf-grid";
 import { PdfRichText } from "./pdf-rich-text";
 
-const styles = StyleSheet.create({
-  page: {
-    paddingVertical: 40,
-    paddingHorizontal: 44,
-    fontFamily: "Inter",
-    fontSize: 9,
-    color: PDF_COLORS.foreground,
-    lineHeight: 1.4,
-  },
-  header: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "flex-start",
-    gap: 24,
-  },
-  headerLeft: { flexShrink: 1 },
-  // No letterSpacing anywhere in PDF styles: react-pdf places letter-spaced
-  // glyphs individually, which destroys word boundaries in text extraction.
-  name: {
-    fontFamily: "Lora",
-    fontSize: 19,
-    textTransform: "uppercase",
-    lineHeight: 1.25,
-  },
-  headline: {
-    marginTop: 2,
-    fontFamily: "Lora",
-    fontSize: 11,
-    color: PDF_COLORS.muted,
-  },
-  headerRight: { alignItems: "flex-end", gap: 4 },
-  contactRow: { flexDirection: "row", alignItems: "center", gap: 4 },
-  linkPlain: { color: PDF_COLORS.foreground, textDecoration: "none" },
-  heading: {
-    borderTopWidth: 0.75,
-    borderTopColor: PDF_COLORS.border,
-    borderBottomWidth: 0.75,
-    borderBottomColor: PDF_COLORS.border,
-    paddingVertical: 4,
-    marginBottom: 4,
-  },
-  headingText: {
-    fontFamily: "Lora",
-    fontSize: 11.5,
-    textAlign: "center",
-  },
-  entryTitle: { fontSize: 9.5, fontWeight: 600 },
-  subtitleRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "baseline",
-    gap: 8,
-  },
-  subtitle: { fontSize: 9, color: PDF_COLORS.muted },
-  subtitleLink: { color: PDF_COLORS.muted, textDecoration: "none" },
-  entryDate: {
-    fontSize: 9,
-    fontStyle: "italic",
-    color: PDF_COLORS.muted,
-    flexShrink: 0,
-  },
-  body: { marginTop: 3 },
-});
+// Font sizes are multiplied by the document's per-group scales (name, title,
+// body); every other value is fixed. At NO_SCALE this is the baseline sheet.
+const makeStyles = (s: FontScales) =>
+  StyleSheet.create({
+    page: {
+      paddingVertical: 40,
+      paddingHorizontal: 44,
+      fontFamily: "Inter",
+      fontSize: 9 * s.body,
+      color: PDF_COLORS.foreground,
+      lineHeight: 1.4,
+    },
+    header: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "flex-start",
+      gap: 24,
+    },
+    headerLeft: { flexShrink: 1 },
+    // No letterSpacing anywhere in PDF styles: react-pdf places letter-spaced
+    // glyphs individually, which destroys word boundaries in text extraction.
+    name: {
+      fontFamily: "Lora",
+      fontSize: 19 * s.name,
+      textTransform: "uppercase",
+      lineHeight: 1.25,
+    },
+    headline: {
+      marginTop: 2,
+      fontFamily: "Lora",
+      fontSize: 11 * s.name,
+      color: PDF_COLORS.muted,
+    },
+    headerRight: { alignItems: "flex-end", gap: 4 },
+    contactRow: { flexDirection: "row", alignItems: "center", gap: 4 },
+    linkPlain: { color: PDF_COLORS.foreground, textDecoration: "none" },
+    heading: {
+      borderTopWidth: 0.75,
+      borderTopColor: PDF_COLORS.border,
+      borderBottomWidth: 0.75,
+      borderBottomColor: PDF_COLORS.border,
+      paddingVertical: 4,
+      marginBottom: 4,
+    },
+    headingText: {
+      fontFamily: "Lora",
+      fontSize: 11.5 * s.title,
+      textAlign: "center",
+    },
+    entryTitle: { fontSize: 9.5 * s.body, fontWeight: 600 },
+    subtitleRow: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "baseline",
+      gap: 8,
+    },
+    subtitle: { fontSize: 9 * s.body, color: PDF_COLORS.muted },
+    subtitleLink: { color: PDF_COLORS.muted, textDecoration: "none" },
+    entryDate: {
+      fontSize: 9 * s.body,
+      fontStyle: "italic",
+      color: PDF_COLORS.muted,
+      flexShrink: 0,
+    },
+    body: { marginTop: 3 },
+  });
+
+const baseStyles = makeStyles(NO_SCALE);
 
 function KetatHeader(props: { header: HeaderView }) {
+  const styles = usePdfStyles(baseStyles);
   const serif = usePdfFontFamily("Lora");
   return (
     <View style={styles.header}>
@@ -119,6 +134,7 @@ function KetatHeader(props: { header: HeaderView }) {
 }
 
 function KetatExperience(props: { item: ExperienceItemView }) {
+  const styles = usePdfStyles(baseStyles);
   return (
     <View>
       <Text style={styles.entryTitle}>{props.item.role}</Text>
@@ -142,6 +158,7 @@ function KetatExperience(props: { item: ExperienceItemView }) {
 }
 
 function KetatEducation(props: { item: EducationItemView }) {
+  const styles = usePdfStyles(baseStyles);
   return (
     <View>
       <Text style={styles.entryTitle}>{props.item.degree}</Text>
@@ -157,6 +174,7 @@ function KetatEducation(props: { item: EducationItemView }) {
 }
 
 function KetatCertificate(props: { item: CertificateItemView }) {
+  const styles = usePdfStyles(baseStyles);
   const range = dateRange(props.item.startDate, props.item.endDate);
   return (
     <View>
@@ -178,6 +196,7 @@ function KetatCertificate(props: { item: CertificateItemView }) {
 }
 
 function KetatBlock(props: { block: ResumeBlock }) {
+  const styles = usePdfStyles(baseStyles);
   const serif = usePdfFontFamily("Lora");
   const { block } = props;
   switch (block.kind) {
@@ -214,24 +233,29 @@ function KetatBlock(props: { block: ResumeBlock }) {
 export function KetatPdfDocument(props: { preview: ResumePreview }) {
   const blocks = buildResumeBlocks(props.preview);
   const typography = pdfTypography(props.preview);
+  const styles = makeStyles(fontScales(props.preview));
   return (
     <PdfFontContext.Provider value={typography.family}>
-      <Document>
-        <Page
-          size="A4"
-          style={typography.page ? [styles.page, typography.page] : styles.page}
-        >
-          {blocks.map((block) => (
-            <View
-              key={block.id}
-              style={{ marginTop: block.gapBefore }}
-              minPresenceAhead={block.keepWithNext ? 48 : 0}
-            >
-              <KetatBlock block={block} />
-            </View>
-          ))}
-        </Page>
-      </Document>
+      <PdfStylesContext.Provider value={styles}>
+        <Document>
+          <Page
+            size="A4"
+            style={
+              typography.page ? [styles.page, typography.page] : styles.page
+            }
+          >
+            {blocks.map((block) => (
+              <View
+                key={block.id}
+                style={{ marginTop: block.gapBefore }}
+                minPresenceAhead={block.keepWithNext ? 48 : 0}
+              >
+                <KetatBlock block={block} />
+              </View>
+            ))}
+          </Page>
+        </Document>
+      </PdfStylesContext.Provider>
     </PdfFontContext.Provider>
   );
 }

--- a/src/components/editor/pdf/ketik-pdf-document.tsx
+++ b/src/components/editor/pdf/ketik-pdf-document.tsx
@@ -15,67 +15,86 @@ import type {
   HeaderView,
   ResumePreview,
 } from "../resume-preview";
-import { PdfFontContext, pdfTypography, usePdfFontFamily } from "./pdf-font";
+import {
+  type FontScales,
+  fontScales,
+  NO_SCALE,
+  PdfFontContext,
+  PdfStylesContext,
+  pdfTypography,
+  usePdfFontFamily,
+  usePdfStyles,
+} from "./pdf-font";
 import { PDF_COLORS } from "./pdf-fonts";
 import { dateRange, PdfGrid } from "./pdf-grid";
 import { PdfRichText } from "./pdf-rich-text";
 
-const styles = StyleSheet.create({
-  page: {
-    paddingVertical: 40,
-    paddingHorizontal: 44,
-    fontFamily: "Inter",
-    fontSize: 9,
-    color: PDF_COLORS.foreground,
-    lineHeight: 1.4,
-  },
-  name: {
-    fontFamily: "GeistMono",
-    fontSize: 16,
-    fontWeight: 700,
-    lineHeight: 1.25,
-  },
-  headline: {
-    marginTop: 2,
-    fontFamily: "GeistMono",
-    fontSize: 10,
-    color: PDF_COLORS.muted,
-  },
-  contactLine: {
-    marginTop: 4,
-    fontFamily: "GeistMono",
-    fontSize: 8,
-    color: PDF_COLORS.muted,
-  },
-  linkMuted: { color: PDF_COLORS.muted, textDecoration: "none" },
-  heading: {
-    fontFamily: "GeistMono",
-    fontSize: 9.5,
-    fontWeight: 700,
-    textTransform: "uppercase",
-    borderBottomWidth: 0.75,
-    borderBottomStyle: "dashed",
-    borderBottomColor: PDF_COLORS.border,
-    paddingBottom: 3,
-  },
-  entryRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "baseline",
-    gap: 8,
-  },
-  entryTitle: { fontFamily: "GeistMono", fontSize: 9, fontWeight: 700 },
-  entryDate: {
-    fontFamily: "GeistMono",
-    fontSize: 8,
-    color: PDF_COLORS.muted,
-    flexShrink: 0,
-  },
-  subtitle: { fontSize: 9, color: PDF_COLORS.muted },
-  body: { marginTop: 3 },
-});
+// Font sizes are multiplied by the document's per-group scales (name, title,
+// body); every other value is fixed. At NO_SCALE this is the baseline sheet.
+const makeStyles = (s: FontScales) =>
+  StyleSheet.create({
+    page: {
+      paddingVertical: 40,
+      paddingHorizontal: 44,
+      fontFamily: "Inter",
+      fontSize: 9 * s.body,
+      color: PDF_COLORS.foreground,
+      lineHeight: 1.4,
+    },
+    name: {
+      fontFamily: "GeistMono",
+      fontSize: 16 * s.name,
+      fontWeight: 700,
+      lineHeight: 1.25,
+    },
+    headline: {
+      marginTop: 2,
+      fontFamily: "GeistMono",
+      fontSize: 10 * s.name,
+      color: PDF_COLORS.muted,
+    },
+    contactLine: {
+      marginTop: 4,
+      fontFamily: "GeistMono",
+      fontSize: 8 * s.body,
+      color: PDF_COLORS.muted,
+    },
+    linkMuted: { color: PDF_COLORS.muted, textDecoration: "none" },
+    heading: {
+      fontFamily: "GeistMono",
+      fontSize: 9.5 * s.title,
+      fontWeight: 700,
+      textTransform: "uppercase",
+      borderBottomWidth: 0.75,
+      borderBottomStyle: "dashed",
+      borderBottomColor: PDF_COLORS.border,
+      paddingBottom: 3,
+    },
+    entryRow: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "baseline",
+      gap: 8,
+    },
+    entryTitle: {
+      fontFamily: "GeistMono",
+      fontSize: 9 * s.body,
+      fontWeight: 700,
+    },
+    entryDate: {
+      fontFamily: "GeistMono",
+      fontSize: 8 * s.body,
+      color: PDF_COLORS.muted,
+      flexShrink: 0,
+    },
+    subtitle: { fontSize: 9 * s.body, color: PDF_COLORS.muted },
+    body: { marginTop: 3 },
+  });
+
+const baseStyles = makeStyles(NO_SCALE);
 
 function KetikContactLine(props: { contacts: ContactView[] }) {
+  const styles = usePdfStyles(baseStyles);
   const mono = usePdfFontFamily("GeistMono");
   return (
     <Text style={[styles.contactLine, { fontFamily: mono }]}>
@@ -96,6 +115,7 @@ function KetikContactLine(props: { contacts: ContactView[] }) {
 }
 
 function KetikHeader(props: { header: HeaderView }) {
+  const styles = usePdfStyles(baseStyles);
   const mono = usePdfFontFamily("GeistMono");
   return (
     <View>
@@ -115,6 +135,7 @@ function KetikHeader(props: { header: HeaderView }) {
 }
 
 function KetikExperience(props: { item: ExperienceItemView }) {
+  const styles = usePdfStyles(baseStyles);
   const mono = usePdfFontFamily("GeistMono");
   return (
     <View>
@@ -141,6 +162,7 @@ function KetikExperience(props: { item: ExperienceItemView }) {
 }
 
 function KetikEducation(props: { item: EducationItemView }) {
+  const styles = usePdfStyles(baseStyles);
   const mono = usePdfFontFamily("GeistMono");
   return (
     <View>
@@ -159,6 +181,7 @@ function KetikEducation(props: { item: EducationItemView }) {
 }
 
 function KetikCertificate(props: { item: CertificateItemView }) {
+  const styles = usePdfStyles(baseStyles);
   const mono = usePdfFontFamily("GeistMono");
   const range = dateRange(props.item.startDate, props.item.endDate);
   return (
@@ -183,6 +206,7 @@ function KetikCertificate(props: { item: CertificateItemView }) {
 }
 
 function KetikBlock(props: { block: ResumeBlock }) {
+  const styles = usePdfStyles(baseStyles);
   const mono = usePdfFontFamily("GeistMono");
   const { block } = props;
   switch (block.kind) {
@@ -218,24 +242,29 @@ function KetikBlock(props: { block: ResumeBlock }) {
 export function KetikPdfDocument(props: { preview: ResumePreview }) {
   const blocks = buildResumeBlocks(props.preview);
   const typography = pdfTypography(props.preview);
+  const styles = makeStyles(fontScales(props.preview));
   return (
     <PdfFontContext.Provider value={typography.family}>
-      <Document>
-        <Page
-          size="A4"
-          style={typography.page ? [styles.page, typography.page] : styles.page}
-        >
-          {blocks.map((block) => (
-            <View
-              key={block.id}
-              style={{ marginTop: block.gapBefore }}
-              minPresenceAhead={block.keepWithNext ? 48 : 0}
-            >
-              <KetikBlock block={block} />
-            </View>
-          ))}
-        </Page>
-      </Document>
+      <PdfStylesContext.Provider value={styles}>
+        <Document>
+          <Page
+            size="A4"
+            style={
+              typography.page ? [styles.page, typography.page] : styles.page
+            }
+          >
+            {blocks.map((block) => (
+              <View
+                key={block.id}
+                style={{ marginTop: block.gapBefore }}
+                minPresenceAhead={block.keepWithNext ? 48 : 0}
+              >
+                <KetikBlock block={block} />
+              </View>
+            ))}
+          </Page>
+        </Document>
+      </PdfStylesContext.Provider>
     </PdfFontContext.Provider>
   );
 }

--- a/src/components/editor/pdf/klasik-pdf-document.tsx
+++ b/src/components/editor/pdf/klasik-pdf-document.tsx
@@ -15,63 +15,76 @@ import type {
   HeaderView,
   ResumePreview,
 } from "../resume-preview";
-import { pdfTypography } from "./pdf-font";
+import {
+  type FontScales,
+  fontScales,
+  NO_SCALE,
+  PdfStylesContext,
+  pdfTypography,
+  usePdfStyles,
+} from "./pdf-font";
 import { PDF_COLORS } from "./pdf-fonts";
 import { dateRange, PdfGrid } from "./pdf-grid";
 import { PdfRichText } from "./pdf-rich-text";
 
-const styles = StyleSheet.create({
-  page: {
-    paddingVertical: 44,
-    paddingHorizontal: 48,
-    fontFamily: "Lora",
-    fontSize: 9,
-    color: PDF_COLORS.foreground,
-    lineHeight: 1.45,
-  },
-  header: { alignItems: "center" },
-  name: { fontSize: 20, lineHeight: 1.25 },
-  headline: {
-    marginTop: 1,
-    fontSize: 10,
-    fontStyle: "italic",
-    color: PDF_COLORS.muted,
-  },
-  contactLine: {
-    marginTop: 4,
-    fontSize: 9,
-    color: PDF_COLORS.muted,
-    textAlign: "center",
-  },
-  linkMuted: { color: PDF_COLORS.muted, textDecoration: "none" },
-  heading: {
-    borderBottomWidth: 0.5,
-    borderBottomColor: PDF_COLORS.border,
-    paddingBottom: 3,
-  },
-  headingText: {
-    fontSize: 10.5,
-    textTransform: "uppercase",
-    textAlign: "center",
-  },
-  entryRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "baseline",
-    gap: 8,
-  },
-  entryTitle: { fontSize: 9.5, fontWeight: 700 },
-  entryDate: {
-    fontSize: 9,
-    fontStyle: "italic",
-    color: PDF_COLORS.muted,
-    flexShrink: 0,
-  },
-  subtitle: { fontSize: 9, color: PDF_COLORS.muted },
-  body: { marginTop: 3 },
-});
+// Font sizes are multiplied by the document's per-group scales (name, title,
+// body); every other value is fixed. At NO_SCALE this is the baseline sheet.
+const makeStyles = (s: FontScales) =>
+  StyleSheet.create({
+    page: {
+      paddingVertical: 44,
+      paddingHorizontal: 48,
+      fontFamily: "Lora",
+      fontSize: 9 * s.body,
+      color: PDF_COLORS.foreground,
+      lineHeight: 1.45,
+    },
+    header: { alignItems: "center" },
+    name: { fontSize: 20 * s.name, lineHeight: 1.25 },
+    headline: {
+      marginTop: 1,
+      fontSize: 10 * s.name,
+      fontStyle: "italic",
+      color: PDF_COLORS.muted,
+    },
+    contactLine: {
+      marginTop: 4,
+      fontSize: 9 * s.body,
+      color: PDF_COLORS.muted,
+      textAlign: "center",
+    },
+    linkMuted: { color: PDF_COLORS.muted, textDecoration: "none" },
+    heading: {
+      borderBottomWidth: 0.5,
+      borderBottomColor: PDF_COLORS.border,
+      paddingBottom: 3,
+    },
+    headingText: {
+      fontSize: 10.5 * s.title,
+      textTransform: "uppercase",
+      textAlign: "center",
+    },
+    entryRow: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "baseline",
+      gap: 8,
+    },
+    entryTitle: { fontSize: 9.5 * s.body, fontWeight: 700 },
+    entryDate: {
+      fontSize: 9 * s.body,
+      fontStyle: "italic",
+      color: PDF_COLORS.muted,
+      flexShrink: 0,
+    },
+    subtitle: { fontSize: 9 * s.body, color: PDF_COLORS.muted },
+    body: { marginTop: 3 },
+  });
+
+const baseStyles = makeStyles(NO_SCALE);
 
 function KlasikContactLine(props: { contacts: ContactView[] }) {
+  const styles = usePdfStyles(baseStyles);
   return (
     <Text style={styles.contactLine}>
       {props.contacts.map((contact, index) => (
@@ -91,6 +104,7 @@ function KlasikContactLine(props: { contacts: ContactView[] }) {
 }
 
 function KlasikHeader(props: { header: HeaderView }) {
+  const styles = usePdfStyles(baseStyles);
   return (
     <View style={styles.header}>
       <Text style={styles.name}>{props.header.fullName}</Text>
@@ -105,6 +119,7 @@ function KlasikHeader(props: { header: HeaderView }) {
 }
 
 function KlasikExperience(props: { item: ExperienceItemView }) {
+  const styles = usePdfStyles(baseStyles);
   return (
     <View>
       <View style={styles.entryRow}>
@@ -128,6 +143,7 @@ function KlasikExperience(props: { item: ExperienceItemView }) {
 }
 
 function KlasikEducation(props: { item: EducationItemView }) {
+  const styles = usePdfStyles(baseStyles);
   return (
     <View>
       <View style={styles.entryRow}>
@@ -143,6 +159,7 @@ function KlasikEducation(props: { item: EducationItemView }) {
 }
 
 function KlasikCertificate(props: { item: CertificateItemView }) {
+  const styles = usePdfStyles(baseStyles);
   const range = dateRange(props.item.startDate, props.item.endDate);
   return (
     <View>
@@ -164,6 +181,7 @@ function KlasikCertificate(props: { item: CertificateItemView }) {
 }
 
 function KlasikBlock(props: { block: ResumeBlock }) {
+  const styles = usePdfStyles(baseStyles);
   const { block } = props;
   switch (block.kind) {
     case "header":
@@ -198,22 +216,25 @@ function KlasikBlock(props: { block: ResumeBlock }) {
 export function KlasikPdfDocument(props: { preview: ResumePreview }) {
   const blocks = buildResumeBlocks(props.preview);
   const typography = pdfTypography(props.preview);
+  const styles = makeStyles(fontScales(props.preview));
   return (
-    <Document>
-      <Page
-        size="A4"
-        style={typography.page ? [styles.page, typography.page] : styles.page}
-      >
-        {blocks.map((block) => (
-          <View
-            key={block.id}
-            style={{ marginTop: block.gapBefore }}
-            minPresenceAhead={block.keepWithNext ? 48 : 0}
-          >
-            <KlasikBlock block={block} />
-          </View>
-        ))}
-      </Page>
-    </Document>
+    <PdfStylesContext.Provider value={styles}>
+      <Document>
+        <Page
+          size="A4"
+          style={typography.page ? [styles.page, typography.page] : styles.page}
+        >
+          {blocks.map((block) => (
+            <View
+              key={block.id}
+              style={{ marginTop: block.gapBefore }}
+              minPresenceAhead={block.keepWithNext ? 48 : 0}
+            >
+              <KlasikBlock block={block} />
+            </View>
+          ))}
+        </Page>
+      </Document>
+    </PdfStylesContext.Provider>
   );
 }

--- a/src/components/editor/pdf/luasa-pdf-document.tsx
+++ b/src/components/editor/pdf/luasa-pdf-document.tsx
@@ -15,65 +15,88 @@ import type {
   HeaderView,
   ResumePreview,
 } from "../resume-preview";
-import { PdfFontContext, pdfTypography, usePdfFontFamily } from "./pdf-font";
+import {
+  type FontScales,
+  fontScales,
+  NO_SCALE,
+  PdfFontContext,
+  PdfStylesContext,
+  pdfTypography,
+  usePdfFontFamily,
+  usePdfStyles,
+} from "./pdf-font";
 import { PDF_COLORS } from "./pdf-fonts";
 import { dateRange, PdfGrid } from "./pdf-grid";
 import { PdfRichText } from "./pdf-rich-text";
 
-const styles = StyleSheet.create({
-  page: {
-    paddingVertical: 44,
-    paddingHorizontal: 48,
-    fontFamily: "Inter",
-    fontSize: 9,
-    color: PDF_COLORS.foreground,
-    lineHeight: 1.45,
-  },
-  accentBar: {
-    borderLeftWidth: 1.5,
-    borderLeftColor: PDF_COLORS.foreground,
-    paddingLeft: 12,
-  },
-  softBar: {
-    borderLeftWidth: 1.5,
-    borderLeftColor: PDF_COLORS.border,
-    paddingLeft: 12,
-  },
-  // No letterSpacing anywhere in PDF styles: react-pdf places letter-spaced
-  // glyphs individually, which destroys word boundaries in text extraction.
-  name: {
-    fontFamily: "Lora",
-    fontSize: 18,
-    textTransform: "uppercase",
-    lineHeight: 1.25,
-  },
-  headline: {
-    marginTop: 1,
-    fontFamily: "Lora",
-    fontSize: 10,
-    color: PDF_COLORS.muted,
-  },
-  contactLine: { marginTop: 3, fontSize: 9, color: PDF_COLORS.muted },
-  linkMuted: { color: PDF_COLORS.muted, textDecoration: "none" },
-  heading: {
-    fontFamily: "Lora",
-    fontSize: 9.5,
-    fontWeight: 700,
-    textTransform: "uppercase",
-  },
-  entryRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "baseline",
-    gap: 8,
-  },
-  entryTitle: { fontSize: 9.5, textTransform: "uppercase" },
-  entryDate: { fontSize: 9, color: PDF_COLORS.muted, flexShrink: 0 },
-  subtitle: { fontSize: 9, fontStyle: "italic", color: PDF_COLORS.muted },
-  body: { marginTop: 3 },
-});
+// Font sizes are multiplied by the document's per-group scales (name, title,
+// body); every other value is fixed. At NO_SCALE this is the baseline sheet.
+const makeStyles = (s: FontScales) =>
+  StyleSheet.create({
+    page: {
+      paddingVertical: 44,
+      paddingHorizontal: 48,
+      fontFamily: "Inter",
+      fontSize: 9 * s.body,
+      color: PDF_COLORS.foreground,
+      lineHeight: 1.45,
+    },
+    accentBar: {
+      borderLeftWidth: 1.5,
+      borderLeftColor: PDF_COLORS.foreground,
+      paddingLeft: 12,
+    },
+    softBar: {
+      borderLeftWidth: 1.5,
+      borderLeftColor: PDF_COLORS.border,
+      paddingLeft: 12,
+    },
+    // No letterSpacing anywhere in PDF styles: react-pdf places letter-spaced
+    // glyphs individually, which destroys word boundaries in text extraction.
+    name: {
+      fontFamily: "Lora",
+      fontSize: 18 * s.name,
+      textTransform: "uppercase",
+      lineHeight: 1.25,
+    },
+    headline: {
+      marginTop: 1,
+      fontFamily: "Lora",
+      fontSize: 10 * s.name,
+      color: PDF_COLORS.muted,
+    },
+    contactLine: {
+      marginTop: 3,
+      fontSize: 9 * s.body,
+      color: PDF_COLORS.muted,
+    },
+    linkMuted: { color: PDF_COLORS.muted, textDecoration: "none" },
+    heading: {
+      fontFamily: "Lora",
+      fontSize: 9.5 * s.title,
+      fontWeight: 700,
+      textTransform: "uppercase",
+    },
+    entryRow: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "baseline",
+      gap: 8,
+    },
+    entryTitle: { fontSize: 9.5 * s.body, textTransform: "uppercase" },
+    entryDate: { fontSize: 9 * s.body, color: PDF_COLORS.muted, flexShrink: 0 },
+    subtitle: {
+      fontSize: 9 * s.body,
+      fontStyle: "italic",
+      color: PDF_COLORS.muted,
+    },
+    body: { marginTop: 3 },
+  });
+
+const baseStyles = makeStyles(NO_SCALE);
 
 function LuasaContactLine(props: { contacts: ContactView[] }) {
+  const styles = usePdfStyles(baseStyles);
   return (
     <Text style={styles.contactLine}>
       {props.contacts.map((contact, index) => (
@@ -93,6 +116,7 @@ function LuasaContactLine(props: { contacts: ContactView[] }) {
 }
 
 function LuasaHeader(props: { header: HeaderView }) {
+  const styles = usePdfStyles(baseStyles);
   const serif = usePdfFontFamily("Lora");
   return (
     <View style={styles.accentBar}>
@@ -112,6 +136,7 @@ function LuasaHeader(props: { header: HeaderView }) {
 }
 
 function LuasaExperience(props: { item: ExperienceItemView }) {
+  const styles = usePdfStyles(baseStyles);
   return (
     <View>
       <View style={styles.entryRow}>
@@ -135,6 +160,7 @@ function LuasaExperience(props: { item: ExperienceItemView }) {
 }
 
 function LuasaEducation(props: { item: EducationItemView }) {
+  const styles = usePdfStyles(baseStyles);
   return (
     <View style={styles.softBar}>
       <View style={styles.entryRow}>
@@ -150,6 +176,7 @@ function LuasaEducation(props: { item: EducationItemView }) {
 }
 
 function LuasaCertificate(props: { item: CertificateItemView }) {
+  const styles = usePdfStyles(baseStyles);
   const range = dateRange(props.item.startDate, props.item.endDate);
   return (
     <View style={styles.softBar}>
@@ -171,6 +198,7 @@ function LuasaCertificate(props: { item: CertificateItemView }) {
 }
 
 function LuasaBlock(props: { block: ResumeBlock }) {
+  const styles = usePdfStyles(baseStyles);
   const serif = usePdfFontFamily("Lora");
   const { block } = props;
   switch (block.kind) {
@@ -209,24 +237,29 @@ function LuasaBlock(props: { block: ResumeBlock }) {
 export function LuasaPdfDocument(props: { preview: ResumePreview }) {
   const blocks = buildResumeBlocks(props.preview);
   const typography = pdfTypography(props.preview);
+  const styles = makeStyles(fontScales(props.preview));
   return (
     <PdfFontContext.Provider value={typography.family}>
-      <Document>
-        <Page
-          size="A4"
-          style={typography.page ? [styles.page, typography.page] : styles.page}
-        >
-          {blocks.map((block) => (
-            <View
-              key={block.id}
-              style={{ marginTop: block.gapBefore }}
-              minPresenceAhead={block.keepWithNext ? 48 : 0}
-            >
-              <LuasaBlock block={block} />
-            </View>
-          ))}
-        </Page>
-      </Document>
+      <PdfStylesContext.Provider value={styles}>
+        <Document>
+          <Page
+            size="A4"
+            style={
+              typography.page ? [styles.page, typography.page] : styles.page
+            }
+          >
+            {blocks.map((block) => (
+              <View
+                key={block.id}
+                style={{ marginTop: block.gapBefore }}
+                minPresenceAhead={block.keepWithNext ? 48 : 0}
+              >
+                <LuasaBlock block={block} />
+              </View>
+            ))}
+          </Page>
+        </Document>
+      </PdfStylesContext.Provider>
     </PdfFontContext.Provider>
   );
 }

--- a/src/components/editor/pdf/pdf-font.ts
+++ b/src/components/editor/pdf/pdf-font.ts
@@ -20,6 +20,36 @@ export function usePdfFontFamily(fallback: string): string {
   return useContext(PdfFontContext) ?? fallback;
 }
 
+/** Per-group font-size multipliers a PDF template applies to its baseline sizes. */
+export interface FontScales {
+  name: number;
+  title: number;
+  body: number;
+}
+
+/** Identity scales: renders each template at its baseline sizes. */
+export const NO_SCALE: FontScales = { name: 1, title: 1, body: 1 };
+
+export function fontScales(preview: ResumePreview): FontScales {
+  return {
+    name: preview.nameScale,
+    title: preview.titleScale,
+    body: preview.bodyScale,
+  };
+}
+
+/**
+ * Carries a template's font-size-scaled StyleSheet to its nested block
+ * components, so they read scaled styles from context instead of the module
+ * baseline and never thread a `styles` prop. Each template narrows the value
+ * to its own sheet via `usePdfStyles`.
+ */
+export const PdfStylesContext = createContext<unknown>(null);
+
+export function usePdfStyles<T>(fallback: T): T {
+  return (useContext(PdfStylesContext) as T | null) ?? fallback;
+}
+
 interface PdfTypography {
   /** Override family for PdfFontContext, or null for template families. */
   family: string | null;

--- a/src/components/editor/pdf/tebal-pdf-document.tsx
+++ b/src/components/editor/pdf/tebal-pdf-document.tsx
@@ -15,65 +15,82 @@ import type {
   ResumePreview,
 } from "../resume-preview";
 import { PdfContactIcon } from "./pdf-contact-icon";
-import { pdfTypography } from "./pdf-font";
+import {
+  type FontScales,
+  fontScales,
+  NO_SCALE,
+  PdfStylesContext,
+  pdfTypography,
+  usePdfStyles,
+} from "./pdf-font";
 import { PDF_COLORS } from "./pdf-fonts";
 import { dateRange, PdfGrid } from "./pdf-grid";
 import { PdfRichText } from "./pdf-rich-text";
 
-const styles = StyleSheet.create({
-  page: {
-    paddingVertical: 40,
-    paddingHorizontal: 44,
-    fontFamily: "Inter",
-    fontSize: 9,
-    color: PDF_COLORS.foreground,
-    lineHeight: 1.4,
-  },
-  name: { fontSize: 22, fontWeight: 700, lineHeight: 1.2 },
-  headline: {
-    marginTop: 2,
-    fontSize: 10.5,
-    fontWeight: 600,
-    color: PDF_COLORS.muted,
-  },
-  contactRowWrap: {
-    marginTop: 6,
-    flexDirection: "row",
-    flexWrap: "wrap",
-    columnGap: 12,
-    rowGap: 3,
-  },
-  contactRow: { flexDirection: "row", alignItems: "center", gap: 4 },
-  linkPlain: { color: PDF_COLORS.foreground, textDecoration: "none" },
-  heading: {
-    borderTopWidth: 2,
-    borderTopColor: PDF_COLORS.foreground,
-    paddingTop: 3,
-  },
-  headingText: {
-    fontSize: 10,
-    fontWeight: 700,
-    textTransform: "uppercase",
-  },
-  entryRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "baseline",
-    gap: 8,
-  },
-  entryTitle: { fontSize: 10, fontWeight: 700 },
-  entryDate: {
-    fontSize: 9,
-    fontWeight: 600,
-    color: PDF_COLORS.muted,
-    flexShrink: 0,
-  },
-  subtitle: { fontSize: 9, fontWeight: 600, color: PDF_COLORS.muted },
-  subtitleLink: { color: PDF_COLORS.muted, textDecoration: "none" },
-  body: { marginTop: 3 },
-});
+// Font sizes are multiplied by the document's per-group scales (name, title,
+// body); every other value is fixed. At NO_SCALE this is the baseline sheet.
+const makeStyles = (s: FontScales) =>
+  StyleSheet.create({
+    page: {
+      paddingVertical: 40,
+      paddingHorizontal: 44,
+      fontFamily: "Inter",
+      fontSize: 9 * s.body,
+      color: PDF_COLORS.foreground,
+      lineHeight: 1.4,
+    },
+    name: { fontSize: 22 * s.name, fontWeight: 700, lineHeight: 1.2 },
+    headline: {
+      marginTop: 2,
+      fontSize: 10.5 * s.name,
+      fontWeight: 600,
+      color: PDF_COLORS.muted,
+    },
+    contactRowWrap: {
+      marginTop: 6,
+      flexDirection: "row",
+      flexWrap: "wrap",
+      columnGap: 12,
+      rowGap: 3,
+    },
+    contactRow: { flexDirection: "row", alignItems: "center", gap: 4 },
+    linkPlain: { color: PDF_COLORS.foreground, textDecoration: "none" },
+    heading: {
+      borderTopWidth: 2,
+      borderTopColor: PDF_COLORS.foreground,
+      paddingTop: 3,
+    },
+    headingText: {
+      fontSize: 10 * s.title,
+      fontWeight: 700,
+      textTransform: "uppercase",
+    },
+    entryRow: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "baseline",
+      gap: 8,
+    },
+    entryTitle: { fontSize: 10 * s.body, fontWeight: 700 },
+    entryDate: {
+      fontSize: 9 * s.body,
+      fontWeight: 600,
+      color: PDF_COLORS.muted,
+      flexShrink: 0,
+    },
+    subtitle: {
+      fontSize: 9 * s.body,
+      fontWeight: 600,
+      color: PDF_COLORS.muted,
+    },
+    subtitleLink: { color: PDF_COLORS.muted, textDecoration: "none" },
+    body: { marginTop: 3 },
+  });
+
+const baseStyles = makeStyles(NO_SCALE);
 
 function TebalHeader(props: { header: HeaderView }) {
+  const styles = usePdfStyles(baseStyles);
   return (
     <View>
       <Text style={styles.name}>{props.header.fullName}</Text>
@@ -103,6 +120,7 @@ function TebalHeader(props: { header: HeaderView }) {
 }
 
 function TebalExperience(props: { item: ExperienceItemView }) {
+  const styles = usePdfStyles(baseStyles);
   return (
     <View>
       <View style={styles.entryRow}>
@@ -126,6 +144,7 @@ function TebalExperience(props: { item: ExperienceItemView }) {
 }
 
 function TebalEducation(props: { item: EducationItemView }) {
+  const styles = usePdfStyles(baseStyles);
   return (
     <View>
       <View style={styles.entryRow}>
@@ -141,6 +160,7 @@ function TebalEducation(props: { item: EducationItemView }) {
 }
 
 function TebalCertificate(props: { item: CertificateItemView }) {
+  const styles = usePdfStyles(baseStyles);
   const range = dateRange(props.item.startDate, props.item.endDate);
   return (
     <View>
@@ -162,6 +182,7 @@ function TebalCertificate(props: { item: CertificateItemView }) {
 }
 
 function TebalBlock(props: { block: ResumeBlock }) {
+  const styles = usePdfStyles(baseStyles);
   const { block } = props;
   switch (block.kind) {
     case "header":
@@ -195,22 +216,25 @@ function TebalBlock(props: { block: ResumeBlock }) {
 export function TebalPdfDocument(props: { preview: ResumePreview }) {
   const blocks = buildResumeBlocks(props.preview);
   const typography = pdfTypography(props.preview);
+  const styles = makeStyles(fontScales(props.preview));
   return (
-    <Document>
-      <Page
-        size="A4"
-        style={typography.page ? [styles.page, typography.page] : styles.page}
-      >
-        {blocks.map((block) => (
-          <View
-            key={block.id}
-            style={{ marginTop: block.gapBefore }}
-            minPresenceAhead={block.keepWithNext ? 48 : 0}
-          >
-            <TebalBlock block={block} />
-          </View>
-        ))}
-      </Page>
-    </Document>
+    <PdfStylesContext.Provider value={styles}>
+      <Document>
+        <Page
+          size="A4"
+          style={typography.page ? [styles.page, typography.page] : styles.page}
+        >
+          {blocks.map((block) => (
+            <View
+              key={block.id}
+              style={{ marginTop: block.gapBefore }}
+              minPresenceAhead={block.keepWithNext ? 48 : 0}
+            >
+              <TebalBlock block={block} />
+            </View>
+          ))}
+        </Page>
+      </Document>
+    </PdfStylesContext.Provider>
   );
 }

--- a/src/components/editor/resume-certificate-item.tsx
+++ b/src/components/editor/resume-certificate-item.tsx
@@ -4,7 +4,7 @@ export function ResumeCertificateItem(props: CertificateItemView) {
   return (
     <article>
       <div className="group flex items-baseline justify-between gap-4">
-        <h3 className="text-xs font-semibold">
+        <h3 className="resume-body-xs font-semibold">
           {props.href ? (
             <a href={props.href} className="hover:underline">
               {props.title}
@@ -14,12 +14,12 @@ export function ResumeCertificateItem(props: CertificateItemView) {
           )}
         </h3>
         {(props.startDate || props.endDate) && (
-          <span className="shrink-0 text-xs text-muted-foreground">
+          <span className="shrink-0 resume-body-xs text-muted-foreground">
             {props.startDate} - {props.endDate}
           </span>
         )}
       </div>
-      <p className="text-xs text-muted-foreground">{props.issuer}</p>
+      <p className="resume-body-xs text-muted-foreground">{props.issuer}</p>
     </article>
   );
 }

--- a/src/components/editor/resume-education-item.tsx
+++ b/src/components/editor/resume-education-item.tsx
@@ -5,12 +5,14 @@ export function ResumeEducationItem(props: EducationItemView) {
   return (
     <article>
       <div className="flex items-baseline justify-between gap-4 pb-1">
-        <h3 className="text-xs font-semibold">{props.degree}</h3>
-        <span className="shrink-0 text-xs text-muted-foreground">
+        <h3 className="resume-body-xs font-semibold">{props.degree}</h3>
+        <span className="shrink-0 resume-body-xs text-muted-foreground">
           {props.startDate} - {props.endDate}
         </span>
       </div>
-      <p className="text-xs text-muted-foreground">{props.institution}</p>
+      <p className="resume-body-xs text-muted-foreground">
+        {props.institution}
+      </p>
       <ResumeRichText blocks={props.details} className="mt-1" />
     </article>
   );

--- a/src/components/editor/resume-experience-item.tsx
+++ b/src/components/editor/resume-experience-item.tsx
@@ -5,13 +5,13 @@ export function ResumeExperienceItem(props: ExperienceItemView) {
   return (
     <article>
       <div className="flex items-baseline justify-between gap-4">
-        <h3 className="text-xs font-semibold">{props.role}</h3>
-        <span className="shrink-0 text-xs text-muted-foreground">
+        <h3 className="resume-body-xs font-semibold">{props.role}</h3>
+        <span className="shrink-0 resume-body-xs text-muted-foreground">
           {props.startDate} - {props.endDate}
         </span>
       </div>
 
-      <p className="text-xs text-muted-foreground">
+      <p className="resume-body-xs text-muted-foreground">
         {props.companyHref ? (
           <a href={props.companyHref} className="hover:underline">
             {props.company}

--- a/src/components/editor/resume-fonts.tsx
+++ b/src/components/editor/resume-fonts.tsx
@@ -5,7 +5,12 @@ import type { ResumePreview } from "./resume-preview";
 
 type TypographySlice = Pick<
   ResumePreview,
-  "font" | "letterSpacing" | "lineHeight"
+  | "font"
+  | "letterSpacing"
+  | "lineHeight"
+  | "nameScale"
+  | "titleScale"
+  | "bodyScale"
 >;
 
 /**
@@ -41,6 +46,13 @@ export function resumeTypographyStyle(
   if (resume.letterSpacing !== 0) {
     style.letterSpacing = `${resume.letterSpacing}px`;
   }
+  // Per-group font-size multipliers; the resume-<group>-* utilities multiply
+  // each element's baseline size by these (default 1 via the class fallback).
+  const record = style as Record<string, unknown>;
+  if (resume.nameScale !== 1) record["--resume-name-scale"] = resume.nameScale;
+  if (resume.titleScale !== 1)
+    record["--resume-title-scale"] = resume.titleScale;
+  if (resume.bodyScale !== 1) record["--resume-body-scale"] = resume.bodyScale;
   return style;
 }
 

--- a/src/components/editor/resume-header.tsx
+++ b/src/components/editor/resume-header.tsx
@@ -5,11 +5,15 @@ export function ResumeHeader(props: HeaderView) {
   return (
     <header className="flex flex-wrap items-start justify-between gap-4">
       <div>
-        <h1 className="text-xl font-bold tracking-tight">{props.fullName}</h1>
-        <p className="mt-1 text-muted-foreground text-sm">{props.headline}</p>
+        <h1 className="resume-name-xl font-bold tracking-tight">
+          {props.fullName}
+        </h1>
+        <p className="mt-1 text-muted-foreground resume-name-sm">
+          {props.headline}
+        </p>
       </div>
 
-      <ul className="space-y-1 text-xs">
+      <ul className="space-y-1 resume-body-xs">
         {props.contacts.map((contact) => (
           <ResumeHeaderContact
             key={contact.kind}

--- a/src/components/editor/resume-language-item.tsx
+++ b/src/components/editor/resume-language-item.tsx
@@ -2,7 +2,7 @@ import type { LanguageItemView } from "./resume-preview";
 
 export function ResumeLanguageItem(props: LanguageItemView) {
   return (
-    <li className="flex items-baseline justify-between gap-4 text-xs">
+    <li className="flex items-baseline justify-between gap-4 resume-body-xs">
       <span className="font-semibold">{props.name}</span>
       {props.proficiency && (
         <span className="text-muted-foreground">{props.proficiency}</span>

--- a/src/components/editor/resume-preview.ts
+++ b/src/components/editor/resume-preview.ts
@@ -133,6 +133,13 @@ export interface ResumePreview {
    * template's baseline (TEMPLATE_LINE_HEIGHT).
    */
   lineHeight: number | null;
+  /**
+   * Per-group font-size multipliers over each template's baseline sizes
+   * (name+headline, section titles, body), clamped 0.8..1.2; 1 = default.
+   */
+  nameScale: number;
+  titleScale: number;
+  bodyScale: number;
   headings: SectionHeadings;
   /**
    * The reorderable sections in document (reading) order. Drives the order blocks

--- a/src/components/editor/resume-rich-text.tsx
+++ b/src/components/editor/resume-rich-text.tsx
@@ -46,7 +46,7 @@ export function ResumeRichText(props: ResumeRichTextProps) {
       className={cn(
         // The document's resolved line height (see resumeTypographyStyle), so
         // the on-screen body rhythm matches the PDF page's.
-        "space-y-1 text-xs leading-(--resume-line-height,1.4) text-muted-foreground",
+        "space-y-1 resume-body-xs leading-(--resume-line-height,1.4) text-muted-foreground",
         props.className,
       )}
     >

--- a/src/components/editor/resume-section-heading.tsx
+++ b/src/components/editor/resume-section-heading.tsx
@@ -5,7 +5,7 @@ interface ResumeSectionHeadingProps {
 export function ResumeSectionHeading(props: ResumeSectionHeadingProps) {
   return (
     <div className="flex flex-col gap-1">
-      <h2 className="text-sm font-semibold uppercase tracking-wide">
+      <h2 className="resume-title-sm font-semibold uppercase tracking-wide">
         {props.title}
       </h2>
       <span className="flex-1 border-t border-dotted border-muted-foreground/40" />

--- a/src/components/editor/resume-skill-item.tsx
+++ b/src/components/editor/resume-skill-item.tsx
@@ -2,7 +2,7 @@ import type { SkillItemView } from "./resume-preview";
 
 export function ResumeSkillItem(props: SkillItemView) {
   return (
-    <li className="flex items-baseline justify-between gap-4 text-xs">
+    <li className="flex items-baseline justify-between gap-4 resume-body-xs">
       <span className="font-semibold">{props.name}</span>
       {props.proficiency && (
         <span className="text-muted-foreground">{props.proficiency}</span>

--- a/src/components/editor/resume-to-preview.ts
+++ b/src/components/editor/resume-to-preview.ts
@@ -37,6 +37,11 @@ function withHttps(value: string): string {
   return /^https?:\/\//i.test(value) ? value : `https://${value}`;
 }
 
+/** Font-size multiplier, defaulting to 1 and bounded to the editor's range. */
+function clampScale(value: number | undefined): number {
+  return Math.min(1.2, Math.max(0.8, value ?? 1));
+}
+
 /**
  * A stored title equal to the registry default means "never renamed": it
  * renders as the document-language label, which is how language switching
@@ -216,6 +221,10 @@ export function resumeToPreview(resume: Resume): ResumePreview {
       resume.lineHeight != null
         ? Math.min(2, Math.max(1.2, resume.lineHeight))
         : null,
+    // Clamped so a hand-edited document keeps template proportions readable.
+    nameScale: clampScale(resume.nameScale),
+    titleScale: clampScale(resume.titleScale),
+    bodyScale: clampScale(resume.bodyScale),
     headings,
     sectionOrder,
     customSections,

--- a/src/components/editor/templates/ketat/ketat-certificate-item.tsx
+++ b/src/components/editor/templates/ketat/ketat-certificate-item.tsx
@@ -4,7 +4,7 @@ export function KetatCertificateItem(props: CertificateItemView) {
   return (
     <article>
       <div className="flex items-baseline justify-between gap-4">
-        <h3 className="text-xs font-semibold">
+        <h3 className="resume-body-xs font-semibold">
           {props.href ? (
             <a href={props.href} className="hover:underline">
               {props.title}
@@ -14,12 +14,12 @@ export function KetatCertificateItem(props: CertificateItemView) {
           )}
         </h3>
         {(props.startDate || props.endDate) && (
-          <span className="shrink-0 text-xs italic text-muted-foreground">
+          <span className="shrink-0 resume-body-xs italic text-muted-foreground">
             {props.startDate} – {props.endDate}
           </span>
         )}
       </div>
-      <p className="text-xs text-muted-foreground">{props.issuer}</p>
+      <p className="resume-body-xs text-muted-foreground">{props.issuer}</p>
     </article>
   );
 }

--- a/src/components/editor/templates/ketat/ketat-education-item.tsx
+++ b/src/components/editor/templates/ketat/ketat-education-item.tsx
@@ -4,10 +4,12 @@ import { ResumeRichText } from "../../resume-rich-text";
 export function KetatEducationItem(props: EducationItemView) {
   return (
     <article>
-      <h3 className="text-xs font-semibold">{props.degree}</h3>
+      <h3 className="resume-body-xs font-semibold">{props.degree}</h3>
       <div className="flex items-baseline justify-between gap-4">
-        <p className="text-xs text-muted-foreground">{props.institution}</p>
-        <span className="shrink-0 text-xs italic text-muted-foreground">
+        <p className="resume-body-xs text-muted-foreground">
+          {props.institution}
+        </p>
+        <span className="shrink-0 resume-body-xs italic text-muted-foreground">
           {props.startDate} – {props.endDate}
         </span>
       </div>

--- a/src/components/editor/templates/ketat/ketat-experience-item.tsx
+++ b/src/components/editor/templates/ketat/ketat-experience-item.tsx
@@ -4,9 +4,9 @@ import { ResumeRichText } from "../../resume-rich-text";
 export function KetatExperienceItem(props: ExperienceItemView) {
   return (
     <article>
-      <h3 className="text-xs font-semibold">{props.role}</h3>
+      <h3 className="resume-body-xs font-semibold">{props.role}</h3>
       <div className="flex items-baseline justify-between gap-4">
-        <p className="text-xs text-muted-foreground">
+        <p className="resume-body-xs text-muted-foreground">
           {props.companyHref ? (
             <a href={props.companyHref} className="hover:underline">
               {props.company}
@@ -15,7 +15,7 @@ export function KetatExperienceItem(props: ExperienceItemView) {
             props.company
           )}
         </p>
-        <span className="shrink-0 text-xs italic text-muted-foreground">
+        <span className="shrink-0 resume-body-xs italic text-muted-foreground">
           {props.startDate} – {props.endDate}
         </span>
       </div>

--- a/src/components/editor/templates/ketat/ketat-header.tsx
+++ b/src/components/editor/templates/ketat/ketat-header.tsx
@@ -20,15 +20,15 @@ export function KetatHeader(props: HeaderView) {
   return (
     <header className="flex flex-wrap items-start justify-between gap-6">
       <div className="min-w-0">
-        <h1 className="font-serif text-2xl uppercase tracking-wide">
+        <h1 className="font-serif resume-name-2xl uppercase tracking-wide">
           {props.fullName}
         </h1>
-        <p className="mt-1 font-serif text-base text-muted-foreground">
+        <p className="mt-1 font-serif resume-name-base text-muted-foreground">
           {props.headline}
         </p>
       </div>
 
-      <ul className="space-y-1.5 text-xs">
+      <ul className="space-y-1.5 resume-body-xs">
         {props.contacts.map((contact) => (
           <KetatHeaderContact
             key={contact.kind}

--- a/src/components/editor/templates/ketat/ketat-section-heading.tsx
+++ b/src/components/editor/templates/ketat/ketat-section-heading.tsx
@@ -5,7 +5,7 @@ interface KetatSectionHeadingProps {
 export function KetatSectionHeading(props: KetatSectionHeadingProps) {
   return (
     <div className="border-y border-muted-foreground/40 py-1.5">
-      <h2 className="text-center font-serif text-base tracking-wide">
+      <h2 className="text-center font-serif resume-title-base tracking-wide">
         {props.title}
       </h2>
     </div>

--- a/src/components/editor/templates/ketik/ketik-certificate-item.tsx
+++ b/src/components/editor/templates/ketik/ketik-certificate-item.tsx
@@ -4,7 +4,7 @@ export function KetikCertificateItem(props: CertificateItemView) {
   return (
     <article>
       <div className="flex items-baseline justify-between gap-4">
-        <h3 className="font-mono text-xs font-bold">
+        <h3 className="font-mono resume-body-xs font-bold">
           {props.href ? (
             <a href={props.href} className="hover:underline">
               {props.title}
@@ -19,7 +19,7 @@ export function KetikCertificateItem(props: CertificateItemView) {
           </span>
         )}
       </div>
-      <p className="text-xs text-muted-foreground">{props.issuer}</p>
+      <p className="resume-body-xs text-muted-foreground">{props.issuer}</p>
     </article>
   );
 }

--- a/src/components/editor/templates/ketik/ketik-education-item.tsx
+++ b/src/components/editor/templates/ketik/ketik-education-item.tsx
@@ -5,12 +5,14 @@ export function KetikEducationItem(props: EducationItemView) {
   return (
     <article>
       <div className="flex items-baseline justify-between gap-4">
-        <h3 className="font-mono text-xs font-bold">{props.degree}</h3>
+        <h3 className="font-mono resume-body-xs font-bold">{props.degree}</h3>
         <span className="shrink-0 font-mono text-[0.6875rem] text-muted-foreground">
           {props.startDate} – {props.endDate}
         </span>
       </div>
-      <p className="text-xs text-muted-foreground">{props.institution}</p>
+      <p className="resume-body-xs text-muted-foreground">
+        {props.institution}
+      </p>
       <ResumeRichText blocks={props.details} className="mt-1" />
     </article>
   );

--- a/src/components/editor/templates/ketik/ketik-experience-item.tsx
+++ b/src/components/editor/templates/ketik/ketik-experience-item.tsx
@@ -5,12 +5,12 @@ export function KetikExperienceItem(props: ExperienceItemView) {
   return (
     <article>
       <div className="flex items-baseline justify-between gap-4">
-        <h3 className="font-mono text-xs font-bold">{props.role}</h3>
+        <h3 className="font-mono resume-body-xs font-bold">{props.role}</h3>
         <span className="shrink-0 font-mono text-[0.6875rem] text-muted-foreground">
           {props.startDate} – {props.endDate}
         </span>
       </div>
-      <p className="text-xs text-muted-foreground">
+      <p className="resume-body-xs text-muted-foreground">
         {props.companyHref ? (
           <a href={props.companyHref} className="hover:underline">
             {props.company}

--- a/src/components/editor/templates/ketik/ketik-header.tsx
+++ b/src/components/editor/templates/ketik/ketik-header.tsx
@@ -4,12 +4,14 @@ import type { HeaderView } from "../../resume-preview";
 export function KetikHeader(props: HeaderView) {
   return (
     <header className="font-mono">
-      <h1 className="text-xl font-bold">{props.fullName}</h1>
+      <h1 className="resume-name-xl font-bold">{props.fullName}</h1>
       {props.headline && (
-        <p className="mt-0.5 text-sm text-muted-foreground">{props.headline}</p>
+        <p className="mt-0.5 resume-name-sm text-muted-foreground">
+          {props.headline}
+        </p>
       )}
       {props.contacts.length > 0 && (
-        <p className="mt-1.5 text-xs text-muted-foreground">
+        <p className="mt-1.5 resume-body-xs text-muted-foreground">
           {props.contacts.map((contact, index) => (
             <Fragment key={contact.kind}>
               {index > 0 && <span aria-hidden> | </span>}

--- a/src/components/editor/templates/ketik/ketik-section-heading.tsx
+++ b/src/components/editor/templates/ketik/ketik-section-heading.tsx
@@ -4,7 +4,7 @@ interface KetikSectionHeadingProps {
 
 export function KetikSectionHeading(props: KetikSectionHeadingProps) {
   return (
-    <h2 className="border-b border-dashed border-muted-foreground/50 pb-1 font-mono text-xs font-bold uppercase">
+    <h2 className="border-b border-dashed border-muted-foreground/50 pb-1 font-mono resume-title-xs font-bold uppercase">
       {props.title}
     </h2>
   );

--- a/src/components/editor/templates/klasik/klasik-certificate-item.tsx
+++ b/src/components/editor/templates/klasik/klasik-certificate-item.tsx
@@ -4,7 +4,7 @@ export function KlasikCertificateItem(props: CertificateItemView) {
   return (
     <article className="font-serif">
       <div className="flex items-baseline justify-between gap-4">
-        <h3 className="text-sm font-semibold">
+        <h3 className="resume-body-sm font-semibold">
           {props.href ? (
             <a href={props.href} className="hover:underline">
               {props.title}
@@ -14,12 +14,12 @@ export function KlasikCertificateItem(props: CertificateItemView) {
           )}
         </h3>
         {(props.startDate || props.endDate) && (
-          <span className="shrink-0 text-xs italic text-muted-foreground">
+          <span className="shrink-0 resume-body-xs italic text-muted-foreground">
             {props.startDate} – {props.endDate}
           </span>
         )}
       </div>
-      <p className="text-xs text-muted-foreground">{props.issuer}</p>
+      <p className="resume-body-xs text-muted-foreground">{props.issuer}</p>
     </article>
   );
 }

--- a/src/components/editor/templates/klasik/klasik-education-item.tsx
+++ b/src/components/editor/templates/klasik/klasik-education-item.tsx
@@ -5,12 +5,14 @@ export function KlasikEducationItem(props: EducationItemView) {
   return (
     <article className="font-serif">
       <div className="flex items-baseline justify-between gap-4">
-        <h3 className="text-sm font-semibold">{props.degree}</h3>
-        <span className="shrink-0 text-xs italic text-muted-foreground">
+        <h3 className="resume-body-sm font-semibold">{props.degree}</h3>
+        <span className="shrink-0 resume-body-xs italic text-muted-foreground">
           {props.startDate} – {props.endDate}
         </span>
       </div>
-      <p className="text-xs text-muted-foreground">{props.institution}</p>
+      <p className="resume-body-xs text-muted-foreground">
+        {props.institution}
+      </p>
       <ResumeRichText blocks={props.details} className="mt-1 font-serif" />
     </article>
   );

--- a/src/components/editor/templates/klasik/klasik-experience-item.tsx
+++ b/src/components/editor/templates/klasik/klasik-experience-item.tsx
@@ -5,12 +5,12 @@ export function KlasikExperienceItem(props: ExperienceItemView) {
   return (
     <article className="font-serif">
       <div className="flex items-baseline justify-between gap-4">
-        <h3 className="text-sm font-semibold">{props.role}</h3>
-        <span className="shrink-0 text-xs italic text-muted-foreground">
+        <h3 className="resume-body-sm font-semibold">{props.role}</h3>
+        <span className="shrink-0 resume-body-xs italic text-muted-foreground">
           {props.startDate} – {props.endDate}
         </span>
       </div>
-      <p className="text-xs text-muted-foreground">
+      <p className="resume-body-xs text-muted-foreground">
         {props.companyHref ? (
           <a href={props.companyHref} className="hover:underline">
             {props.company}

--- a/src/components/editor/templates/klasik/klasik-header.tsx
+++ b/src/components/editor/templates/klasik/klasik-header.tsx
@@ -4,14 +4,14 @@ import type { HeaderView } from "../../resume-preview";
 export function KlasikHeader(props: HeaderView) {
   return (
     <header className="text-center font-serif">
-      <h1 className="text-2xl">{props.fullName}</h1>
+      <h1 className="resume-name-2xl">{props.fullName}</h1>
       {props.headline && (
-        <p className="mt-0.5 text-sm italic text-muted-foreground">
+        <p className="mt-0.5 resume-name-sm italic text-muted-foreground">
           {props.headline}
         </p>
       )}
       {props.contacts.length > 0 && (
-        <p className="mt-1.5 text-xs text-muted-foreground">
+        <p className="mt-1.5 resume-body-xs text-muted-foreground">
           {props.contacts.map((contact, index) => (
             <Fragment key={contact.kind}>
               {index > 0 && <span aria-hidden> · </span>}

--- a/src/components/editor/templates/klasik/klasik-section-heading.tsx
+++ b/src/components/editor/templates/klasik/klasik-section-heading.tsx
@@ -5,7 +5,7 @@ interface KlasikSectionHeadingProps {
 export function KlasikSectionHeading(props: KlasikSectionHeadingProps) {
   return (
     <div className="border-b border-muted-foreground/40 pb-1">
-      <h2 className="text-center font-serif text-sm uppercase">
+      <h2 className="text-center font-serif resume-title-sm uppercase">
         {props.title}
       </h2>
     </div>

--- a/src/components/editor/templates/luasa/luasa-certificate-item.tsx
+++ b/src/components/editor/templates/luasa/luasa-certificate-item.tsx
@@ -4,7 +4,7 @@ export function LuasaCertificateItem(props: CertificateItemView) {
   return (
     <article className="border-l-2 border-foreground/30 pl-4">
       <div className="flex items-baseline justify-between gap-4">
-        <h3 className="text-xs uppercase tracking-wide">
+        <h3 className="resume-body-xs uppercase tracking-wide">
           {props.href ? (
             <a href={props.href} className="hover:underline">
               {props.title}
@@ -14,12 +14,14 @@ export function LuasaCertificateItem(props: CertificateItemView) {
           )}
         </h3>
         {(props.startDate || props.endDate) && (
-          <span className="shrink-0 text-xs text-muted-foreground">
+          <span className="shrink-0 resume-body-xs text-muted-foreground">
             {props.startDate} – {props.endDate}
           </span>
         )}
       </div>
-      <p className="text-xs italic text-muted-foreground">{props.issuer}</p>
+      <p className="resume-body-xs italic text-muted-foreground">
+        {props.issuer}
+      </p>
     </article>
   );
 }

--- a/src/components/editor/templates/luasa/luasa-education-item.tsx
+++ b/src/components/editor/templates/luasa/luasa-education-item.tsx
@@ -5,12 +5,14 @@ export function LuasaEducationItem(props: EducationItemView) {
   return (
     <article className="border-l-2 border-foreground/30 pl-4">
       <div className="flex items-baseline justify-between gap-4">
-        <h3 className="text-xs uppercase tracking-wide">{props.degree}</h3>
-        <span className="shrink-0 text-xs text-muted-foreground">
+        <h3 className="resume-body-xs uppercase tracking-wide">
+          {props.degree}
+        </h3>
+        <span className="shrink-0 resume-body-xs text-muted-foreground">
           {props.startDate} – {props.endDate}
         </span>
       </div>
-      <p className="text-xs italic text-muted-foreground">
+      <p className="resume-body-xs italic text-muted-foreground">
         {props.institution}
       </p>
       <ResumeRichText blocks={props.details} className="mt-1" />

--- a/src/components/editor/templates/luasa/luasa-experience-item.tsx
+++ b/src/components/editor/templates/luasa/luasa-experience-item.tsx
@@ -5,12 +5,12 @@ export function LuasaExperienceItem(props: ExperienceItemView) {
   return (
     <article>
       <div className="flex items-baseline justify-between gap-4">
-        <h3 className="text-xs uppercase tracking-wide">{props.role}</h3>
-        <span className="shrink-0 text-xs text-muted-foreground">
+        <h3 className="resume-body-xs uppercase tracking-wide">{props.role}</h3>
+        <span className="shrink-0 resume-body-xs text-muted-foreground">
           {props.startDate} – {props.endDate}
         </span>
       </div>
-      <p className="text-xs italic text-muted-foreground">
+      <p className="resume-body-xs italic text-muted-foreground">
         {props.companyHref ? (
           <a href={props.companyHref} className="hover:underline">
             {props.company}

--- a/src/components/editor/templates/luasa/luasa-header.tsx
+++ b/src/components/editor/templates/luasa/luasa-header.tsx
@@ -4,16 +4,16 @@ import type { HeaderView } from "../../resume-preview";
 export function LuasaHeader(props: HeaderView) {
   return (
     <header className="border-l-2 border-foreground/80 pl-4">
-      <h1 className="font-serif text-2xl uppercase tracking-[0.08em]">
+      <h1 className="font-serif resume-name-2xl uppercase tracking-[0.08em]">
         {props.fullName}
       </h1>
       {props.headline && (
-        <p className="mt-0.5 font-serif text-sm text-muted-foreground">
+        <p className="mt-0.5 font-serif resume-name-sm text-muted-foreground">
           {props.headline}
         </p>
       )}
       {props.contacts.length > 0 && (
-        <p className="mt-1 text-xs text-muted-foreground">
+        <p className="mt-1 resume-body-xs text-muted-foreground">
           {props.contacts.map((contact, index) => (
             <Fragment key={contact.kind}>
               {index > 0 && <span aria-hidden> • </span>}

--- a/src/components/editor/templates/luasa/luasa-section-heading.tsx
+++ b/src/components/editor/templates/luasa/luasa-section-heading.tsx
@@ -4,7 +4,7 @@ interface LuasaSectionHeadingProps {
 
 export function LuasaSectionHeading(props: LuasaSectionHeadingProps) {
   return (
-    <h2 className="font-serif text-xs font-semibold uppercase tracking-[0.2em]">
+    <h2 className="font-serif resume-title-xs font-semibold uppercase tracking-[0.2em]">
       {props.title}
     </h2>
   );

--- a/src/components/editor/templates/tebal/tebal-certificate-item.tsx
+++ b/src/components/editor/templates/tebal/tebal-certificate-item.tsx
@@ -4,7 +4,7 @@ export function TebalCertificateItem(props: CertificateItemView) {
   return (
     <article>
       <div className="flex items-baseline justify-between gap-4">
-        <h3 className="text-sm font-bold">
+        <h3 className="resume-body-sm font-bold">
           {props.href ? (
             <a href={props.href} className="hover:underline">
               {props.title}
@@ -14,12 +14,12 @@ export function TebalCertificateItem(props: CertificateItemView) {
           )}
         </h3>
         {(props.startDate || props.endDate) && (
-          <span className="shrink-0 text-xs font-semibold text-muted-foreground">
+          <span className="shrink-0 resume-body-xs font-semibold text-muted-foreground">
             {props.startDate} – {props.endDate}
           </span>
         )}
       </div>
-      <p className="text-xs font-medium text-muted-foreground">
+      <p className="resume-body-xs font-medium text-muted-foreground">
         {props.issuer}
       </p>
     </article>

--- a/src/components/editor/templates/tebal/tebal-education-item.tsx
+++ b/src/components/editor/templates/tebal/tebal-education-item.tsx
@@ -5,12 +5,12 @@ export function TebalEducationItem(props: EducationItemView) {
   return (
     <article>
       <div className="flex items-baseline justify-between gap-4">
-        <h3 className="text-sm font-bold">{props.degree}</h3>
-        <span className="shrink-0 text-xs font-semibold text-muted-foreground">
+        <h3 className="resume-body-sm font-bold">{props.degree}</h3>
+        <span className="shrink-0 resume-body-xs font-semibold text-muted-foreground">
           {props.startDate} – {props.endDate}
         </span>
       </div>
-      <p className="text-xs font-medium text-muted-foreground">
+      <p className="resume-body-xs font-medium text-muted-foreground">
         {props.institution}
       </p>
       <ResumeRichText blocks={props.details} className="mt-1" />

--- a/src/components/editor/templates/tebal/tebal-experience-item.tsx
+++ b/src/components/editor/templates/tebal/tebal-experience-item.tsx
@@ -5,12 +5,12 @@ export function TebalExperienceItem(props: ExperienceItemView) {
   return (
     <article>
       <div className="flex items-baseline justify-between gap-4">
-        <h3 className="text-sm font-bold">{props.role}</h3>
-        <span className="shrink-0 text-xs font-semibold text-muted-foreground">
+        <h3 className="resume-body-sm font-bold">{props.role}</h3>
+        <span className="shrink-0 resume-body-xs font-semibold text-muted-foreground">
           {props.startDate} – {props.endDate}
         </span>
       </div>
-      <p className="text-xs font-medium text-muted-foreground">
+      <p className="resume-body-xs font-medium text-muted-foreground">
         {props.companyHref ? (
           <a href={props.companyHref} className="hover:underline">
             {props.company}

--- a/src/components/editor/templates/tebal/tebal-header.tsx
+++ b/src/components/editor/templates/tebal/tebal-header.tsx
@@ -4,16 +4,16 @@ import type { HeaderView } from "../../resume-preview";
 export function TebalHeader(props: HeaderView) {
   return (
     <header>
-      <h1 className="text-3xl font-extrabold tracking-tight">
+      <h1 className="resume-name-3xl font-extrabold tracking-tight">
         {props.fullName}
       </h1>
       {props.headline && (
-        <p className="mt-1 text-sm font-medium text-muted-foreground">
+        <p className="mt-1 resume-name-sm font-medium text-muted-foreground">
           {props.headline}
         </p>
       )}
       {props.contacts.length > 0 && (
-        <ul className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs">
+        <ul className="mt-2 flex flex-wrap gap-x-4 gap-y-1 resume-body-xs">
           {props.contacts.map((contact) => (
             <ResumeHeaderContact
               key={contact.kind}

--- a/src/components/editor/templates/tebal/tebal-section-heading.tsx
+++ b/src/components/editor/templates/tebal/tebal-section-heading.tsx
@@ -5,7 +5,7 @@ interface TebalSectionHeadingProps {
 export function TebalSectionHeading(props: TebalSectionHeadingProps) {
   return (
     <div className="border-t-4 border-foreground pt-1">
-      <h2 className="text-sm font-extrabold uppercase tracking-wide">
+      <h2 className="resume-title-sm font-extrabold uppercase tracking-wide">
         {props.title}
       </h2>
     </div>

--- a/src/lib/interchange/codec.ts
+++ b/src/lib/interchange/codec.ts
@@ -34,6 +34,9 @@ export interface ResumeContent {
   font?: string;
   letterSpacing?: number;
   lineHeight?: number;
+  nameScale?: number;
+  titleScale?: number;
+  bodyScale?: number;
   header: Header;
   sections: Section[];
 }
@@ -121,6 +124,9 @@ export function resumeToInterchange(resume: Resume): InterchangeResume {
     font: resume.font,
     letterSpacing: resume.letterSpacing ?? 0,
     lineHeight: resume.lineHeight,
+    nameScale: resume.nameScale,
+    titleScale: resume.titleScale,
+    bodyScale: resume.bodyScale,
     header,
     sections: resume.sections.map(sectionToInterchange),
   };
@@ -226,6 +232,9 @@ export function interchangeToContent(data: InterchangeResume): ResumeContent {
     font: data.font,
     letterSpacing: data.letterSpacing,
     lineHeight: data.lineHeight,
+    nameScale: data.nameScale,
+    titleScale: data.titleScale,
+    bodyScale: data.bodyScale,
     header,
     sections,
   };

--- a/src/lib/interchange/import-file.ts
+++ b/src/lib/interchange/import-file.ts
@@ -30,6 +30,15 @@ function buildImportedResume(
   if (parsed.content.lineHeight !== undefined) {
     resume.lineHeight = parsed.content.lineHeight;
   }
+  if (parsed.content.nameScale !== undefined) {
+    resume.nameScale = parsed.content.nameScale;
+  }
+  if (parsed.content.titleScale !== undefined) {
+    resume.titleScale = parsed.content.titleScale;
+  }
+  if (parsed.content.bodyScale !== undefined) {
+    resume.bodyScale = parsed.content.bodyScale;
+  }
   if (parsed.content.title) resume.title = parsed.content.title;
   return { ok: true, resume, leftovers: [] };
 }

--- a/src/lib/interchange/schema.ts
+++ b/src/lib/interchange/schema.ts
@@ -93,6 +93,9 @@ export const interchangeSchema = z
     font: z.string().optional(),
     letterSpacing: z.number().min(-0.5).max(0.5).optional(),
     lineHeight: z.number().min(1.2).max(2).optional(),
+    nameScale: z.number().min(0.8).max(1.2).optional(),
+    titleScale: z.number().min(0.8).max(1.2).optional(),
+    bodyScale: z.number().min(0.8).max(1.2).optional(),
     header: entryShape(HEADER_SCHEMA).optional(),
     sections: z.array(sectionSchema).optional(),
   })

--- a/src/lib/resume/migrations.ts
+++ b/src/lib/resume/migrations.ts
@@ -565,6 +565,22 @@ const migrateV18toV19: Migration = (doc) => {
 };
 
 /**
+ * v19→v20: adds the presentation-only per-group font-size scales. Absence means
+ * "template default" (scale 1), so existing documents need no new field; the
+ * step only clears a malformed non-number value. Bail-safe: everything else is
+ * left untouched.
+ */
+const migrateV19toV20: Migration = (doc) => {
+  const next = structuredClone(doc);
+  for (const key of ["nameScale", "titleScale", "bodyScale"] as const) {
+    if (next[key] !== undefined && !G.isNumber(next[key])) {
+      delete next[key];
+    }
+  }
+  return next;
+};
+
+/**
  * The migration ladder. Each key N is a forward-only step from version N to N+1.
  */
 const LADDER: Record<number, Migration> = {
@@ -586,6 +602,7 @@ const LADDER: Record<number, Migration> = {
   16: migrateV16toV17,
   17: migrateV17toV18,
   18: migrateV18toV19,
+  19: migrateV19toV20,
 };
 
 /** The persisted schemaVersion of a raw document; 0 when absent or malformed. */

--- a/src/lib/resume/types.ts
+++ b/src/lib/resume/types.ts
@@ -5,7 +5,7 @@ import type { JSONContent } from "@tiptap/core";
  * governs object-store/index structure only. Bumped whenever a persisted field
  * shape changes; every bump gets a forward-only step in the migration ladder.
  */
-export const CURRENT_SCHEMA_VERSION = 19;
+export const CURRENT_SCHEMA_VERSION = 20;
 
 /** The language the rendered document's fixed labels (headings, dates) use. */
 export type ResumeLanguage = "en" | "id";
@@ -166,6 +166,21 @@ export interface Resume {
    * leading) still win over the document value.
    */
   lineHeight?: number;
+  /**
+   * Presentation-only font-size scale for the person's name and the job-title
+   * headline beneath it, multiplying each template's baseline size. 1 or unset
+   * is the template default; bounded to 0.8..1.2. A multiplier (not an absolute
+   * size) so every template keeps its own proportions.
+   */
+  nameScale?: number;
+  /** Presentation-only font-size scale for section headings; see `nameScale`. */
+  titleScale?: number;
+  /**
+   * Presentation-only font-size scale for body text (summary, entries, contact,
+   * skills, languages), multiplying each template's baseline body sizes so
+   * their internal hierarchy is preserved; see `nameScale`.
+   */
+  bodyScale?: number;
   header: Header;
   sections: Section[];
   /** ISO 8601. */


### PR DESCRIPTION
Adds three font-size sliders to the Document tab, Name size, Heading size, and Body size, each resting at 100% and adjustable from 80% to 120%. They apply to the preview and the PDF together. The Name slider covers the job-title headline too, so the header stays one visual unit.

These are per-group scale multipliers, not absolute point sizes. Each template's baseline sizes remain the source of truth and are multiplied, so a template's built-in proportions survive (Awal's name is 18pt, Tebal's 22pt, each scaling from its own baseline) and body text keeps what little internal hierarchy it has (PDF entry titles 10pt vs dates 9pt) instead of flattening. At 100% the output is byte-for-byte the previous layout.

Font size can't ride a single document-wide value the way font family and line height can, so the injection differs per renderer:

- Preview: ten Tailwind v4 `@utility` classes each multiply a fixed baseline rem by a per-group CSS variable set on the preview root. Every size-bearing class across the shared and per-template components was swapped to one of these, centralizing the base-size-to-group mapping.
- PDF: each template's `StyleSheet` became a `makeStyles(scales)` factory that multiplies each fontSize by its group; the scaled sheet reaches nested block components through React context (the same pattern as the existing font-family context), so no leaf code or prop threading changed. Body text inherits the scaled page size; entry titles keep their explicit scaled sizes.

Around that: `nameScale`/`titleScale`/`bodyScale` on the document (absent means default, like font and line height), `CURRENT_SCHEMA_VERSION` bumped to 20 with a bail-safe rung, JSON and YAML round-trip with the same bounds, view-model clamps, and the three scales folded into the styling reset's pristine check and reset action. English and Indonesian labels plus a changelog highlight.

Testing: at 100% the preview renders identical baseline sizes (name 20px, heading 14px, body 12px on Awal). Each slider scales only its own group: Name to 120% grows the name to 24px while heading and body hold; Body to 80% shrinks body and skills to 9.6px while name and heading hold; Heading to 120% grows headings to 16.8px. Settings persist a reload and read back, and reset restores every baseline. The scaled PDF extracts name, role, and sections in linear reading order with the enlarged name glyph clearly larger than the shrunk body. A document saved at schemaVersion 19 opens at baseline sizes, and Ketik (the mono template that uses both the font and styles contexts) scales and exports cleanly with no console errors.