### PR TITLE
fix: keep fi/fl pairs extractable in pdf export by disabling ligatures

### DIFF
--- a/docs/export-validation.md
+++ b/docs/export-validation.md
@@ -57,6 +57,17 @@ Decisions made to satisfy them:
   boundaries are destroyed and fields stop matching. `textTransform: "uppercase"`
   is fine (whole words survive; the gate matches fields case-insensitively). The
   DOM preview may still use CSS `tracking-*`; it is never text-extracted.
+- **Ligatures (`liga`/`clig`) are disabled in the PDF shaper.** fontkit collapses
+  `f`+`i` and `f`+`l` into a single ligature glyph whose ToUnicode maps back to two
+  codepoints; readers that ignore the CMap then drop or garble the pair (e.g.
+  `fintech` → `fntech`). This is done through a `pnpm patch` on `@react-pdf/textkit`
+  (`patches/@react-pdf__textkit@6.3.0.patch`) that passes `{ liga: false, clig: false }`
+  to the two `font.layout` calls, so each letter stays its own glyph with a
+  single-codepoint ToUnicode. GPOS kerning still applies; only the aesthetic glyph
+  merge is removed, so the visual result is near-identical. The gate renders an fi/fl
+  probe and fails if any
+  glyph maps back to an `fi`/`fl` pair, which also catches the patch silently dropping
+  on a `@react-pdf` upgrade. The DOM preview is HTML and keeps native ligatures.
 - **Location** relies on the parser. OpenResume, for one, only matches US-style
   `City, ST` with a **two-letter** state (regex `[A-Z][a-zA-Z\s]+, [A-Z]{2}`); a full
   "City, Province, Country" won't be detected as a location. This is a parser

--- a/patches/@react-pdf__textkit@6.3.0.patch
+++ b/patches/@react-pdf__textkit@6.3.0.patch
@@ -1,0 +1,30 @@
+diff --git a/lib/textkit.js b/lib/textkit.js
+index 0b8b6fa636c48ef0ac9cecb27040d2bac9303ce8..2e07d3dcdbe2ecb1d2aab58739f3472eb5598648 100644
+--- a/lib/textkit.js
++++ b/lib/textkit.js
+@@ -284,8 +284,10 @@ const slice$2 = (start, end, font, glyph) => {
+         return [glyph];
+     const slicedCodePoints = codePoints.slice(start, end);
+     const string = String.fromCodePoint(...slicedCodePoints);
+-    // Force LTR direction to prevent fontkit from reversing the string
+-    return font.layout(string, undefined, undefined, undefined, 'ltr').glyphs;
++    // Force LTR direction to prevent fontkit from reversing the string.
++    // liga/clig disabled so f+i / f+l stay separate glyphs with single-char
++    // ToUnicode, keeping PDF text extraction robust for non-CMap-aware parsers.
++    return font.layout(string, { liga: false, clig: false }, undefined, undefined, 'ltr').glyphs;
+ };
+ 
+ /**
+@@ -1155,8 +1157,10 @@ const layoutRun = (string) => {
+         const runString = string.slice(start, end);
+         if (typeof font === 'string')
+             throw new Error('Invalid font');
+-        // passing LTR To force fontkit to not reverse the string
+-        const glyphRun = font[0].layout(runString, undefined, undefined, undefined, 'ltr');
++        // passing LTR To force fontkit to not reverse the string.
++        // liga/clig disabled so f+i / f+l stay separate glyphs with single-char
++        // ToUnicode, keeping PDF text extraction robust for non-CMap-aware parsers.
++        const glyphRun = font[0].layout(runString, { liga: false, clig: false }, undefined, undefined, 'ltr');
+         const positions = scalePositions(run, glyphRun.positions);
+         const stringIndices = resolve$1(glyphRun.glyphs);
+         const glyphIndices = resolve(glyphRun.glyphs);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@react-pdf/textkit@6.3.0':
+    hash: 72923b0f9a34c63884de8024158b5192f8e80d361d55b016cad6aa41fb920e09
+    path: patches/@react-pdf__textkit@6.3.0.patch
+
 importers:
 
   .:
@@ -7025,7 +7030,7 @@ snapshots:
       '@react-pdf/image': 3.1.0
       '@react-pdf/primitives': 4.3.0
       '@react-pdf/stylesheet': 6.2.1
-      '@react-pdf/textkit': 6.3.0
+      '@react-pdf/textkit': 6.3.0(patch_hash=72923b0f9a34c63884de8024158b5192f8e80d361d55b016cad6aa41fb920e09)
       '@react-pdf/types': 2.11.1
       emoji-regex-xs: 1.0.0
       queue: 6.0.2
@@ -7057,7 +7062,7 @@ snapshots:
       '@babel/runtime': 7.29.7
       '@react-pdf/fns': 3.1.3
       '@react-pdf/primitives': 4.3.0
-      '@react-pdf/textkit': 6.3.0
+      '@react-pdf/textkit': 6.3.0(patch_hash=72923b0f9a34c63884de8024158b5192f8e80d361d55b016cad6aa41fb920e09)
       '@react-pdf/types': 2.11.1
       abs-svg-path: 0.1.1
       color-string: 2.1.4
@@ -7095,7 +7100,7 @@ snapshots:
     dependencies:
       '@react-pdf/primitives': 4.3.0
 
-  '@react-pdf/textkit@6.3.0':
+  '@react-pdf/textkit@6.3.0(patch_hash=72923b0f9a34c63884de8024158b5192f8e80d361d55b016cad6aa41fb920e09)':
     dependencies:
       '@react-pdf/fns': 3.1.3
       bidi-js: 1.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,10 @@
 ignoredBuiltDependencies:
   - sharp
   - unrs-resolver
+
 onlyBuiltDependencies:
   - esbuild
   - workerd
+
+patchedDependencies:
+  '@react-pdf/textkit@6.3.0': patches/@react-pdf__textkit@6.3.0.patch

--- a/scripts/validate-exports.tsx
+++ b/scripts/validate-exports.tsx
@@ -5,7 +5,15 @@
  * This is the automated "text-extraction test" (pdftotext-equivalent) that must
  * pass after any change to an export path. Run: `pnpm validate:exports`.
  */
