### PR TITLE
feat: add undo and redo to rich text fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Customization applies to how the resume looks. It does not extend to layouts tha
 - Template gallery with search, sort, and live seed-data previews
 - Résumé library with live first-page thumbnails, rename, and delete
 - Print-accurate A4 preview with automatic pagination
-- Rich text editing per field, scoped to ATS-safe formatting (bold, italic, lists, links)
+- Rich text editing per field, scoped to ATS-safe formatting (bold, italic, lists, links), with undo and redo per field
 - Custom sections alongside the fixed types, all sharing the same restricted schema
 - Drag to reorder sections and toggle any section's visibility (entries within a section sort by date automatically)
 - Document-level presentation controls: font, font size, section spacing, line height, letter spacing, contact-icon visibility, and a one-click style reset

--- a/messages/en.json
+++ b/messages/en.json
@@ -790,6 +790,8 @@
       "remove": "Remove language"
     },
     "richText": {
+      "undo": "Undo",
+      "redo": "Redo",
       "bold": "Bold",
       "italic": "Italic",
       "bulletList": "Bullet list",

--- a/messages/id.json
+++ b/messages/id.json
@@ -790,6 +790,8 @@
       "remove": "Hapus bahasa"
     },
     "richText": {
+      "undo": "Urungkan",
+      "redo": "Ulangi",
       "bold": "Tebal",
       "italic": "Miring",
       "bulletList": "Daftar poin",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@tiptap/extension-paragraph": "^3.27.1",
     "@tiptap/extension-placeholder": "^3.27.1",
     "@tiptap/extension-text": "^3.27.1",
+    "@tiptap/extensions": "^3.27.1",
     "@tiptap/pm": "^3.27.1",
     "@tiptap/react": "^3.27.1",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ importers:
       '@tiptap/extension-text':
         specifier: ^3.27.1
         version: 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
+      '@tiptap/extensions':
+        specifier: ^3.27.1
+        version: 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
       '@tiptap/pm':
         specifier: ^3.27.1
         version: 3.27.1

--- a/src/components/editor/rich-text/rich-text-extensions.ts
+++ b/src/components/editor/rich-text/rich-text-extensions.ts
@@ -9,6 +9,7 @@ import OrderedList from "@tiptap/extension-ordered-list";
 import Paragraph from "@tiptap/extension-paragraph";
 import Placeholder from "@tiptap/extension-placeholder";
 import Text from "@tiptap/extension-text";
+import { UndoRedo } from "@tiptap/extensions";
 import type { RichTextFeature } from "@/lib/resume/schema-registry";
 
 /**
@@ -22,7 +23,9 @@ export function buildRichTextExtensions(
   placeholder?: string,
 ): Extensions {
   const has = (feature: RichTextFeature) => features.includes(feature);
-  const extensions: Extensions = [Document, Paragraph, Text];
+  // UndoRedo is a plugin over the transaction stream, not a node or mark, so
+  // per-field history costs the schema nothing.
+  const extensions: Extensions = [Document, Paragraph, Text, UndoRedo];
 
   // Presentation-only decoration: renders empty-state text, adds no node or mark
   // to the schema, so it never affects parse/export structure.

--- a/src/components/editor/rich-text/rich-text-toolbar.tsx
+++ b/src/components/editor/rich-text/rich-text-toolbar.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { type Editor, useEditorState } from "@tiptap/react";
-import { Bold, Italic, List, ListOrdered } from "lucide-react";
+import { Bold, Italic, List, ListOrdered, Redo2, Undo2 } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
 import { Toggle } from "@/components/ui/toggle";
 import type { RichTextFeature } from "@/lib/resume/schema-registry";
 import { RichTextLinkPopover } from "./rich-text-link-popover";
@@ -22,6 +24,8 @@ export function RichTextToolbar(props: RichTextToolbarProps) {
       bulletList: editor.isActive("bulletList"),
       orderedList: editor.isActive("orderedList"),
       link: editor.isActive("link"),
+      canUndo: editor.can().undo(),
+      canRedo: editor.can().redo(),
     }),
   });
 
@@ -29,6 +33,27 @@ export function RichTextToolbar(props: RichTextToolbarProps) {
 
   return (
     <div className="flex items-center gap-0.5 rounded-md border border-input p-0.5">
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        aria-label={t("undo")}
+        disabled={!state.canUndo}
+        onClick={() => props.editor.chain().focus().undo().run()}
+      >
+        <Undo2 />
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        aria-label={t("redo")}
+        disabled={!state.canRedo}
+        onClick={() => props.editor.chain().focus().redo().run()}
+      >
+        <Redo2 />
+      </Button>
+      <Separator orientation="vertical" className="mx-0.5 my-1" />
       {has("bold") && (
         <Toggle
           size="xs"


### PR DESCRIPTION
Part of #137.

The rich-text fields had no history at all. `buildRichTextExtensions` registered Document, Paragraph, Text and the opt-in marks, and never a history plugin, so ProseMirror had nothing to undo against and Cmd+Z was a dead key in every description field. This registers TipTap's `UndoRedo` extension and adds undo and redo buttons at the head of the field toolbar, disabled when there is nothing to undo or redo.

`UndoRedo` is a plugin over the transaction stream rather than a node or mark, so it adds nothing to the restricted schema and leaves export structure untouched. It ships in `@tiptap/extensions`, pinned to 3.27.1 to match the rest of the TipTap packages. History is per field and per mount: each editor instance keeps its own stack, and closing a section unmounts its editors and drops theirs.

This does not give the document a global undo. Reordering sections, toggling visibility, and edits made in the plain inputs are outside a rich-text field's history, so #137 stays open.

## Testing

Typed into a summary field and pressed Cmd+Z: the text returned to exactly its previous content, and Cmd+Shift+Z put it back. The toolbar buttons do the same thing, start out disabled on a freshly opened field, and the undo button enables as soon as there is an edit to take back. An undo also flows through to the live preview, so the reverted text disappears from the rendered page and from what would be exported.