### PR TITLE
feat: walk the editor sidebar tabs in the guided tour

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -122,25 +122,41 @@
     "editor": {
       "preview": {
         "title": "Live preview",
-        "content": "This paper is your resume exactly as it will export. It updates as you type and is saved to this browser automatically."
+        "content": "This is your live preview, exactly what gets exported. It updates as you type and saves to this browser automatically."
       },
       "sections": {
-        "title": "Fill in your details",
-        "content": "Each section maps to a fixed, ATS-parseable structure. Work top to bottom."
+        "title": "Editor tab",
+        "content": "Fill in each section here. Drag to reorder them or hide the ones you don't need; the structure stays ATS-parseable underneath."
+      },
+      "layout": {
+        "title": "Layout tab",
+        "content": "Swap templates from the Layout tab. Each one restyles typography and spacing only, so your content and its reading order never change."
       },
       "document": {
-        "title": "Document",
-        "content": "Export your resume, switch its language, or import from a PDF, all from the Document tab."
+        "title": "Document tab",
+        "content": "Style the whole resume here: font, sizes, spacing, line height, and letter spacing. It's also where you switch language and export or import as PDF, DOCX, JSON, or YAML."
       }
     },
     "editor-sheet": {
       "preview": {
         "title": "Live preview",
-        "content": "This paper is your resume exactly as it will export. It updates as you type and is saved to this browser automatically."
+        "content": "This is your live preview, exactly what gets exported. It updates as you type and saves to this browser automatically."
       },
       "edit": {
-        "title": "Fill in your details",
-        "content": "Tap Edit to open the section forms. Each section maps to a fixed, ATS-parseable structure."
+        "title": "Open the editor",
+        "content": "Tap Edit anytime to open this panel and make changes."
+      },
+      "sections": {
+        "title": "Editor tab",
+        "content": "Fill in each section here. Drag to reorder them or hide the ones you don't need; the structure stays ATS-parseable underneath."
+      },
+      "layout": {
+        "title": "Layout tab",
+        "content": "Swap templates from the Layout tab. Each one restyles typography and spacing only, so your content and its reading order never change."
+      },
+      "document": {
+        "title": "Document tab",
+        "content": "Style the whole resume here: font, sizes, spacing, line height, and letter spacing. It's also where you switch language and export or import as PDF, DOCX, JSON, or YAML."
       }
     }
   },

--- a/messages/id.json
+++ b/messages/id.json
@@ -122,25 +122,41 @@
     "editor": {
       "preview": {
         "title": "Pratinjau langsung",
-        "content": "Kertas ini adalah resume kamu, persis seperti yang bakal diekspor. Update otomatis pas kamu ngetik dan langsung tersimpan di browser ini."
+        "content": "Ini pratinjau langsung kamu, persis seperti yang bakal diekspor. Update otomatis pas kamu ngetik dan langsung tersimpan di browser ini."
       },
       "sections": {
-        "title": "Isi detail kamu",
-        "content": "Tiap bagian ngikutin struktur tetap yang kebaca ATS. Kerjain dari atas ke bawah."
+        "title": "Tab Editor",
+        "content": "Isi tiap bagian di sini. Seret buat mengubah urutannya atau sembunyikan yang nggak kamu perlu; strukturnya tetap kebaca ATS di baliknya."
+      },
+      "layout": {
+        "title": "Tab Tata Letak",
+        "content": "Ganti template dari tab Tata Letak. Masing-masing cuma mengubah tipografi dan spasi, jadi konten dan urutan bacanya nggak pernah berubah."
       },
       "document": {
-        "title": "Dokumen",
-        "content": "Ekspor resume, ganti bahasanya, atau impor dari PDF, semua dari tab Dokumen."
+        "title": "Tab Dokumen",
+        "content": "Atur gaya seluruh resume di sini: font, ukuran, spasi, tinggi baris, dan jarak antarhuruf. Di sini juga kamu ganti bahasa dan ekspor atau impor sebagai PDF, DOCX, JSON, atau YAML."
       }
     },
     "editor-sheet": {
       "preview": {
         "title": "Pratinjau langsung",
-        "content": "Kertas ini adalah resume kamu, persis seperti yang bakal diekspor. Update otomatis pas kamu ngetik dan langsung tersimpan di browser ini."
+        "content": "Ini pratinjau langsung kamu, persis seperti yang bakal diekspor. Update otomatis pas kamu ngetik dan langsung tersimpan di browser ini."
       },
       "edit": {
-        "title": "Isi detail kamu",
-        "content": "Ketuk Edit buat buka formulir bagiannya. Tiap bagian ngikutin struktur tetap yang kebaca ATS."
+        "title": "Buka editor",
+        "content": "Ketuk Edit kapan aja buat buka panel ini dan mulai mengubah."
+      },
+      "sections": {
+        "title": "Tab Editor",
+        "content": "Isi tiap bagian di sini. Seret buat mengubah urutannya atau sembunyikan yang nggak kamu perlu; strukturnya tetap kebaca ATS di baliknya."
+      },
+      "layout": {
+        "title": "Tab Tata Letak",
+        "content": "Ganti template dari tab Tata Letak. Masing-masing cuma mengubah tipografi dan spasi, jadi konten dan urutan bacanya nggak pernah berubah."
+      },
+      "document": {
+        "title": "Tab Dokumen",
+        "content": "Atur gaya seluruh resume di sini: font, ukuran, spasi, tinggi baris, dan jarak antarhuruf. Di sini juga kamu ganti bahasa dan ekspor atau impor sebagai PDF, DOCX, JSON, atau YAML."
       }
     }
   },

