### PR TITLE
docs: align readme and agents with shipped features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,17 @@ Any feature request that adds structural freedom (tables, columns, floating elem
 - Provide a plain text or .docx export path in addition to PDF. This is the actual ATS-safe submission format for many applicant tracking systems.
 - Before marking export work done, run output through at least one real parser test (Workday/Greenhouse test upload, or an open-source resume parser) and confirm fields map correctly.
 
+## Documentation
+
+- Docs are part of the change, not a follow-up. Before opening a PR, check whether the change makes any of these stale and update the affected ones in the same PR:
+  - `README.md`: user-facing features, template list, tech stack table, scripts.
+  - `AGENTS.md`: tech stack, section types, architecture rules, conventions.
+  - `design.md`: design system, tokens, routes, page-type families.
+  - `docs/schema-migrations.md`: any document-shape or `DB_VERSION` change.
+  - `docs/export-validation.md`: any change to the PDF/docx/txt export path.
+- Common triggers: adding or removing a dependency (tech stack lists), a new section type or field shape (section-type lists), a new user-facing capability (README features), a new script (scripts tables), a new route or server surface (`design.md`, the data-flow rule).
+- Verify every documented claim against the code before writing it. Describe what ships, not intended behavior. A doc that overstates the product is worse than a missing line.
+
 ## Commits
 
 - Use commitizen format via commitlint config. Do not bypass with --no-verify.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,15 +13,21 @@ An ATS Builder. Free, Open-Source, local-first resume builder. Customizable pres
 ## Tech Stack
 
 - Next.js (App Router)
-- open-next on Cloudflare (hosting only, no server-side handling of user resume data)
+- open-next on Cloudflare (hosting only; the sole server surface is the `/api/feedback` route, which relays bug reports and feature requests and never receives resume content)
+- next-intl (internationalization; `[locale]` routing for English and Indonesian, `messages/*.json`, edge middleware)
 - shadcn (base-ui variant)
 - Tailwind CSS
 - [TipTap](https://tiptap.dev/docs) (rich text editing, restricted extension set)
+- react-hook-form + zod + @hookform/resolvers (forms; every field goes through Controller, schemas in `src/lib/forms`)
+- @dnd-kit (section and entry drag-to-reorder)
+- @react-pdf/renderer and docx (PDF and .docx export)
+- nextstepjs (guided tour)
 - motion/react (animation)
 - zustand (in-memory state)
 - IndexedDB via idb (persistence layer)
 - date-fns
 - @mobily/ts-belt (general utilities)
+- Biome (lint and format; not Prettier or ESLint)
 - commitlint + commitizen (commit message enforcement)
 - husky + lint-staged (pre-commit hooks)
 - nuqs (search params state)
@@ -30,7 +36,7 @@ An ATS Builder. Free, Open-Source, local-first resume builder. Customizable pres
 
 ## Architecture Rule: Two Layers
 
-1. Structural layer. Fixed section types (header, summary, experience, education, skills, custom sections from an approved list). Each field has a restricted TipTap schema: bold, italic, bullet list, ordered list, link. No tables, no multi-column layout, no text boxes, no inline images, no custom heading levels beyond what the section template defines.
+1. Structural layer. Fixed section types (header, summary, experience, internship, projects, organizations, education, certifications, skills, languages, plus custom sections from an approved variant list). The canonical type order and per-type field schemas live in `src/lib/resume/schema-registry.ts`. Each field has a restricted TipTap schema: bold, italic, bullet list, ordered list, link. No tables, no multi-column layout, no text boxes, no inline images, no custom heading levels beyond what the section template defines.
 
 2. Presentation layer. Typography, spacing, color, accent styles, section visual ordering. Fully customizable. Must never alter the underlying linear text structure used for parsing or export.
 
@@ -49,7 +55,7 @@ Any feature request that adds structural freedom (tables, columns, floating elem
 
 ## Reordering
 
-- Section and entry reordering (if/when built) changes ordering metadata only. It does not alter content schema.
+- Section reordering (drag-to-reorder via @dnd-kit, `reorderSections` in the store) changes ordering metadata only. It does not alter content schema. Summary is pinned below the Header and does not participate; every other section type is reorderable (`REORDERABLE_SECTION_TYPES` in `src/lib/resume/schema-registry.ts`). Entries within a section are not manually reordered; they sort by date.
 
 ## Export
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 A resume builder split into two layers:
 
-- **Structural layer**: fixed section types (header, summary, experience, education, skills, languages, certificates) with a restricted rich-text schema per field. This keeps export output parseable by Applicant Tracking System (ATS) software.
+- **Structural layer**: fixed section types (header, summary, experience, internship, projects, organizations, education, certifications, skills, languages, plus custom sections from an approved list) with a restricted rich-text schema per field. This keeps export output parseable by Applicant Tracking System (ATS) software.
 - **Presentation layer**: typography, spacing, color, and theming. Fully customizable. Changes here never affect the underlying text structure used for parsing or export.
 
 Customization applies to how the resume looks. It does not extend to layouts that break ATS parsing (tables, multi-column body text, floating text boxes, embedded icons in text runs).
@@ -26,8 +26,15 @@ Customization applies to how the resume looks. It does not extend to layouts tha
 - Résumé library with live first-page thumbnails, rename, and delete
 - Print-accurate A4 preview with automatic pagination
 - Rich text editing per field, scoped to ATS-safe formatting (bold, italic, lists, links)
-- Local persistence via IndexedDB, no data leaves the browser
+- Custom sections alongside the fixed types, all sharing the same restricted schema
+- Drag to reorder sections and toggle any section's visibility (entries within a section sort by date automatically)
+- Document-level presentation controls: font, font size, section spacing, line height, letter spacing, contact-icon visibility, and a one-click style reset
+- Available in English and Indonesian (`next-intl`)
 - Export to PDF (linear reading order preserved) and plain text / .docx
+- Copy, download, and re-import a résumé as JSON or YAML
+- Guided tour of the editor and library for first-time users
+- Send bug reports and feature requests in-app, no GitHub account required
+- Local persistence via IndexedDB, no data leaves the browser
 - Fully local: works offline after initial load
 
 ## Templates
@@ -49,15 +56,20 @@ Every template renders the same linear block sequence, so switching templates ne
 |---|---|
 | Framework | Next.js (App Router) |
 | Hosting | open-next on Cloudflare |
+| Internationalization | next-intl (English, Indonesian) |
 | UI components | shadcn (base-ui) |
 | Styling | Tailwind CSS |
 | Rich text editor | TipTap |
+| Forms | react-hook-form + zod |
+| Drag and drop | @dnd-kit |
+| Export | @react-pdf/renderer, docx |
 | Animation | motion/react |
 | State | zustand |
 | Search params state | nuqs |
 | Persistence | IndexedDB (via idb) |
 | Utilities | @mobily/ts-belt |
 | Dates | date-fns |
+| Lint / format | Biome |
 
 ## Getting Started
 
@@ -76,6 +88,7 @@ Open `http://localhost:3000`.
 |---|---|
 | `pnpm dev` | Start the dev server |
 | `pnpm lint` / `pnpm format` | Check / write with Biome |
+| `pnpm typecheck` | Generate Next types and run `tsc --noEmit` |
 | `pnpm validate:exports` | Regenerate PDF/DOCX/TXT from the seed résumé and verify extraction order and field mapping |
 | `pnpm preview` | Build with open-next and preview the Cloudflare worker locally |
 | `pnpm ship` | Build and deploy to Cloudflare |


### PR DESCRIPTION
README.md and AGENTS.md had drifted from the code that landed since 0.9.3, ahead of the 0.10 release. This brings both back in line with what actually ships, and adds a rule so they stay that way.

The section-type lists were missing internship, projects, organizations, certifications, languages, and custom sections; both files now carry the full set in canonical order, with a pointer to the schema registry. The docs now cover the internationalization work (next-intl, English and Indonesian), the forms stack, dnd-kit section reordering, PDF and .docx export, and the guided tour, and record Biome as the linter and formatter. The AGENTS.md reordering rule dropped its "if/when built" hedge and is corrected to sections only, since entries sort by date rather than being manually reordered. The open-next note now carves out /api/feedback as the sole server surface, which relays bug reports and feature requests and never receives resume content.

To keep the docs from drifting again, AGENTS.md gains a Documentation section: agents treat docs as part of the change and update the affected files in the same PR, with a per-file checklist, the common triggers that make a doc stale, and a rule to verify each claim against the code rather than describe intended behavior.

Verified every claim against the code: section registry, i18n routing and middleware, the feedback route payload, the export and form modules, the import formats, and the store's reorder action. The one inaccuracy caught during that pass, entry-level reordering, was corrected to match the store, which only reorders sections.