-import { Font, renderToBuffer } from "@react-pdf/renderer";
+import { inflateSync } from "node:zlib";
+import {
+  Document,
+  Font,
+  Page,
+  renderToBuffer,
+  Text,
+  View,
+} from "@react-pdf/renderer";
 import { Packer } from "docx";
 import JSZip from "jszip";
 import { extractText, getDocumentProxy } from "unpdf";
@@ -60,7 +68,80 @@ function registerFonts(): void {
       { src: `${root}/public/fonts/GeistMono-Bold.ttf`, fontWeight: 700 },
     ],
   });
+  Font.register({
+    family: "Merriweather",
+    fonts: [
+      { src: `${root}/public/fonts/Merriweather-Regular.ttf`, fontWeight: 400 },
+      { src: `${root}/public/fonts/Merriweather-Bold.ttf`, fontWeight: 700 },
+    ],
+  });
   Font.registerHyphenationCallback((word) => [word]);
+}
+
+/**
+ * fi/fl-heavy probe. fontkit applies GSUB "liga"/"clig" by default, collapsing
+ * f+i and f+l into a single ligature glyph whose ToUnicode maps back to two
+ * codepoints. Readers that ignore the CMap then drop or garble the pair. The
+ * @react-pdf/textkit patch disables those features so each letter stays its own
+ * glyph with a single-codepoint ToUnicode, robust for every parser.
+ */
+const LIGATURE_PROBE = "fintech workflow office final affix fluent classified";
+
+/** ToUnicode destinations that a fi/fl ligature glyph would map back to. */
+const LIGATURE_MAPPINGS = [/0066\s*0069/i, /0066\s*006c/i];
+
+/**
+ * Fails if any embedded font maps a single glyph to the "fi" or "fl" codepoint
+ * pair, i.e. a ligature survived into the PDF. Inflates the FlateDecode streams
+ * (which include the ToUnicode CMaps) and scans their bfchar destinations.
+ */
+async function checkLigatureSafety(family: string): Promise<string[]> {
+  const buffer = await renderToBuffer(
+    <Document>
+      <Page style={{ padding: 40 }}>
+        <View>
+          <Text style={{ fontFamily: family, fontSize: 12 }}>
+            {LIGATURE_PROBE}
+          </Text>
+        </View>
+      </Page>
+    </Document>,
+  );
+  const label = `PDF ligatures (${family})`;
+  const errors: string[] = [];
+
+  const text = await extractPdfText(buffer);
+  for (const word of LIGATURE_PROBE.split(" ")) {
+    if (!text.toLowerCase().includes(word)) {
+      errors.push(`${label}: "${word}" missing from extracted text`);
+    }
+  }
+
+  const bytes = Buffer.from(buffer);
+  const streams = bytes
+    .toString("latin1")
+    .matchAll(/stream\r?\n([\s\S]*?)\r?\nendstream/g);
+  const cmaps: string[] = [];
+  for (const match of streams) {
+    let inflated: string;
+    try {
+      inflated = inflateSync(Buffer.from(match[1], "latin1")).toString(
+        "latin1",
+      );
+    } catch {
+      continue;
+    }
+    if (inflated.includes("beginbfchar")) cmaps.push(inflated);
+  }
+  for (const cmap of cmaps) {
+    if (LIGATURE_MAPPINGS.some((pattern) => pattern.test(cmap))) {
+      errors.push(
+        `${label}: a glyph maps back to an fi/fl pair (ligature not disabled)`,
+      );
+      break;
+    }
+  }
+  return errors;
 }
 
 /** Section headings in the order the linear document must present them. */
