### PR TITLE
fix: link the project name instead of the contributor role

### DIFF
--- a/src/components/editor/docx/resume-to-docx.ts
+++ b/src/components/editor/docx/resume-to-docx.ts
@@ -70,11 +70,14 @@ function sectionHeading(title: string): Paragraph {
 }
 
 /** A "Title …… Dates" row with the date right-aligned via a tab stop. */
-function titleRow(title: string, date: string): Paragraph {
+function titleRow(title: string, date: string, href?: string): Paragraph {
+  const titleRun = new TextRun({ text: title, bold: true, size: 19 });
   return new Paragraph({
     tabStops: [{ type: TabStopType.RIGHT, position: RIGHT_TAB }],
     children: [
-      new TextRun({ text: title, bold: true, size: 19 }),
+      href
+        ? new ExternalHyperlink({ link: href, children: [titleRun] })
+        : titleRun,
       ...(date ? [new TextRun({ text: `\t${date}`, color: MUTED })] : []),
     ],
   });
@@ -171,7 +174,11 @@ export function buildAwalDocx(preview: ResumePreview): Document {
       case "experience": {
         const item = block.item;
         children.push(
-          titleRow(item.role, dateRange(item.startDate, item.endDate)),
+          titleRow(
+            item.role,
+            dateRange(item.startDate, item.endDate),
+            item.roleHref,
+          ),
         );
         if (item.company)
           children.push(subtitle(item.company, item.companyHref));

--- a/src/components/editor/pdf/awal-pdf-document.tsx
+++ b/src/components/editor/pdf/awal-pdf-document.tsx
@@ -116,7 +116,21 @@ function PdfExperience(props: { item: ExperienceItemView }) {
   return (
     <View>
       <View style={styles.entryRow}>
-        <Text style={styles.entryTitle}>{props.item.role}</Text>
+        <Text style={styles.entryTitle}>
+          {props.item.roleHref ? (
+            <Link
+              src={props.item.roleHref}
+              style={[
+                styles.entryTitle,
+                { color: PDF_COLORS.foreground, textDecoration: "none" },
+              ]}
+            >
+              {props.item.role}
+            </Link>
+          ) : (
+            props.item.role
+          )}
+        </Text>
         <Text style={styles.entryDate}>
           {dateRange(props.item.startDate, props.item.endDate)}
         </Text>

--- a/src/components/editor/pdf/ketat-pdf-document.tsx
+++ b/src/components/editor/pdf/ketat-pdf-document.tsx
@@ -137,7 +137,21 @@ function KetatExperience(props: { item: ExperienceItemView }) {
   const styles = usePdfStyles(baseStyles);
   return (
     <View>
-      <Text style={styles.entryTitle}>{props.item.role}</Text>
+      <Text style={styles.entryTitle}>
+        {props.item.roleHref ? (
+          <Link
+            src={props.item.roleHref}
+            style={[
+              styles.entryTitle,
+              { color: PDF_COLORS.foreground, textDecoration: "none" },
+            ]}
+          >
+            {props.item.role}
+          </Link>
+        ) : (
+          props.item.role
+        )}
+      </Text>
       <View style={styles.subtitleRow}>
         <Text style={styles.subtitle}>
           {props.item.companyHref ? (

--- a/src/components/editor/pdf/ketik-pdf-document.tsx
+++ b/src/components/editor/pdf/ketik-pdf-document.tsx
@@ -141,7 +141,23 @@ function KetikExperience(props: { item: ExperienceItemView }) {
     <View>
       <View style={styles.entryRow}>
         <Text style={[styles.entryTitle, { fontFamily: mono }]}>
-          {props.item.role}
+          {props.item.roleHref ? (
+            <Link
+              src={props.item.roleHref}
+              style={[
+                styles.entryTitle,
+                {
+                  fontFamily: mono,
+                  color: PDF_COLORS.foreground,
+                  textDecoration: "none",
+                },
+              ]}
+            >
+              {props.item.role}
+            </Link>
+          ) : (
+            props.item.role
+          )}
         </Text>
         <Text style={[styles.entryDate, { fontFamily: mono }]}>
           {dateRange(props.item.startDate, props.item.endDate)}

--- a/src/components/editor/pdf/klasik-pdf-document.tsx
+++ b/src/components/editor/pdf/klasik-pdf-document.tsx
@@ -123,7 +123,21 @@ function KlasikExperience(props: { item: ExperienceItemView }) {
   return (
     <View>
       <View style={styles.entryRow}>
-        <Text style={styles.entryTitle}>{props.item.role}</Text>
+        <Text style={styles.entryTitle}>
+          {props.item.roleHref ? (
+            <Link
+              src={props.item.roleHref}
+              style={[
+                styles.entryTitle,
+                { color: PDF_COLORS.foreground, textDecoration: "none" },
+              ]}
+            >
+              {props.item.role}
+            </Link>
+          ) : (
+            props.item.role
+          )}
+        </Text>
         <Text style={styles.entryDate}>
           {dateRange(props.item.startDate, props.item.endDate)}
         </Text>

--- a/src/components/editor/pdf/luasa-pdf-document.tsx
+++ b/src/components/editor/pdf/luasa-pdf-document.tsx
@@ -140,7 +140,21 @@ function LuasaExperience(props: { item: ExperienceItemView }) {
   return (
     <View>
       <View style={styles.entryRow}>
-        <Text style={styles.entryTitle}>{props.item.role}</Text>
+        <Text style={styles.entryTitle}>
+          {props.item.roleHref ? (
+            <Link
+              src={props.item.roleHref}
+              style={[
+                styles.entryTitle,
+                { color: PDF_COLORS.foreground, textDecoration: "none" },
+              ]}
+            >
+              {props.item.role}
+            </Link>
+          ) : (
+            props.item.role
+          )}
+        </Text>
         <Text style={styles.entryDate}>
           {dateRange(props.item.startDate, props.item.endDate)}
         </Text>

--- a/src/components/editor/pdf/tebal-pdf-document.tsx
+++ b/src/components/editor/pdf/tebal-pdf-document.tsx
@@ -124,7 +124,21 @@ function TebalExperience(props: { item: ExperienceItemView }) {
   return (
     <View>
       <View style={styles.entryRow}>
-        <Text style={styles.entryTitle}>{props.item.role}</Text>
+        <Text style={styles.entryTitle}>
+          {props.item.roleHref ? (
+            <Link
+              src={props.item.roleHref}
+              style={[
+                styles.entryTitle,
+                { color: PDF_COLORS.foreground, textDecoration: "none" },
+              ]}
+            >
+              {props.item.role}
+            </Link>
+          ) : (
+            props.item.role
+          )}
+        </Text>
         <Text style={styles.entryDate}>
           {dateRange(props.item.startDate, props.item.endDate)}
         </Text>

--- a/src/components/editor/resume-preview.ts
+++ b/src/components/editor/resume-preview.ts
@@ -41,6 +41,7 @@ export interface HeaderView {
 export interface ExperienceItemView {
   id: string;
   role: string;
+  roleHref?: string;
   company: string;
   companyHref?: string;
   startDate: string;
@@ -162,7 +163,8 @@ export interface ResumePreview {
   /**
    * Project entries reuse `ExperienceItemView`: `role` holds the project name
    * and `company` the contributor role, so they render through the experience
-   * path in every template and export; only the section heading differs.
+   * path in every template and export; only the section heading differs. The
+   * project URL rides on `roleHref` (not `companyHref`).
    */
   projects: ExperienceItemView[];
   /**

--- a/src/components/editor/resume-to-preview.ts
+++ b/src/components/editor/resume-to-preview.ts
@@ -266,8 +266,8 @@ export function resumeToPreview(resume: Resume): ResumePreview {
         return {
           id: entry.id,
           role: plain(entry.fields.title),
+          roleHref: website ? withHttps(website) : undefined,
           company: plain(entry.fields.company),
-          companyHref: website ? withHttps(website) : undefined,
           startDate: plain(entry.fields.startDate),
           endDate: plain(entry.fields.endDate),
           description: richBlocks(entry.fields.description),

--- a/src/components/editor/templates/ketat/ketat-experience-item.tsx
+++ b/src/components/editor/templates/ketat/ketat-experience-item.tsx
@@ -4,7 +4,15 @@ import { ResumeRichText } from "../../resume-rich-text";
 export function KetatExperienceItem(props: ExperienceItemView) {
   return (
     <article>
-      <h3 className="resume-body-xs font-semibold">{props.role}</h3>
+      <h3 className="resume-body-xs font-semibold">
+        {props.roleHref ? (
+          <a href={props.roleHref} className="hover:underline">
+            {props.role}
+          </a>
+        ) : (
+          props.role
+        )}
+      </h3>
       <div className="flex items-baseline justify-between gap-4">
         <p className="resume-body-xs text-muted-foreground">
           {props.companyHref ? (

--- a/src/components/editor/templates/ketik/ketik-experience-item.tsx
+++ b/src/components/editor/templates/ketik/ketik-experience-item.tsx
@@ -5,7 +5,15 @@ export function KetikExperienceItem(props: ExperienceItemView) {
   return (
     <article>
       <div className="flex items-baseline justify-between gap-4">
-        <h3 className="font-mono resume-body-xs font-bold">{props.role}</h3>
+        <h3 className="font-mono resume-body-xs font-bold">
+          {props.roleHref ? (
+            <a href={props.roleHref} className="hover:underline">
+              {props.role}
+            </a>
+          ) : (
+            props.role
+          )}
+        </h3>
         <span className="shrink-0 font-mono text-[0.6875rem] text-muted-foreground">
           {props.startDate} – {props.endDate}
         </span>

--- a/src/components/editor/templates/klasik/klasik-experience-item.tsx
+++ b/src/components/editor/templates/klasik/klasik-experience-item.tsx
@@ -5,7 +5,15 @@ export function KlasikExperienceItem(props: ExperienceItemView) {
   return (
     <article className="font-serif">
       <div className="flex items-baseline justify-between gap-4">
-        <h3 className="resume-body-sm font-semibold">{props.role}</h3>
+        <h3 className="resume-body-sm font-semibold">
+          {props.roleHref ? (
+            <a href={props.roleHref} className="hover:underline">
+              {props.role}
+            </a>
+          ) : (
+            props.role
+          )}
+        </h3>
         <span className="shrink-0 resume-body-xs italic text-muted-foreground">
           {props.startDate} – {props.endDate}
         </span>

--- a/src/components/editor/templates/luasa/luasa-experience-item.tsx
+++ b/src/components/editor/templates/luasa/luasa-experience-item.tsx
@@ -5,7 +5,15 @@ export function LuasaExperienceItem(props: ExperienceItemView) {
   return (
     <article>
       <div className="flex items-baseline justify-between gap-4">
-        <h3 className="resume-body-xs uppercase tracking-wide">{props.role}</h3>
+        <h3 className="resume-body-xs uppercase tracking-wide">
+          {props.roleHref ? (
+            <a href={props.roleHref} className="hover:underline">
+              {props.role}
+            </a>
+          ) : (
+            props.role
+          )}
+        </h3>
         <span className="shrink-0 resume-body-xs text-muted-foreground">
           {props.startDate} – {props.endDate}
         </span>

--- a/src/components/editor/templates/tebal/tebal-experience-item.tsx
+++ b/src/components/editor/templates/tebal/tebal-experience-item.tsx
@@ -5,7 +5,15 @@ export function TebalExperienceItem(props: ExperienceItemView) {
   return (
     <article>
       <div className="flex items-baseline justify-between gap-4">
-        <h3 className="resume-body-sm font-bold">{props.role}</h3>
+        <h3 className="resume-body-sm font-bold">
+          {props.roleHref ? (
+            <a href={props.roleHref} className="hover:underline">
+              {props.role}
+            </a>
+          ) : (
+            props.role
+          )}
+        </h3>
         <span className="shrink-0 resume-body-xs font-semibold text-muted-foreground">
           {props.startDate} – {props.endDate}
         </span>


### PR DESCRIPTION
Project entries reuse `ExperienceItemView`, where `company` holds the contributor role and the project URL was bound to `companyHref`. That made the contributor role the clickable text instead of the project name.

Projects now carry the URL on a new `roleHref`, so the project name is the linked target across every web template, PDF, and docx, and the contributor role renders as plain text. Experience, internship, and organization entries are unchanged; they still link the company. No schema or migration change, since the `website` field already existed and this only retargets where the link renders.

Verified the project name is the linked element and the contributor role is not, while experience company links continue to work. The export validation gate passes across every template PDF, DOCX, and TXT, confirming the linked title preserves reading order and field mapping.