### PR TITLE
feat: show a value bubble on slider thumbs while focused

### DIFF
--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -2,6 +2,13 @@ import { Slider as SliderPrimitive } from "@base-ui/react/slider";
 
 import { cn } from "@/lib/utils";
 
+/** Trims float noise from stepped values so the thumb label reads cleanly. */
+function formatThumbValue(value: number): string {
+  return Number.isInteger(value)
+    ? String(value)
+    : String(Math.round(value * 100) / 100);
+}
+
 function Slider({
   className,
   defaultValue,
@@ -12,9 +19,13 @@ function Slider({
 }: SliderPrimitive.Root.Props) {
   const _values = Array.isArray(value)
     ? value
-    : Array.isArray(defaultValue)
-      ? defaultValue
-      : [min, max];
+    : typeof value === "number"
+      ? [value]
+      : Array.isArray(defaultValue)
+        ? defaultValue
+        : typeof defaultValue === "number"
+          ? [defaultValue]
+          : [min, max];
 
   return (
     <SliderPrimitive.Root
@@ -37,13 +48,24 @@ function Slider({
             className="bg-primary select-none data-horizontal:h-full data-vertical:w-full"
           />
         </SliderPrimitive.Track>
-        {Array.from({ length: _values.length }, (_, index) => (
+        {_values.map((thumbValue, index) => (
           <SliderPrimitive.Thumb
             data-slot="slider-thumb"
-            // biome-ignore lint/suspicious/noArrayIndexKey: ignore
+            // biome-ignore lint/suspicious/noArrayIndexKey: thumbs have no id; position is their identity
             key={index}
-            className="block size-4 shrink-0 rounded-lg bg-white shadow-md ring-1 ring-black/10 transition-[color,box-shadow] duration-200 select-none not-dark:bg-clip-padding hover:ring-4 hover:ring-ring/30 focus-visible:ring-4 focus-visible:ring-ring/30 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
-          />
+            index={index}
+            className="group/thumb block size-4 shrink-0 rounded-lg bg-white shadow-md ring-1 ring-black/10 transition-[color,box-shadow] duration-200 select-none not-dark:bg-clip-padding hover:ring-4 hover:ring-ring/30 focus-visible:ring-4 focus-visible:ring-ring/30 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+          >
+            {/* Value label, shown while the thumb is focused (keyboard or drag)
+                and hidden on blur. aria-hidden: the value is already announced
+                via the thumb's aria-valuenow. */}
+            <span
+              aria-hidden
+              className="pointer-events-none absolute bottom-full left-1/2 mb-1.5 -translate-x-1/2 rounded-md bg-foreground px-1.5 py-0.5 text-[0.6875rem] font-medium leading-none text-background opacity-0 shadow-sm transition-opacity duration-150 group-focus-within/thumb:opacity-100"
+            >
+              {formatThumbValue(thumbValue)}
+            </span>
+          </SliderPrimitive.Thumb>
         ))}
       </SliderPrimitive.Control>
     </SliderPrimitive.Root>


### PR DESCRIPTION
Every document slider (name/heading/body size, section spacing, line height, letter spacing) now shows a small value bubble above its thumb while focused. It fades in on focus (keyboard or drag), updates live as the value changes, and fades out on blur. The bubble mirrors the thumb's aria-valuenow and is aria-hidden, since screen readers already announce that value, so there's no double-speak. It's driven by CSS focus-within, not a JS-managed tooltip, so it can't get stuck open.

This also fixes a latent bug the feature surfaced: the shared Slider's `_values` fallback was `[min, max]`, so every single-value slider was rendering two overlapping thumbs (both reading aria-valuenow 0). They stacked at the same spot so it looked like one, but it was wrong. The wrapper now derives `[value]` from a numeric value, so exactly one thumb renders and the bubble is unambiguous.

Testing: each slider renders a single thumb; the bubble is hidden at rest, appears on focus, reads the correct value and updates live (section spacing showed "3" after three steps, line height showed "1.45"), and hides on blur. It sits centered just above the thumb as a light pill with dark text, confirmed visually. Values are formatted to strip float noise from stepped decimals.