### PR TITLE
feat: add document-level undo and redo to the editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Customization applies to how the resume looks. It does not extend to layouts tha
 - Résumé library with live first-page thumbnails, rename, and delete
 - Print-accurate A4 preview with automatic pagination
 - Rich text editing per field, scoped to ATS-safe formatting (bold, italic, lists, links), with undo and redo per field
+- Document-level undo and redo across every edit (typing, reorder, layout, settings), from the editor toolbar or Ctrl/Cmd+Z
 - Custom sections alongside the fixed types, all sharing the same restricted schema
 - Drag to reorder sections and toggle any section's visibility (entries within a section sort by date automatically)
 - Document-level presentation controls: font, font size, section spacing, line height, letter spacing, contact-icon visibility, and a one-click style reset

--- a/messages/en.json
+++ b/messages/en.json
@@ -595,7 +595,9 @@
       "resetOrder": "Reset section order",
       "sectionsHeading": "Sections",
       "addSection": "Custom Section",
-      "tabDocument": "Document"
+      "tabDocument": "Document",
+      "undo": "Undo",
+      "redo": "Redo"
     },
     "dateRange": {
       "startDate": "Start Date",

--- a/messages/id.json
+++ b/messages/id.json
@@ -595,7 +595,9 @@
       "resetOrder": "Setel ulang urutan bagian",
       "sectionsHeading": "Bagian",
       "addSection": "Bagian Khusus",
-      "tabDocument": "Dokumen"
+      "tabDocument": "Dokumen",
+      "undo": "Urungkan",
+      "redo": "Ulangi"
     },
     "dateRange": {
       "startDate": "Tanggal Mulai",

--- a/src/components/editor/editor-document-style-reset.tsx
+++ b/src/components/editor/editor-document-style-reset.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Undo2 } from "lucide-react";
+import { RefreshCw } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import {
@@ -63,7 +63,7 @@ export function EditorDocumentStyleReset() {
         }
       >
         <span className="sr-only">{t("resetStyling")}</span>
-        <Undo2 />
+        <RefreshCw />
       </TooltipTrigger>
       <TooltipContent>
         <span>{t("resetStylingHint")}</span>

--- a/src/components/editor/editor-panels.tsx
+++ b/src/components/editor/editor-panels.tsx
@@ -11,6 +11,7 @@ import {
 import { ScrollArea } from "../ui/scroll-area";
 import { EditorSheet } from "./editor-sheet";
 import { EditorSidebar } from "./editor-sidebar";
+import { EditorUndoShortcuts } from "./editor-undo-shortcuts";
 
 const PANELS_CONTAINER = "h-[calc(100svh-3rem-1px)] min-h-0 overflow-hidden";
 
@@ -21,6 +22,7 @@ export function EditorPanels(props: { children: ReactNode }) {
   if (isDesktop) {
     return (
       <div className={PANELS_CONTAINER}>
+        <EditorUndoShortcuts />
         <ResizablePanelGroup style={{ overflow: "hidden" }}>
           <ResizablePanel defaultSize="68%" minSize="40%" maxSize="72%">
             <EditorPreviewScroll>{props.children}</EditorPreviewScroll>
@@ -36,6 +38,7 @@ export function EditorPanels(props: { children: ReactNode }) {
 
   return (
     <div className={PANELS_CONTAINER}>
+      <EditorUndoShortcuts />
       <EditorPreviewScroll>{props.children}</EditorPreviewScroll>
       {isDesktop === false && <EditorSheet />}
     </div>

--- a/src/components/editor/editor-sections/ed-section-certifications/ed-section-certifications.tsx
+++ b/src/components/editor/editor-sections/ed-section-certifications/ed-section-certifications.tsx
@@ -12,7 +12,7 @@ export function EditorSectionCertifications() {
   const t = useTranslations("editor.certifications");
 
   return (
-    <AccordionItem className="relative">
+    <AccordionItem value="certifications" className="relative">
       <AccordionTrigger className="items-center gap-3">
         <Award className="size-4" /> {t("accordionTitle")}
       </AccordionTrigger>

--- a/src/components/editor/editor-sections/ed-section-education/ed-section-education.tsx
+++ b/src/components/editor/editor-sections/ed-section-education/ed-section-education.tsx
@@ -12,7 +12,7 @@ export function EditorSectionEducation() {
   const t = useTranslations("editor.education");
 
   return (
-    <AccordionItem className="relative">
+    <AccordionItem value="education" className="relative">
       <AccordionTrigger className="items-center gap-3">
         <GraduationCap className="size-4" /> {t("accordionTitle")}
       </AccordionTrigger>

--- a/src/components/editor/editor-sections/ed-section-experience/ed-section-experience.tsx
+++ b/src/components/editor/editor-sections/ed-section-experience/ed-section-experience.tsx
@@ -12,7 +12,7 @@ export function EditorSectionExperience() {
   const t = useTranslations("editor.experience");
 
   return (
-    <AccordionItem className="relative">
+    <AccordionItem value="experience" className="relative">
       <AccordionTrigger className="items-center gap-3">
         <BriefcaseBusiness className="size-4" /> {t("accordionTitle")}
       </AccordionTrigger>

--- a/src/components/editor/editor-sections/ed-section-internship/ed-section-internship.tsx
+++ b/src/components/editor/editor-sections/ed-section-internship/ed-section-internship.tsx
@@ -12,7 +12,7 @@ export function EditorSectionInternship() {
   const t = useTranslations("editor.internship");
 
   return (
-    <AccordionItem className="relative">
+    <AccordionItem value="internship" className="relative">
       <AccordionTrigger className="items-center gap-3">
         <Backpack className="size-4" /> {t("accordionTitle")}
       </AccordionTrigger>

--- a/src/components/editor/editor-sections/ed-section-languages/ed-section-languages.tsx
+++ b/src/components/editor/editor-sections/ed-section-languages/ed-section-languages.tsx
@@ -12,7 +12,7 @@ export function EditorSectionLanguages() {
   const t = useTranslations("editor.languages");
 
   return (
-    <AccordionItem className="relative">
+    <AccordionItem value="languages" className="relative">
       <AccordionTrigger className="items-center gap-3">
         <Languages className="size-4" /> {t("accordionTitle")}
       </AccordionTrigger>

--- a/src/components/editor/editor-sections/ed-section-list.tsx
+++ b/src/components/editor/editor-sections/ed-section-list.tsx
@@ -42,12 +42,14 @@ const SECTION_EDITORS: Partial<Record<SectionType, () => ReactNode>> = {
 export function EditorSectionList() {
   const openStatus = useResumeStore((state) => state.openStatus);
   const open = useResumeStore((state) => state.open);
+  const undoEpoch = useResumeStore((state) => state.undoEpoch);
   const reorderSections = useResumeStore((state) => state.reorderSections);
   const t = useTranslations("editor.chrome");
 
   // Controlled accordion open-state, single-open so only the section being
   // edited is visible. Item values are the section id for custom sections (so a
-  // newly added one can be opened by id) and base-ui-generated ids for the rest.
+  // newly added one can be opened by id) and the section type for the rest;
+  // explicit values keep the open section open across the undo-epoch remount.
   // Stale ids from another résumé simply match nothing.
   const [openSections, setOpenSections] = useState<string[]>([]);
 
@@ -77,13 +79,15 @@ export function EditorSectionList() {
     isReorderableSection(section.type),
   );
 
-  // Keyed by the open résumé so a load/switch remounts the forms; this is how
-  // the uncontrolled rich-text editors pick up the loaded document. Personal
-  // Details (the Header) and Summary are pinned; the rest drag to reorder.
+  // Keyed by the open résumé and the undo epoch so a load, switch, undo, or
+  // redo remounts the forms; the forms own their values (RHF writes into the
+  // store, never the reverse), so a remount is the only way a rewound document
+  // reaches them and the uncontrolled rich-text editors. Personal Details (the
+  // Header) and Summary are pinned; the rest drag to reorder.
   return (
     <>
       <Accordion
-        key={open.id}
+        key={`${open.id}:${undoEpoch}`}
         value={openSections}
         onValueChange={setOpenSections}
         className="border-none"

--- a/src/components/editor/editor-sections/ed-section-organizations/ed-section-organizations.tsx
+++ b/src/components/editor/editor-sections/ed-section-organizations/ed-section-organizations.tsx
@@ -12,7 +12,7 @@ export function EditorSectionOrganizations() {
   const t = useTranslations("editor.organizations");
 
   return (
-    <AccordionItem className="relative">
+    <AccordionItem value="organizations" className="relative">
       <AccordionTrigger className="items-center gap-3">
         <Users className="size-4" /> {t("accordionTitle")}
       </AccordionTrigger>

--- a/src/components/editor/editor-sections/ed-section-personal/ed-section-personal.tsx
+++ b/src/components/editor/editor-sections/ed-section-personal/ed-section-personal.tsx
@@ -11,7 +11,7 @@ export function EditorSectionPersonal() {
   const t = useTranslations("editor.personal");
 
   return (
-    <AccordionItem>
+    <AccordionItem value="personal">
       <AccordionTrigger className="items-center gap-3">
         <User2 className="size-4" />
         {t("accordionTitle")}

--- a/src/components/editor/editor-sections/ed-section-projects/ed-section-projects.tsx
+++ b/src/components/editor/editor-sections/ed-section-projects/ed-section-projects.tsx
@@ -12,7 +12,7 @@ export function EditorSectionProjects() {
   const t = useTranslations("editor.projects");
 
   return (
-    <AccordionItem className="relative">
+    <AccordionItem value="projects" className="relative">
       <AccordionTrigger className="items-center gap-3">
         <FolderGit2 className="size-4" /> {t("accordionTitle")}
       </AccordionTrigger>

--- a/src/components/editor/editor-sections/ed-section-skills/ed-section-skills.tsx
+++ b/src/components/editor/editor-sections/ed-section-skills/ed-section-skills.tsx
@@ -12,7 +12,7 @@ export function EditorSectionSkills() {
   const t = useTranslations("editor.skills");
 
   return (
-    <AccordionItem className="relative">
+    <AccordionItem value="skills" className="relative">
       <AccordionTrigger className="items-center gap-3">
         <Sparkles className="size-4" /> {t("accordionTitle")}
       </AccordionTrigger>

--- a/src/components/editor/editor-sections/ed-section-summary/ed-section-summary.tsx
+++ b/src/components/editor/editor-sections/ed-section-summary/ed-section-summary.tsx
@@ -12,7 +12,7 @@ export function EditorSectionSummary() {
   const t = useTranslations("editor.summary");
 
   return (
-    <AccordionItem className="relative">
+    <AccordionItem value="summary" className="relative">
       <AccordionTrigger className="items-center gap-3">
         <ScrollText className="size-4" /> {t("accordionTitle")}
       </AccordionTrigger>

--- a/src/components/editor/editor-sidebar-content.tsx
+++ b/src/components/editor/editor-sidebar-content.tsx
@@ -9,6 +9,7 @@ import { EditorImportLeftovers } from "./editor-import-leftovers";
 import { EditorLayoutTemplateList } from "./editor-layout/ed-layout-template-list";
 import { EditorSectionList } from "./editor-sections/ed-section-list";
 import { EditorSectionOrderReset } from "./editor-sections/ed-section-order-reset";
+import { EditorUndoRedo } from "./editor-undo-redo";
 
 const TABS = [
   { value: "editor", labelKey: "tabEditor" },
@@ -38,6 +39,9 @@ export function EditorSidebarContent() {
               </TabsTrigger>
             ))}
           </TabsList>
+          <div className="ml-auto">
+            <EditorUndoRedo />
+          </div>
         </div>
 
         <TabsContent value="editor">

--- a/src/components/editor/editor-undo-redo.tsx
+++ b/src/components/editor/editor-undo-redo.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Redo2, Undo2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useResumeStore } from "@/lib/store";
+
+export function EditorUndoRedo() {
+  const canUndo = useResumeStore((state) => state.canUndo);
+  const canRedo = useResumeStore((state) => state.canRedo);
+  const undo = useResumeStore((state) => state.undo);
+  const redo = useResumeStore((state) => state.redo);
+  const t = useTranslations("editor.chrome");
+
+  return (
+    <div className="flex items-center">
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              size="icon-sm"
+              variant="ghost"
+              disabled={!canUndo}
+              onClick={() => undo()}
+            />
+          }
+        >
+          <Undo2 />
+          <span className="sr-only">{t("undo")}</span>
+        </TooltipTrigger>
+        <TooltipContent>{t("undo")}</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              size="icon-sm"
+              variant="ghost"
+              disabled={!canRedo}
+              onClick={() => redo()}
+            />
+          }
+        >
+          <Redo2 />
+          <span className="sr-only">{t("redo")}</span>
+        </TooltipTrigger>
+        <TooltipContent>{t("redo")}</TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}

--- a/src/components/editor/editor-undo-shortcuts.tsx
+++ b/src/components/editor/editor-undo-shortcuts.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect } from "react";
+import { useResumeStore } from "@/lib/store";
+
+/**
+ * Text inputs and the rich-text editors keep their own native or TipTap
+ * history; the document-level shortcut only fires when neither has focus.
+ */
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  return target.closest("input, textarea, [contenteditable=true]") !== null;
+}
+
+export function EditorUndoShortcuts() {
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (!(event.metaKey || event.ctrlKey) || event.altKey) return;
+      const key = event.key.toLowerCase();
+      const isUndo = key === "z" && !event.shiftKey;
+      const isRedo = (key === "z" && event.shiftKey) || key === "y";
+      if (!isUndo && !isRedo) return;
+      if (isEditableTarget(event.target)) return;
+      event.preventDefault();
+      const store = useResumeStore.getState();
+      if (isUndo) store.undo();
+      else store.redo();
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  return null;
+}

--- a/src/lib/store/resume-store.ts
+++ b/src/lib/store/resume-store.ts
@@ -55,6 +55,15 @@ interface ResumeStoreState {
   openStatus: OpenStatus;
   /** Bumped whenever a document's import leftovers change, so views re-read them. */
   leftoversVersion: number;
+  /**
+   * Bumped on every undo and redo. The section forms own their values (RHF
+   * writes into the store, never the reverse), so a rewind only reaches a
+   * mounted form by remounting it: the accordion keys on this counter the same
+   * way it already keys on the open document's id.
+   */
+  undoEpoch: number;
+  canUndo: boolean;
+  canRedo: boolean;
 
   hydrateIndex: () => Promise<void>;
   createResume: (
@@ -70,6 +79,10 @@ interface ResumeStoreState {
   openResume: (id: string) => Promise<void>;
   /** Apply an edit to the open document; schedules a debounced persist. */
   updateOpen: (recipe: (draft: Resume) => void) => void;
+  /** Rewind the open document one undo step; no-op when the history is empty. */
+  undo: () => void;
+  /** Reapply the last undone step; no-op when nothing was undone. */
+  redo: () => void;
   /**
    * Move a reorderable section from one position to another. Indices are into the
    * reorderable subset (Summary and the Header are pinned and excluded); pinned
@@ -105,6 +118,28 @@ interface ResumeStoreState {
   flush: () => Promise<void>;
 }
 
+const UNDO_LIMIT = 100;
+/**
+ * Edits landing within this window join the previous undo step. Form writes
+ * arrive once per keystroke and slider drags once per tick, so without
+ * coalescing a single word would cost a dozen undo presses.
+ */
+const UNDO_GROUP_MS = 600;
+
+// The stacks hold previous `open` snapshots by reference; `updateOpen` never
+// mutates a published document, it clones and replaces, so snapshots stay
+// frozen. Kept at module level so pushes do not re-render subscribers;
+// `canUndo`/`canRedo` mirror the stack heads into reactive state.
+let undoPast: Resume[] = [];
+let undoFuture: Resume[] = [];
+let undoGroupUntil = 0;
+
+function resetUndoHistory(): void {
+  undoPast = [];
+  undoFuture = [];
+  undoGroupUntil = 0;
+}
+
 function toIndexEntry(resume: Resume): ResumeIndexEntry {
   return { id: resume.id, title: resume.title, updatedAt: resume.updatedAt };
 }
@@ -130,6 +165,9 @@ export const useResumeStore = create<ResumeStoreState>()((set, get) => ({
   open: null,
   openStatus: "idle",
   leftoversVersion: 0,
+  undoEpoch: 0,
+  canUndo: false,
+  canRedo: false,
 
   async hydrateIndex() {
     set({ indexStatus: "loading" });
@@ -165,10 +203,13 @@ export const useResumeStore = create<ResumeStoreState>()((set, get) => ({
       set((state) => ({ leftoversVersion: state.leftoversVersion + 1 }));
     }
     await setLastOpenedResumeId(resume.id);
+    resetUndoHistory();
     set((state) => ({
       index: syncIndexEntry(state.index, resume),
       open: resume,
       openStatus: "ready",
+      canUndo: false,
+      canRedo: false,
     }));
     return resume;
   },
@@ -202,12 +243,15 @@ export const useResumeStore = create<ResumeStoreState>()((set, get) => ({
   async removeResume(id) {
     const current = get().open;
     const removed = current?.id === id ? current : await getResume(id);
+    if (current?.id === id) resetUndoHistory();
     set((state) => {
       const isOpen = state.open?.id === id;
       return {
         index: A.reject(state.index, (item) => item.id === id),
         open: isOpen ? null : state.open,
         openStatus: isOpen ? "idle" : state.openStatus,
+        canUndo: isOpen ? false : state.canUndo,
+        canRedo: isOpen ? false : state.canRedo,
       };
     });
     await dbDeleteResume(id);
@@ -231,7 +275,8 @@ export const useResumeStore = create<ResumeStoreState>()((set, get) => ({
       return;
     }
     await setLastOpenedResumeId(id);
-    set({ open: resume, openStatus: "ready" });
+    resetUndoHistory();
+    set({ open: resume, openStatus: "ready", canUndo: false, canRedo: false });
   },
 
   updateOpen(recipe) {
@@ -240,9 +285,52 @@ export const useResumeStore = create<ResumeStoreState>()((set, get) => ({
     const draft = structuredClone(current);
     recipe(draft);
     draft.updatedAt = new Date().toISOString();
+    const now = Date.now();
+    if (now > undoGroupUntil) {
+      undoPast.push(current);
+      if (undoPast.length > UNDO_LIMIT) undoPast.shift();
+    }
+    undoGroupUntil = now + UNDO_GROUP_MS;
+    undoFuture = [];
     set((state) => ({
       open: draft,
       index: syncIndexEntry(state.index, draft),
+      canUndo: true,
+      canRedo: false,
+    }));
+    scheduleOpenResumePersist();
+  },
+
+  undo() {
+    const current = get().open;
+    const previous = undoPast.pop();
+    if (!current || !previous) return;
+    undoFuture.push(current);
+    undoGroupUntil = 0;
+    const restored = { ...previous, updatedAt: new Date().toISOString() };
+    set((state) => ({
+      open: restored,
+      index: syncIndexEntry(state.index, restored),
+      undoEpoch: state.undoEpoch + 1,
+      canUndo: undoPast.length > 0,
+      canRedo: true,
+    }));
+    scheduleOpenResumePersist();
+  },
+
+  redo() {
+    const current = get().open;
+    const next = undoFuture.pop();
+    if (!current || !next) return;
+    undoPast.push(current);
+    undoGroupUntil = 0;
+    const restored = { ...next, updatedAt: new Date().toISOString() };
+    set((state) => ({
+      open: restored,
+      index: syncIndexEntry(state.index, restored),
+      undoEpoch: state.undoEpoch + 1,
+      canUndo: true,
+      canRedo: undoFuture.length > 0,
     }));
     scheduleOpenResumePersist();
   },


### PR DESCRIPTION
Closes #137.

Undo and redo now cover the whole document, not only the rich text fields from #141. Typing in any field, deleting an entry, reordering sections, toggling visibility, layout and document settings, custom section changes, and an in-place PDF import all rewind and replay, from two toolbar buttons beside the sidebar tabs or with Ctrl/Cmd+Z and Shift+Ctrl/Cmd+Z (Ctrl+Y also redoes).

Every document mutation already funnels through the store's updateOpen, so the store keeps the history itself: past and future stacks of document snapshots, capped at 100 steps, with a 600 ms coalescing window so a typing burst or a slider drag lands as one undo step. Undo and redo restamp the document, resync the library index, and schedule the IndexedDB persist. History clears when a different document opens. No new dependency; zundo was considered and rejected because the single write path makes middleware interception redundant, and it does not solve the real blocker.

That blocker was the form layer. The section forms own their values; react-hook-form writes into the store and never reads back, so a rewound document could not reach a mounted form. The store now bumps an undo epoch on every undo and redo, and the section accordion keys on the open document id plus that epoch, extending the remount idiom the list already used for document switches. Verification caught a follow-on bug: core sections relied on base-ui's generated accordion values, so the remount collapsed the open section. Every section item now has a stable explicit value and the open section stays open through an undo.

The keyboard shortcut defers to focused inputs and rich text fields, so the per-field history from #141 keeps first claim; the document-level shortcut fires only when neither has focus. One known limit: an undo remounts the open form, which resets that field's TipTap history stack (already per-mount) and drops focus. The "Reset document styling" button also moves from the Undo2 icon to RefreshCw so it cannot be mistaken for the new undo button.

Testing: drove the real app in a browser against the dev server. Created a resume through the UI, edited the first experience job title, and confirmed the full cycle: the edit reaches the form and the preview, toolbar undo reverts both, redo restores the edit, and Cmd+Z with focus outside any field undoes again, with the Experience section staying open throughout. Lint and typecheck pass; the export path is untouched.