@@ -164,6 +245,14 @@ async function main(): Promise<void> {
   for (const [label, text] of outputs) {
     console.log(`${label}: extracted ${text.length} chars`);
     errors.push(...checkReadingOrder(text, label), ...checkFields(text, label));
+  }
+
+  for (const family of ["Lora", "Merriweather"]) {
+    const ligatureErrors = await checkLigatureSafety(family);
+    console.log(
+      `PDF ligatures (${family}): ${ligatureErrors.length === 0 ? "fi/fl stay separate glyphs" : "FAILED"}`,
+    );
+    errors.push(...ligatureErrors);
   }
 
   if (errors.length > 0) {


### PR DESCRIPTION
Exported résumés render correctly but extract wrong in readers that don't honor the ToUnicode CMap: `fintech` comes back as `fntech`, `workflows` as `workfows`. fontkit applies GSUB `liga`/`clig` by default, collapsing `f`+`i` and `f`+`l` into a single ligature glyph whose ToUnicode maps back to two codepoints, so a naive extractor drops or garbles the pair. This surfaced when a résumé exported from Lanjut was read back by an external PDF ingestor, and the same risk applies to some ATS parsers, which is exactly the parseability the app exists to guarantee.

The PDF is technically spec-correct (the CMap is right), so the fix is to stop emitting the ligature in the first place. `@react-pdf/textkit` hard-codes `undefined` features at its two `font.layout` calls with no style or prop to override, so this is a `pnpm patch` that passes `{ liga: false, clig: false }`. Each letter then stays its own glyph with a single-codepoint ToUnicode, robust for every parser. GPOS kerning is untouched and the merge is purely aesthetic, so the visual result is near-identical; the on-screen preview is HTML and keeps native ligatures. `rlig` is left on for any future non-Latin font.

The export validation gate now renders an fi/fl probe in Lora and Merriweather and fails if any glyph maps back to an `fi`/`fl` pair. That guards the behavior and also catches the patch silently dropping on a future `@react-pdf` upgrade.

Verified the rendered content stream now encodes `f` and `i` as separate glyphs with single-char ToUnicode, that the probe extracts every fi/fl word literally, that a rasterized Merriweather sample renders cleanly with no glyph collisions, and that the full gate still passes across every template PDF, DOCX, and TXT.