### PR TITLE
fix: underline links in the preview and every export

### DIFF
--- a/src/components/editor/docx/resume-to-docx.ts
+++ b/src/components/editor/docx/resume-to-docx.ts
@@ -26,6 +26,7 @@ function inlineRuns(runs: InlineRun[]): (TextRun | ExternalHyperlink)[] {
       text: run.text,
       bold: run.bold,
       italics: run.italic,
+      underline: run.href ? {} : undefined,
     });
     return run.href
       ? new ExternalHyperlink({ link: run.href, children: [child] })
@@ -72,7 +73,12 @@ function sectionHeading(title: string): Paragraph {
 
 /** A "Title …… Dates" row with the date right-aligned via a tab stop. */
 function titleRow(title: string, date: string, href?: string): Paragraph {
-  const titleRun = new TextRun({ text: title, bold: true, size: 19 });
+  const titleRun = new TextRun({
+    text: title,
+    bold: true,
+    size: 19,
+    underline: href ? {} : undefined,
+  });
   return new Paragraph({
     tabStops: [{ type: TabStopType.RIGHT, position: RIGHT_TAB }],
     children: [
@@ -86,7 +92,11 @@ function titleRow(title: string, date: string, href?: string): Paragraph {
 
 /** A muted subtitle: an optionally linked subject, then a plain-text tail. */
 function subtitle(text: string, href?: string, suffix = ""): Paragraph {
-  const child = new TextRun({ text, color: MUTED });
+  const child = new TextRun({
+    text,
+    color: MUTED,
+    underline: href ? {} : undefined,
+  });
   const subject = href
     ? new ExternalHyperlink({ link: href, children: [child] })
     : child;
@@ -129,7 +139,10 @@ function contactRuns(contacts: ContactView[]): (TextRun | ExternalHyperlink)[] {
   const runs: (TextRun | ExternalHyperlink)[] = [];
   contacts.forEach((contact, index) => {
     if (index > 0) runs.push(new TextRun({ text: "   |   ", color: MUTED }));
-    const child = new TextRun({ text: contact.value });
+    const child = new TextRun({
+      text: contact.value,
+      underline: contact.href ? {} : undefined,
+    });
     runs.push(
       contact.href
         ? new ExternalHyperlink({ link: contact.href, children: [child] })

--- a/src/components/editor/pdf/awal-pdf-document.tsx
+++ b/src/components/editor/pdf/awal-pdf-document.tsx
@@ -59,7 +59,7 @@ const makeStyles = (s: FontScales) =>
     },
     headerRight: { alignItems: "flex-start", gap: 3 },
     contactRow: { flexDirection: "row", alignItems: "center", gap: 4 },
-    linkPlain: { color: PDF_COLORS.foreground, textDecoration: "none" },
+    linkPlain: { color: PDF_COLORS.foreground, textDecoration: "underline" },
     heading: {
       fontSize: 10 * s.title,
       fontWeight: 600,
@@ -80,7 +80,7 @@ const makeStyles = (s: FontScales) =>
     entryTitle: { fontSize: 9.5 * s.body, fontWeight: 600 },
     entryDate: { fontSize: 9 * s.body, color: PDF_COLORS.muted, flexShrink: 0 },
     subtitle: { fontSize: 9 * s.body, color: PDF_COLORS.muted },
-    subtitleLink: { color: PDF_COLORS.muted, textDecoration: "none" },
+    subtitleLink: { color: PDF_COLORS.muted, textDecoration: "underline" },
     body: { marginTop: 3 },
   });
 
@@ -127,7 +127,7 @@ function PdfExperience(props: { item: ExperienceItemView }) {
               src={props.item.roleHref}
               style={[
                 styles.entryTitle,
-                { color: PDF_COLORS.foreground, textDecoration: "none" },
+                { color: PDF_COLORS.foreground, textDecoration: "underline" },
               ]}
             >
               {props.item.role}

--- a/src/components/editor/pdf/ketat-pdf-document.tsx
+++ b/src/components/editor/pdf/ketat-pdf-document.tsx
@@ -69,7 +69,7 @@ const makeStyles = (s: FontScales) =>
     },
     headerRight: { alignItems: "flex-end", gap: 4 },
     contactRow: { flexDirection: "row", alignItems: "center", gap: 4 },
-    linkPlain: { color: PDF_COLORS.foreground, textDecoration: "none" },
+    linkPlain: { color: PDF_COLORS.foreground, textDecoration: "underline" },
     heading: {
       borderTopWidth: 0.75,
       borderTopColor: PDF_COLORS.border,
@@ -91,7 +91,7 @@ const makeStyles = (s: FontScales) =>
       gap: 8,
     },
     subtitle: { fontSize: 9 * s.body, color: PDF_COLORS.muted },
-    subtitleLink: { color: PDF_COLORS.muted, textDecoration: "none" },
+    subtitleLink: { color: PDF_COLORS.muted, textDecoration: "underline" },
     entryDate: {
       fontSize: 9 * s.body,
       fontStyle: "italic",
@@ -148,7 +148,7 @@ function KetatExperience(props: { item: ExperienceItemView }) {
             src={props.item.roleHref}
             style={[
               styles.entryTitle,
-              { color: PDF_COLORS.foreground, textDecoration: "none" },
+              { color: PDF_COLORS.foreground, textDecoration: "underline" },
             ]}
           >
             {props.item.role}

--- a/src/components/editor/pdf/ketik-pdf-document.tsx
+++ b/src/components/editor/pdf/ketik-pdf-document.tsx
@@ -64,7 +64,7 @@ const makeStyles = (s: FontScales) =>
       fontSize: 8 * s.body,
       color: PDF_COLORS.muted,
     },
-    linkMuted: { color: PDF_COLORS.muted, textDecoration: "none" },
+    linkMuted: { color: PDF_COLORS.muted, textDecoration: "underline" },
     heading: {
       fontFamily: "GeistMono",
       fontSize: 9.5 * s.title,
@@ -155,7 +155,7 @@ function KetikExperience(props: { item: ExperienceItemView }) {
                 {
                   fontFamily: mono,
                   color: PDF_COLORS.foreground,
-                  textDecoration: "none",
+                  textDecoration: "underline",
                 },
               ]}
             >

--- a/src/components/editor/pdf/klasik-pdf-document.tsx
+++ b/src/components/editor/pdf/klasik-pdf-document.tsx
@@ -58,7 +58,7 @@ const makeStyles = (s: FontScales) =>
       color: PDF_COLORS.muted,
       textAlign: "center",
     },
-    linkMuted: { color: PDF_COLORS.muted, textDecoration: "none" },
+    linkMuted: { color: PDF_COLORS.muted, textDecoration: "underline" },
     heading: {
       borderBottomWidth: 0.5,
       borderBottomColor: PDF_COLORS.border,
@@ -135,7 +135,7 @@ function KlasikExperience(props: { item: ExperienceItemView }) {
               src={props.item.roleHref}
               style={[
                 styles.entryTitle,
-                { color: PDF_COLORS.foreground, textDecoration: "none" },
+                { color: PDF_COLORS.foreground, textDecoration: "underline" },
               ]}
             >
               {props.item.role}

--- a/src/components/editor/pdf/luasa-pdf-document.tsx
+++ b/src/components/editor/pdf/luasa-pdf-document.tsx
@@ -75,7 +75,7 @@ const makeStyles = (s: FontScales) =>
       fontSize: 9 * s.body,
       color: PDF_COLORS.muted,
     },
-    linkMuted: { color: PDF_COLORS.muted, textDecoration: "none" },
+    linkMuted: { color: PDF_COLORS.muted, textDecoration: "underline" },
     heading: {
       fontFamily: "Lora",
       fontSize: 9.5 * s.title,
@@ -154,7 +154,7 @@ function LuasaExperience(props: { item: ExperienceItemView }) {
               src={props.item.roleHref}
               style={[
                 styles.entryTitle,
-                { color: PDF_COLORS.foreground, textDecoration: "none" },
+                { color: PDF_COLORS.foreground, textDecoration: "underline" },
               ]}
             >
               {props.item.role}

--- a/src/components/editor/pdf/tebal-pdf-document.tsx
+++ b/src/components/editor/pdf/tebal-pdf-document.tsx
@@ -59,7 +59,7 @@ const makeStyles = (s: FontScales) =>
       rowGap: 3,
     },
     contactRow: { flexDirection: "row", alignItems: "center", gap: 4 },
-    linkPlain: { color: PDF_COLORS.foreground, textDecoration: "none" },
+    linkPlain: { color: PDF_COLORS.foreground, textDecoration: "underline" },
     heading: {
       borderTopWidth: 2,
       borderTopColor: PDF_COLORS.foreground,
@@ -88,7 +88,7 @@ const makeStyles = (s: FontScales) =>
       fontWeight: 600,
       color: PDF_COLORS.muted,
     },
-    subtitleLink: { color: PDF_COLORS.muted, textDecoration: "none" },
+    subtitleLink: { color: PDF_COLORS.muted, textDecoration: "underline" },
     body: { marginTop: 3 },
   });
 
@@ -135,7 +135,7 @@ function TebalExperience(props: { item: ExperienceItemView }) {
               src={props.item.roleHref}
               style={[
                 styles.entryTitle,
-                { color: PDF_COLORS.foreground, textDecoration: "none" },
+                { color: PDF_COLORS.foreground, textDecoration: "underline" },
               ]}
             >
               {props.item.role}

--- a/src/components/editor/resume-certificate-item.tsx
+++ b/src/components/editor/resume-certificate-item.tsx
@@ -6,7 +6,7 @@ export function ResumeCertificateItem(props: CertificateItemView) {
       <div className="group flex items-baseline justify-between gap-4">
         <h3 className="resume-body-xs font-semibold">
           {props.href ? (
-            <a href={props.href} className="hover:underline">
+            <a href={props.href} className="underline">
               {props.title}
             </a>
           ) : (

--- a/src/components/editor/resume-experience-item.tsx
+++ b/src/components/editor/resume-experience-item.tsx
@@ -14,7 +14,7 @@ export function ResumeExperienceItem(props: ExperienceItemView) {
 
       <p className="resume-body-xs text-muted-foreground">
         {props.companyHref ? (
-          <a href={props.companyHref} className="hover:underline">
+          <a href={props.companyHref} className="underline">
             {props.company}
           </a>
         ) : (

--- a/src/components/editor/resume-header-contact.tsx
+++ b/src/components/editor/resume-header-contact.tsx
@@ -12,7 +12,7 @@ export function ResumeHeaderContact(
         className="text-muted-foreground"
       />
       {props.href ? (
-        <a href={props.href} className="hover:underline">
+        <a href={props.href} className="underline">
           {props.value}
         </a>
       ) : (

--- a/src/components/editor/templates/ketat/ketat-certificate-item.tsx
+++ b/src/components/editor/templates/ketat/ketat-certificate-item.tsx
@@ -6,7 +6,7 @@ export function KetatCertificateItem(props: CertificateItemView) {
       <div className="flex items-baseline justify-between gap-4">
         <h3 className="resume-body-xs font-semibold">
           {props.href ? (
-            <a href={props.href} className="hover:underline">
+            <a href={props.href} className="underline">
               {props.title}
             </a>
           ) : (

--- a/src/components/editor/templates/ketat/ketat-experience-item.tsx
+++ b/src/components/editor/templates/ketat/ketat-experience-item.tsx
@@ -7,7 +7,7 @@ export function KetatExperienceItem(props: ExperienceItemView) {
     <article>
       <h3 className="resume-body-xs font-semibold">
         {props.roleHref ? (
-          <a href={props.roleHref} className="hover:underline">
+          <a href={props.roleHref} className="underline">
             {props.role}
           </a>
         ) : (
@@ -17,7 +17,7 @@ export function KetatExperienceItem(props: ExperienceItemView) {
       <div className="flex items-baseline justify-between gap-4">
         <p className="resume-body-xs text-muted-foreground">
           {props.companyHref ? (
-            <a href={props.companyHref} className="hover:underline">
+            <a href={props.companyHref} className="underline">
               {props.company}
             </a>
           ) : (

--- a/src/components/editor/templates/ketat/ketat-header.tsx
+++ b/src/components/editor/templates/ketat/ketat-header.tsx
@@ -5,7 +5,7 @@ function KetatHeaderContact(props: ContactView & { showIcons: boolean }) {
   return (
     <li className="flex items-center justify-end gap-2">
       {props.href ? (
-        <a href={props.href} className="hover:underline">
+        <a href={props.href} className="underline">
           {props.value}
         </a>
       ) : (

--- a/src/components/editor/templates/ketik/ketik-certificate-item.tsx
+++ b/src/components/editor/templates/ketik/ketik-certificate-item.tsx
@@ -6,7 +6,7 @@ export function KetikCertificateItem(props: CertificateItemView) {
       <div className="flex items-baseline justify-between gap-4">
         <h3 className="font-mono resume-body-xs font-bold">
           {props.href ? (
-            <a href={props.href} className="hover:underline">
+            <a href={props.href} className="underline">
               {props.title}
             </a>
           ) : (

--- a/src/components/editor/templates/ketik/ketik-experience-item.tsx
+++ b/src/components/editor/templates/ketik/ketik-experience-item.tsx
@@ -8,7 +8,7 @@ export function KetikExperienceItem(props: ExperienceItemView) {
       <div className="flex items-baseline justify-between gap-4">
         <h3 className="font-mono resume-body-xs font-bold">
           {props.roleHref ? (
-            <a href={props.roleHref} className="hover:underline">
+            <a href={props.roleHref} className="underline">
               {props.role}
             </a>
           ) : (
@@ -21,7 +21,7 @@ export function KetikExperienceItem(props: ExperienceItemView) {
       </div>
       <p className="resume-body-xs text-muted-foreground">
         {props.companyHref ? (
-          <a href={props.companyHref} className="hover:underline">
+          <a href={props.companyHref} className="underline">
             {props.company}
           </a>
         ) : (

--- a/src/components/editor/templates/ketik/ketik-header.tsx
+++ b/src/components/editor/templates/ketik/ketik-header.tsx
@@ -16,7 +16,7 @@ export function KetikHeader(props: HeaderView) {
             <Fragment key={contact.kind}>
               {index > 0 && <span aria-hidden> | </span>}
               {contact.href ? (
-                <a href={contact.href} className="hover:underline">
+                <a href={contact.href} className="underline">
                   {contact.value}
                 </a>
               ) : (

--- a/src/components/editor/templates/klasik/klasik-certificate-item.tsx
+++ b/src/components/editor/templates/klasik/klasik-certificate-item.tsx
@@ -6,7 +6,7 @@ export function KlasikCertificateItem(props: CertificateItemView) {
       <div className="flex items-baseline justify-between gap-4">
         <h3 className="resume-body-sm font-semibold">
           {props.href ? (
-            <a href={props.href} className="hover:underline">
+            <a href={props.href} className="underline">
               {props.title}
             </a>
           ) : (

--- a/src/components/editor/templates/klasik/klasik-experience-item.tsx
+++ b/src/components/editor/templates/klasik/klasik-experience-item.tsx
@@ -8,7 +8,7 @@ export function KlasikExperienceItem(props: ExperienceItemView) {
       <div className="flex items-baseline justify-between gap-4">
         <h3 className="resume-body-sm font-semibold">
           {props.roleHref ? (
-            <a href={props.roleHref} className="hover:underline">
+            <a href={props.roleHref} className="underline">
               {props.role}
             </a>
           ) : (
@@ -21,7 +21,7 @@ export function KlasikExperienceItem(props: ExperienceItemView) {
       </div>
       <p className="resume-body-xs text-muted-foreground">
         {props.companyHref ? (
-          <a href={props.companyHref} className="hover:underline">
+          <a href={props.companyHref} className="underline">
             {props.company}
           </a>
         ) : (

--- a/src/components/editor/templates/klasik/klasik-header.tsx
+++ b/src/components/editor/templates/klasik/klasik-header.tsx
@@ -16,7 +16,7 @@ export function KlasikHeader(props: HeaderView) {
             <Fragment key={contact.kind}>
               {index > 0 && <span aria-hidden> · </span>}
               {contact.href ? (
-                <a href={contact.href} className="hover:underline">
+                <a href={contact.href} className="underline">
                   {contact.value}
                 </a>
               ) : (

--- a/src/components/editor/templates/luasa/luasa-certificate-item.tsx
+++ b/src/components/editor/templates/luasa/luasa-certificate-item.tsx
@@ -6,7 +6,7 @@ export function LuasaCertificateItem(props: CertificateItemView) {
       <div className="flex items-baseline justify-between gap-4">
         <h3 className="resume-body-xs uppercase tracking-wide">
           {props.href ? (
-            <a href={props.href} className="hover:underline">
+            <a href={props.href} className="underline">
               {props.title}
             </a>
           ) : (

--- a/src/components/editor/templates/luasa/luasa-experience-item.tsx
+++ b/src/components/editor/templates/luasa/luasa-experience-item.tsx
@@ -8,7 +8,7 @@ export function LuasaExperienceItem(props: ExperienceItemView) {
       <div className="flex items-baseline justify-between gap-4">
         <h3 className="resume-body-xs uppercase tracking-wide">
           {props.roleHref ? (
-            <a href={props.roleHref} className="hover:underline">
+            <a href={props.roleHref} className="underline">
               {props.role}
             </a>
           ) : (
@@ -21,7 +21,7 @@ export function LuasaExperienceItem(props: ExperienceItemView) {
       </div>
       <p className="resume-body-xs italic text-muted-foreground">
         {props.companyHref ? (
-          <a href={props.companyHref} className="hover:underline">
+          <a href={props.companyHref} className="underline">
             {props.company}
           </a>
         ) : (

--- a/src/components/editor/templates/luasa/luasa-header.tsx
+++ b/src/components/editor/templates/luasa/luasa-header.tsx
@@ -18,7 +18,7 @@ export function LuasaHeader(props: HeaderView) {
             <Fragment key={contact.kind}>
               {index > 0 && <span aria-hidden> • </span>}
               {contact.href ? (
-                <a href={contact.href} className="hover:underline">
+                <a href={contact.href} className="underline">
                   {contact.value}
                 </a>
               ) : (

--- a/src/components/editor/templates/tebal/tebal-certificate-item.tsx
+++ b/src/components/editor/templates/tebal/tebal-certificate-item.tsx
@@ -6,7 +6,7 @@ export function TebalCertificateItem(props: CertificateItemView) {
       <div className="flex items-baseline justify-between gap-4">
         <h3 className="resume-body-sm font-bold">
           {props.href ? (
-            <a href={props.href} className="hover:underline">
+            <a href={props.href} className="underline">
               {props.title}
             </a>
           ) : (

--- a/src/components/editor/templates/tebal/tebal-experience-item.tsx
+++ b/src/components/editor/templates/tebal/tebal-experience-item.tsx
@@ -8,7 +8,7 @@ export function TebalExperienceItem(props: ExperienceItemView) {
       <div className="flex items-baseline justify-between gap-4">
         <h3 className="resume-body-sm font-bold">
           {props.roleHref ? (
-            <a href={props.roleHref} className="hover:underline">
+            <a href={props.roleHref} className="underline">
               {props.role}
             </a>
           ) : (
@@ -21,7 +21,7 @@ export function TebalExperienceItem(props: ExperienceItemView) {
       </div>
       <p className="resume-body-xs font-medium text-muted-foreground">
         {props.companyHref ? (
-          <a href={props.companyHref} className="hover:underline">
+          <a href={props.companyHref} className="underline">
             {props.company}
           </a>
         ) : (


### PR DESCRIPTION
Part of #143 (the link visibility half; the extra optional header link slot stays open there).

Links in the exported PDF were always clickable, and email already opens the mail client, but nothing marked them as links. Every structural link (contacts, company, role, certificate) rendered with no underline and the same color as the surrounding text, in the preview, the PDF, and the .docx.

This change underlines every structural link in all six templates, in the preview and in the PDF, and keeps each template's colors. Rich text body links already used an underline, so the whole document now follows one convention. The preview drops its hover-only underline for a constant one, so the page on screen matches the export. In the .docx, linked runs now carry an underline as well; they were already real hyperlinks in Word but looked like plain text.

An underline was chosen over a blue color because the templates are monochrome by design and an underline survives grayscale printing.

Testing: rendered all six template PDFs from the seed resume and counted draw operations in the output. Every template gains exactly twelve stroke operations, which matches the six structural links in the seed document, and the baseline strokes for borders and body links stay unchanged. The full export validation pass (every template PDF, DOCX, TXT), lint, and typecheck all pass.