### PR TITLE
feat: keep only one editor section accordion open at a time

### DIFF
--- a/src/components/editor/editor-sections/ed-section-list.tsx
+++ b/src/components/editor/editor-sections/ed-section-list.tsx
@@ -45,9 +45,10 @@ export function EditorSectionList() {
   const reorderSections = useResumeStore((state) => state.reorderSections);
   const t = useTranslations("editor.chrome");
 
-  // Controlled accordion open-state. Item values are the section id for custom
-  // sections (so a newly added one can be opened by id) and base-ui-generated
-  // ids for the rest. Stale ids from another résumé simply match nothing.
+  // Controlled accordion open-state, single-open so only the section being
+  // edited is visible. Item values are the section id for custom sections (so a
+  // newly added one can be opened by id) and base-ui-generated ids for the rest.
+  // Stale ids from another résumé simply match nothing.
   const [openSections, setOpenSections] = useState<string[]>([]);
 
   if (!open) {
@@ -83,7 +84,6 @@ export function EditorSectionList() {
     <>
       <Accordion
         key={open.id}
-        multiple
         value={openSections}
         onValueChange={setOpenSections}
         className="border-none"
@@ -121,9 +121,7 @@ export function EditorSectionList() {
         </SortableList>
       </Accordion>
 
-      <EditorSectionCustomAdd
-        onAdded={(id) => setOpenSections((prev) => [...prev, id])}
-      />
+      <EditorSectionCustomAdd onAdded={(id) => setOpenSections([id])} />
     </>
   );
 }


### PR DESCRIPTION
Closes #138.

The editor section list let every section accordion stay open at once, so it was easy to lose track of which entry form was actually being edited and type content into the wrong one. The Accordion root now runs in single-open mode: opening a section closes whichever one was previously open.

Adding a custom section follows the same rule. The list used to append the new section id to the open set, which under single-open would have left two panels expanded; it now replaces the open value, so the new section opens on its own.

## Testing

Opened Education in the editor, then opened Organization: Education collapsed and only Organization stayed expanded. Added a custom section from the sidebar with another section already open: the new section opened by itself and the previous one closed.