--- a/src/components/editor/editor-sheet.tsx
+++ b/src/components/editor/editor-sheet.tsx
@@ -2,6 +2,7 @@
 
 import { PenLine } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { useEditorChromeStore } from "@/lib/store";
 import { Button } from "../ui/button";
 import {
   Sheet,
@@ -15,9 +16,11 @@ import { EditorSidebarContent } from "./editor-sidebar-content";
 
 export function EditorSheet() {
   const t = useTranslations("editor.chrome");
+  const open = useEditorChromeStore((state) => state.sheetOpen);
+  const setSheetOpen = useEditorChromeStore((state) => state.setSheetOpen);
 
   return (
-    <Sheet>
+    <Sheet open={open} onOpenChange={setSheetOpen}>
       <SheetTrigger
         render={
           <Button

--- a/src/components/editor/editor-sidebar-content.tsx
+++ b/src/components/editor/editor-sidebar-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { parseAsString, useQueryState } from "nuqs";
+import { type EditorTab, useEditorChromeStore } from "@/lib/store";
 import { ScrollArea } from "../ui/scroll-area";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 import { EditorDocumentPanel } from "./editor-document-panel";
@@ -20,12 +20,10 @@ const PANEL_HEIGHT = "h-[calc(100vh-7rem)] xl:h-[calc(100vh-7rem)]";
 
 export function EditorSidebarContent() {
   const t = useTranslations("editor.chrome");
-  const [tab, setTab] = useQueryState(
-    "editor-tab",
-    parseAsString.withDefault(TABS[0].value),
-  );
+  const tab = useEditorChromeStore((state) => state.activeTab);
+  const setActiveTab = useEditorChromeStore((state) => state.setActiveTab);
 
-  const onTabChange = (next: string) => setTab(next);
+  const onTabChange = (next: string) => setActiveTab(next as EditorTab);
 
   return (
     <div className="flex flex-col py-6">
@@ -55,13 +53,13 @@ export function EditorSidebarContent() {
         </TabsContent>
 
         <TabsContent value="layout">
-          <ScrollArea className={PANEL_HEIGHT}>
+          <ScrollArea id="tour-editor-layout" className={PANEL_HEIGHT}>
             <EditorLayoutTemplateList />
           </ScrollArea>
         </TabsContent>
 
         <TabsContent value="document">
-          <ScrollArea className={PANEL_HEIGHT}>
+          <ScrollArea id="tour-editor-document" className={PANEL_HEIGHT}>
             <EditorDocumentPanel />
           </ScrollArea>
         </TabsContent>

--- a/src/components/tour/tour-provider.tsx
+++ b/src/components/tour/tour-provider.tsx
@@ -4,22 +4,39 @@ import { useTranslations } from "next-intl";
 import { useTheme } from "next-themes";
 import { NextStep, NextStepProvider } from "nextstepjs";
 import { type PropsWithChildren, useMemo } from "react";
-import { useSidebarStore, useTourStore } from "@/lib/store";
+import {
+  useEditorChromeStore,
+  useSidebarStore,
+  useTourStore,
+} from "@/lib/store";
 import { getTourStep, localizeTours } from "@/lib/tour";
 import { TourCard } from "./tour-card";
 
-const SIDEBAR_SETTLE_MS = 400;
+const SIDEBAR_SETTLE_MS = 450;
 
 function prepareStep(tourName: string | null, stepIndex: number) {
   const step = getTourStep(tourName, stepIndex);
-  if (!step || (!step.sidebar && !step.scrollTop)) return;
+  if (
+    !step ||
+    (!step.sidebar && !step.scrollTop && !step.sheet && !step.editorTab)
+  ) {
+    return;
+  }
   if (step.scrollTop) window.scrollTo({ top: 0, behavior: "instant" });
   if (step.sidebar) {
     useSidebarStore.getState().ensureVisible(step.sidebar === "open");
   }
+  // Open/close the mobile editing sheet before switching its tab, so the tab's
+  // content is mounted by the time NextStep anchors to it.
+  if (step.sheet) {
+    useEditorChromeStore.getState().setSheetOpen(step.sheet === "open");
+  }
+  if (step.editorTab) {
+    useEditorChromeStore.getState().setActiveTab(step.editorTab);
+  }
 
-  // NextStep re-anchors on window resize; nudge it once the sidebar settles
-  // so targets that mount with the mobile sheet get a real position.
+  // NextStep re-anchors on window resize; nudge it once the sidebar/sheet and
+  // the newly shown tab settle so targets get a real position.
   setTimeout(
     () => window.dispatchEvent(new Event("resize")),
     SIDEBAR_SETTLE_MS,
@@ -38,6 +55,7 @@ function handleStepChange(stepIndex: number, tourName: string | null) {
 
 function handleTourEnd() {
   useSidebarStore.getState().ensureVisible(false);
+  useEditorChromeStore.getState().setSheetOpen(false);
 }
 
 export function TourProvider(props: PropsWithChildren) {

--- a/src/lib/store/editor-chrome-store.ts
+++ b/src/lib/store/editor-chrome-store.ts
@@ -1,0 +1,26 @@
+import { create } from "zustand";
+
+/** The editor sidebar's tabs, in display order. */
+export type EditorTab = "editor" | "layout" | "document";
+
+/**
+ * Imperative control over the editor's sidebar chrome: which tab is active and,
+ * on small screens, whether the editing sheet is open. Held in a store (rather
+ * than component-local nuqs/useState) so the guided tour can drive both as it
+ * walks the tabs, mirroring how `useSidebarStore.ensureVisible` lets the tour
+ * open the platform sidebar.
+ */
+interface EditorChromeState {
+  activeTab: EditorTab;
+  setActiveTab: (tab: EditorTab) => void;
+  /** Only meaningful below xl, where the sidebar renders as a sheet. */
+  sheetOpen: boolean;
+  setSheetOpen: (open: boolean) => void;
+}
+
+export const useEditorChromeStore = create<EditorChromeState>()((set) => ({
+  activeTab: "editor",
+  setActiveTab: (activeTab) => set({ activeTab }),
+  sheetOpen: false,
+  setSheetOpen: (sheetOpen) => set({ sheetOpen }),
+}));

--- a/src/lib/store/index.ts
+++ b/src/lib/store/index.ts
@@ -1,4 +1,5 @@
 export { useChangelogStore } from "./changelog-store";
+export { type EditorTab, useEditorChromeStore } from "./editor-chrome-store";
 export { useIssueReportStore } from "./issue-report-store";
 export {
   flushOpenResumePersist,

--- a/src/lib/tour.ts
+++ b/src/lib/tour.ts
@@ -1,4 +1,5 @@
 import type { Step } from "nextstepjs";
+import type { EditorTab } from "@/lib/store";
 
 export const LIBRARY_TOUR = "library";
 export const TEMPLATE_TOUR = "template";
@@ -14,6 +15,10 @@ export type TourName =
 export interface AppStep extends Step {
   sidebar?: "open" | "closed";
   scrollTop?: boolean;
+  /** Editor tab to switch to before the step anchors, so its content is shown. */
+  editorTab?: EditorTab;
+  /** Below xl, whether the editing sheet should be open for this step. */
+  sheet?: "open" | "closed";
 }
 
 export interface AppStepMeta extends Omit<AppStep, "title" | "content"> {
@@ -138,6 +143,8 @@ export const TOUR_STEPS: AppTourMeta[] = [
     ],
   },
   {
+    // Desktop: the sidebar is always visible, so each step just switches the
+    // tab it explains and anchors to that tab's content.
     tour: EDITOR_TOUR,
     steps: [
       {
@@ -149,27 +156,67 @@ export const TOUR_STEPS: AppTourMeta[] = [
       {
         ...BASE_STEP,
         id: "sections",
+        editorTab: "editor",
         selector: "#tour-editor-sections",
         side: "left",
       },
       {
         ...BASE_STEP,
+        id: "layout",
+        editorTab: "layout",
+        selector: "#tour-editor-layout",
+        side: "left",
+      },
+      {
+        ...BASE_STEP,
         id: "document",
-        selector: "#tour-document-tab",
+        editorTab: "document",
+        selector: "#tour-editor-document",
         side: "left",
       },
     ],
   },
   {
+    // Small screens: the sidebar lives in a sheet, so the tab steps open it
+    // first, then switch the tab, walking the same three tabs as desktop.
     tour: EDITOR_SHEET_TOUR,
     steps: [
-      { ...BASE_STEP, id: "preview", sidebar: "closed" },
+      {
+        ...BASE_STEP,
+        id: "preview",
+        sheet: "closed",
+        selector: "#tour-editor-preview",
+      },
       {
         ...BASE_STEP,
         id: "edit",
-        sidebar: "closed",
+        sheet: "closed",
         selector: "#tour-editor-edit",
         side: "top-right",
+      },
+      {
+        ...BASE_STEP,
+        id: "sections",
+        sheet: "open",
+        editorTab: "editor",
+        selector: "#tour-editor-sections",
+        side: "left",
+      },
+      {
+        ...BASE_STEP,
+        id: "layout",
+        sheet: "open",
+        editorTab: "layout",
+        selector: "#tour-editor-layout",
+        side: "left",
+      },
+      {
+        ...BASE_STEP,
+        id: "document",
+        sheet: "open",
+        editorTab: "document",
+        selector: "#tour-editor-document",
+        side: "left",
       },
     ],
   },


### PR DESCRIPTION
Expands the editor guided tour to explain the sidebar in full and drive the UI as it goes.

- Both editor tours now step through all three tabs, Editor (fill in, reorder, and hide sections), Layout (swap templates, presentation-only), and Document (font, sizes, spacing, line height, letter spacing, plus language and export/import), instead of the old shallow preview then sections then document.
- Each step switches the tab it's explaining. The active tab moved from a nuqs URL param into a small `useEditorChromeStore`, mirroring how the tour already drives the platform sidebar through `useSidebarStore.ensureVisible`, so the tour (and normal clicks) set it imperatively.
- On small screens the sidebar lives in a sheet, so the tab steps open it automatically. The sheet is now controlled by the same store; the mobile tour goes preview, then an "Open the editor" step on the Edit button, then opens the sheet and walks the three tabs, and the sheet closes when the tour ends.

`editor-tab` was only read in one component, so moving it to the store is self-contained. Manual tab clicks and the mobile Edit button keep working as before; the replay Guide button and autostart already pick the desktop vs mobile tour by viewport.

Testing: the desktop tour walks preview, Editor, Layout, Document with the active tab switching each step and each tab's content visible. The mobile tour goes preview (sheet closed), edit (sheet closed), then auto-opens the sheet on the Editor tab, Layout, Document, and closes the sheet on finish. Manual checks confirm clicking a tab still switches it and the Edit button still opens the sheet. English and Indonesian copy updated; typecheck and lint pass.