### PR TITLE
docs: add the 0.12.0 changelog entry for the what's new sheet

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -180,6 +180,20 @@
       "latest": "Latest",
       "fullChangelog": "Full changelog on GitHub",
       "entries": {
+        "0_12_0": [
+          {
+            "title": "Undo and redo",
+            "description": "Change your mind freely: every edit can now be undone and redone, from typing and deleted entries to section order and layout settings. Use the arrows beside the sidebar tabs or Ctrl/Cmd+Z, and each text field keeps its own history while you write."
+          },
+          {
+            "title": "One section at a time",
+            "description": "The editor list now keeps a single section open, so the form you are working in stays in view instead of pushing the others off screen."
+          },
+          {
+            "title": "Bug fixes",
+            "description": "Fixed three reported bugs: links in your exports now show as clickable, a stray dash no longer appears in the PDF contact line, and locations land in the right field when you import a PDF."
+          }
+        ],
         "0_11_0": [
           {
             "title": "Company location",

--- a/messages/id.json
+++ b/messages/id.json
@@ -180,6 +180,20 @@
       "latest": "Terbaru",
       "fullChangelog": "Changelog lengkap di GitHub",
       "entries": {
+        "0_12_0": [
+          {
+            "title": "Urungkan dan ulangi",
+            "description": "Bebas berubah pikiran: semua editan sekarang bisa diurungkan dan diulangi, dari ketikan, entri yang terhapus, sampai urutan section dan pengaturan layout. Pakai tombol panah di samping tab sidebar atau Ctrl/Cmd+Z, dan tiap kolom teks juga menyimpan riwayatnya sendiri selagi kamu menulis."
+          },
+          {
+            "title": "Satu section dalam satu waktu",
+            "description": "Daftar editor sekarang hanya membuka satu section, jadi form yang lagi kamu isi tetap kelihatan, nggak terdorong keluar layar."
+          },
+          {
+            "title": "Perbaikan bug",
+            "description": "Tiga bug yang dilaporkan sudah diperbaiki: tautan di hasil ekspor sekarang kelihatan bisa diklik, tanda minus nyasar di baris kontak PDF sudah hilang, dan lokasi masuk ke kolom yang benar saat impor PDF."
+          }
+        ],
         "0_11_0": [
           {
             "title": "Lokasi perusahaan",

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -9,6 +9,7 @@ export interface ChangelogEntry {
  * with dots replaced by underscores, as a list of { title, description }.
  */
 export const CHANGELOG: ChangelogEntry[] = [
+  { version: "0.12.0", date: "2026-09-02" },
   { version: "0.11.0", date: "2026-08-02" },
   { version: "0.10.0", date: "2026-07-17" },
   { version: "0.9.0", date: "2026-07-14" },


### PR DESCRIPTION
Adds the 0.12.0 entry to the in-app "What's new" sheet ahead of the release: two feature highlights (document-level undo and redo, single-open editor sections) and one collapsed bug-fixes entry covering the three reported fixes (visible links in exports, the stray dash in the PDF contact line, and PDF import locations). English and Indonesian.

Testing: lint and typecheck pass; the sheet reads the new version from the changelog list, dated today.