### PR TITLE
fix: keep pdf entries from splitting across page breaks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ Any feature request that adds structural freedom (tables, columns, floating elem
 - PDF export must preserve linear reading order. Do not use a method that achieves visual layout via absolute positioning that breaks text extraction order. Verify with a text-extraction test (e.g., pdftotext) after any change to the PDF generation path.
 - Provide a plain text or .docx export path in addition to PDF. This is the actual ATS-safe submission format for many applicant tracking systems.
 - Before marking export work done, run output through at least one real parser test (Workday/Greenhouse test upload, or an open-source resume parser) and confirm fields map correctly.
+- Entry blocks (experience, education, certificate, and the internship/projects/organizations and custom `list` sections that reuse the experience kind) must never split across a page break; their title, subtitle, and body stay on one page, matching the on-screen paginator which never splits a block. `isAtomicBlock` in `src/components/editor/resume-blocks.ts` is the source of truth; every PDF template's block wrapper sets `wrap={isAtomicBlock(block) ? false : undefined}`. A new PDF template MUST do the same, or its entries will orphan their header at a page foot. Apply `wrap={false}` only at the whole-entry level, never on the individual bullet rows in `pdf-rich-text.tsx` (that collapses list items on top of each other at a page boundary).
 
 ## Documentation
 

--- a/src/components/editor/pdf/awal-pdf-document.tsx
+++ b/src/components/editor/pdf/awal-pdf-document.tsx
@@ -6,7 +6,11 @@ import {
   Text,
   View,
 } from "@react-pdf/renderer";
-import { buildResumeBlocks, type ResumeBlock } from "../resume-blocks";
+import {
+  buildResumeBlocks,
+  isAtomicBlock,
+  type ResumeBlock,
+} from "../resume-blocks";
 import type {
   CertificateItemView,
   EducationItemView,
@@ -233,6 +237,7 @@ export function AwalPdfDocument(props: { preview: ResumePreview }) {
               key={block.id}
               style={{ marginTop: block.gapBefore }}
               minPresenceAhead={block.keepWithNext ? 48 : 0}
+              wrap={isAtomicBlock(block) ? false : undefined}
             >
               <PdfBlock block={block} />
             </View>

--- a/src/components/editor/pdf/ketat-pdf-document.tsx
+++ b/src/components/editor/pdf/ketat-pdf-document.tsx
@@ -6,7 +6,11 @@ import {
   Text,
   View,
 } from "@react-pdf/renderer";
-import { buildResumeBlocks, type ResumeBlock } from "../resume-blocks";
+import {
+  buildResumeBlocks,
+  isAtomicBlock,
+  type ResumeBlock,
+} from "../resume-blocks";
 import type {
   CertificateItemView,
   EducationItemView,
@@ -263,6 +267,7 @@ export function KetatPdfDocument(props: { preview: ResumePreview }) {
                 key={block.id}
                 style={{ marginTop: block.gapBefore }}
                 minPresenceAhead={block.keepWithNext ? 48 : 0}
+                wrap={isAtomicBlock(block) ? false : undefined}
               >
                 <KetatBlock block={block} />
               </View>

--- a/src/components/editor/pdf/ketik-pdf-document.tsx
+++ b/src/components/editor/pdf/ketik-pdf-document.tsx
@@ -6,7 +6,11 @@ import {
   Text,
   View,
 } from "@react-pdf/renderer";
-import { buildResumeBlocks, type ResumeBlock } from "../resume-blocks";
+import {
+  buildResumeBlocks,
+  isAtomicBlock,
+  type ResumeBlock,
+} from "../resume-blocks";
 import type {
   CertificateItemView,
   ContactView,
@@ -274,6 +278,7 @@ export function KetikPdfDocument(props: { preview: ResumePreview }) {
                 key={block.id}
                 style={{ marginTop: block.gapBefore }}
                 minPresenceAhead={block.keepWithNext ? 48 : 0}
+                wrap={isAtomicBlock(block) ? false : undefined}
               >
                 <KetikBlock block={block} />
               </View>

--- a/src/components/editor/pdf/klasik-pdf-document.tsx
+++ b/src/components/editor/pdf/klasik-pdf-document.tsx
@@ -6,7 +6,11 @@ import {
   Text,
   View,
 } from "@react-pdf/renderer";
-import { buildResumeBlocks, type ResumeBlock } from "../resume-blocks";
+import {
+  buildResumeBlocks,
+  isAtomicBlock,
+  type ResumeBlock,
+} from "../resume-blocks";
 import type {
   CertificateItemView,
   ContactView,
@@ -243,6 +247,7 @@ export function KlasikPdfDocument(props: { preview: ResumePreview }) {
               key={block.id}
               style={{ marginTop: block.gapBefore }}
               minPresenceAhead={block.keepWithNext ? 48 : 0}
+              wrap={isAtomicBlock(block) ? false : undefined}
             >
               <KlasikBlock block={block} />
             </View>

--- a/src/components/editor/pdf/luasa-pdf-document.tsx
+++ b/src/components/editor/pdf/luasa-pdf-document.tsx
@@ -6,7 +6,11 @@ import {
   Text,
   View,
 } from "@react-pdf/renderer";
-import { buildResumeBlocks, type ResumeBlock } from "../resume-blocks";
+import {
+  buildResumeBlocks,
+  isAtomicBlock,
+  type ResumeBlock,
+} from "../resume-blocks";
 import type {
   CertificateItemView,
   ContactView,
@@ -267,6 +271,7 @@ export function LuasaPdfDocument(props: { preview: ResumePreview }) {
                 key={block.id}
                 style={{ marginTop: block.gapBefore }}
                 minPresenceAhead={block.keepWithNext ? 48 : 0}
+                wrap={isAtomicBlock(block) ? false : undefined}
               >
                 <LuasaBlock block={block} />
               </View>

--- a/src/components/editor/pdf/tebal-pdf-document.tsx
+++ b/src/components/editor/pdf/tebal-pdf-document.tsx
@@ -6,7 +6,11 @@ import {
   Text,
   View,
 } from "@react-pdf/renderer";
-import { buildResumeBlocks, type ResumeBlock } from "../resume-blocks";
+import {
+  buildResumeBlocks,
+  isAtomicBlock,
+  type ResumeBlock,
+} from "../resume-blocks";
 import type {
   CertificateItemView,
   EducationItemView,
@@ -243,6 +247,7 @@ export function TebalPdfDocument(props: { preview: ResumePreview }) {
               key={block.id}
               style={{ marginTop: block.gapBefore }}
               minPresenceAhead={block.keepWithNext ? 48 : 0}
+              wrap={isAtomicBlock(block) ? false : undefined}
             >
               <TebalBlock block={block} />
             </View>

--- a/src/components/editor/resume-blocks.ts
+++ b/src/components/editor/resume-blocks.ts
@@ -41,6 +41,22 @@ export type ResumeBlock = BlockMeta &
     | { kind: "languages"; items: LanguageItemView[]; columns: SectionColumns }
   );
 
+const ATOMIC_KINDS = new Set<ResumeBlock["kind"]>([
+  "experience",
+  "education",
+  "certificate",
+]);
+
+/**
+ * Entry blocks are indivisible: their title, subtitle, and body must never be
+ * split across a page break. The on-screen paginator already treats every block
+ * as one unit; PDF templates mark these with `wrap={false}` so react-pdf agrees,
+ * moving a whole entry to the next page rather than stranding its header.
+ */
+export function isAtomicBlock(block: ResumeBlock): boolean {
+  return ATOMIC_KINDS.has(block.kind);
+}
+
 const GAP = {
   /** Space above a section heading. */
   section: 24,


### PR DESCRIPTION
Experience, education, and certificate entries (and the internship, projects, organizations, and custom `list` sections that reuse the experience block kind) rendered as a single react-pdf View that could break in the middle of an entry. When that happened at a page boundary the title, company, and date were stranded at the foot of one page while the bullets started the next, so the downloaded PDF no longer matched what the editor preview showed. The on-screen paginator never splits a block, so the two had drifted apart.

The fix marks entry blocks as atomic through a new `isAtomicBlock` helper in `resume-blocks.ts`, and every template's block wrapper now sets `wrap={false}` for those blocks. A whole entry that does not fit on the current page moves to the next page intact instead of splitting. Atomicity is applied at the entry-block level only; the individual bullet rows are deliberately left wrappable, since forcing those atomic makes react-pdf pile them on top of each other at a page boundary.

Summary, custom rich-text sections, and the skills and languages grids are intentionally left splittable: their headings are already protected from being orphaned, and a long text block or grid continues cleanly across a page rather than being clipped. A single entry taller than a full page is still clipped, which is the same behaviour as the preview.

Verified against a real multi-page résumé: entries that previously split now move whole to the next page and match the editor preview, all six templates show no overlapping text, and the export reading-order and field-mapping checks still pass.
