### PR TITLE
fix: remove stray hyphen where the pdf contact line wraps

### DIFF
--- a/src/components/editor/pdf/ketik-pdf-document.tsx
+++ b/src/components/editor/pdf/ketik-pdf-document.tsx
@@ -101,6 +101,7 @@ const baseStyles = makeStyles(NO_SCALE);
 function KetikContactLine(props: { contacts: ContactView[] }) {
   const styles = usePdfStyles(baseStyles);
   const mono = usePdfFontFamily("GeistMono");
+  // Single-spaced separator, same wrap fix as LuasaContactLine (#145).
   return (
     <Text style={[styles.contactLine, { fontFamily: mono }]}>
       {props.contacts.map((contact, index) => (

--- a/src/components/editor/pdf/klasik-pdf-document.tsx
+++ b/src/components/editor/pdf/klasik-pdf-document.tsx
@@ -90,11 +90,12 @@ const baseStyles = makeStyles(NO_SCALE);
 
 function KlasikContactLine(props: { contacts: ContactView[] }) {
   const styles = usePdfStyles(baseStyles);
+  // Single-spaced separator, same wrap fix as LuasaContactLine (#145).
   return (
     <Text style={styles.contactLine}>
       {props.contacts.map((contact, index) => (
         <Text key={contact.kind}>
-          {index > 0 ? "  ·  " : ""}
+          {index > 0 ? " · " : ""}
           {contact.href ? (
             <Link src={contact.href} style={styles.linkMuted}>
               {contact.value}

--- a/src/components/editor/pdf/luasa-pdf-document.tsx
+++ b/src/components/editor/pdf/luasa-pdf-document.tsx
@@ -102,11 +102,14 @@ const baseStyles = makeStyles(NO_SCALE);
 
 function LuasaContactLine(props: { contacts: ContactView[] }) {
   const styles = usePdfStyles(baseStyles);
+  // Single spaces around the bullet are load-bearing: textkit marks any word
+  // not followed by exactly one plain space as a hyphenation point and injects
+  // a stray "-" when the line wraps there (#145).
   return (
     <Text style={styles.contactLine}>
       {props.contacts.map((contact, index) => (
         <Text key={contact.kind}>
-          {index > 0 ? "  •  " : ""}
+          {index > 0 ? " • " : ""}
           {contact.href ? (
             <Link src={contact.href} style={styles.linkMuted}>
               {contact.value}


### PR DESCRIPTION
Fixes #145.

The \"-\" that Luasa adds before the location in the exported PDF is not part of the location text. It is a hyphen glyph that the react-pdf line breaker injects. Textkit marks a word as a hyphenation point when the text after it is not exactly one plain space. Luasa joined contacts with a double-spaced bullet, so every contact boundary became a fake hyphenation point. When the contact line wrapped there, the PDF got a stray hyphen next to the wrapped contact. The global no-hyphenation callback cannot prevent this, because the penalty comes from the gap width, not from word splitting. The preview looked correct only because it did not wrap at that width.

The fix narrows the separators to single spaces, which removes every hyphenation penalty from the contact line. Luasa and Klasik both carried the double-spaced form; Klasik showed the same artifact in a reproduction, so both change. Ketik already used single spaces and only gains a guard comment so the gap does not widen later.

Testing: rendered Luasa, Klasik, and Ketik with a long Indonesian contact line that mirrors the reporter's data, and rebuilt the visual lines from glyph positions. Before the change, Luasa ended the wrapped line with a bullet-hyphen pair and Klasik split a website address with a hyphen. After the change, all three templates wrap the contact line with no stray hyphen, and the extracted text keeps every contact intact. The full export validation pass (every template PDF, DOCX, TXT), lint, and typecheck all pass.