### PR TITLE
feat: add an optional extra link to the resume header

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -640,6 +640,8 @@
       "websitePlaceholder": "rimzzlabs.com",
       "linkedin": "LinkedIn",
       "linkedinPlaceholder": "johndoe",
+      "link": "Link",
+      "linkPlaceholder": "github.com/johndoe",
       "location": "Location",
       "locationDesc": "Where are you from?",
       "city": "City",

--- a/messages/id.json
+++ b/messages/id.json
@@ -640,6 +640,8 @@
       "websitePlaceholder": "rimzzlabs.com",
       "linkedin": "LinkedIn",
       "linkedinPlaceholder": "johndoe",
+      "link": "Tautan",
+      "linkPlaceholder": "github.com/johndoe",
       "location": "Lokasi",
       "locationDesc": "Kamu dari mana?",
       "city": "Kota",

--- a/scripts/validate-exports.tsx
+++ b/scripts/validate-exports.tsx
@@ -160,6 +160,7 @@ const REQUIRED_FIELDS = [
   "Senior Frontend Engineer",
   "john.doe@example.com",
   "johndoe.dev",
+  "github.com/johndoe",
   "Acme Corp",
   "San Francisco, CA",
   "Globex",

--- a/src/components/editor/editor-sections/ed-section-personal/ed-section-personal-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-personal/ed-section-personal-form.tsx
@@ -184,6 +184,23 @@ export function EditorSectionPersonalForm() {
                 </Field>
               )}
             />
+            <Controller
+              control={form.control}
+              name="link"
+              render={({ field, fieldState }) => (
+                <Field>
+                  <FieldLabel htmlFor={field.name}>{t("link")}</FieldLabel>
+                  <UrlInput
+                    id={field.name}
+                    value={field.value}
+                    placeholder={t("linkPlaceholder")}
+                    onChange={field.onChange}
+                    onBlur={field.onBlur}
+                  />
+                  <FieldError errors={[fieldState.error]} />
+                </Field>
+              )}
+            />
           </FieldGroup>
         </FieldSet>
 

--- a/src/components/editor/editor-sections/resume-form-adapter.ts
+++ b/src/components/editor/editor-sections/resume-form-adapter.ts
@@ -12,6 +12,7 @@ export interface PersonalFormValues {
   phone: string;
   website: string;
   linkedin: string;
+  link: string;
   city: string;
   province: string;
   country: string;
@@ -160,6 +161,7 @@ export function toPersonalValues(resume: Resume): PersonalFormValues {
     phone: plainValue(fields.phone),
     website: plainValue(fields.website),
     linkedin: plainValue(fields.linkedin),
+    link: plainValue(fields.link),
     city: plainValue(fields.city),
     province: plainValue(fields.province),
     country: plainValue(fields.country),
@@ -178,6 +180,7 @@ export function applyPersonalValues(
   fields.phone = plain(values.phone);
   fields.website = plain(values.website);
   fields.linkedin = plain(values.linkedin);
+  fields.link = plain(values.link);
   fields.city = plain(values.city);
   fields.province = plain(values.province);
   fields.country = plain(values.country);

--- a/src/components/editor/pdf/pdf-contact-icon.tsx
+++ b/src/components/editor/pdf/pdf-contact-icon.tsx
@@ -48,6 +48,17 @@ export function PdfContactIcon(props: { kind: ContactKind }) {
           />
         </Svg>
       );
+    case "link":
+      return (
+        <Svg width={8} height={8} viewBox="0 0 24 24">
+          <Path {...ICON} d="M15 3h6v6" />
+          <Path {...ICON} d="M10 14 21 3" />
+          <Path
+            {...ICON}
+            d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"
+          />
+        </Svg>
+      );
     case "location":
       return (
         <Svg width={8} height={8} viewBox="0 0 24 24">

--- a/src/components/editor/resume-contact-icon.tsx
+++ b/src/components/editor/resume-contact-icon.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Globe, Link, Mail, MapPin, Phone } from "lucide-react";
+import { ExternalLink, Globe, Link, Mail, MapPin, Phone } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { cn } from "@/lib/utils";
 import type { ContactKind } from "./resume-preview";
@@ -12,6 +12,7 @@ const CONTACT_ICON: Record<ContactKind, typeof Phone> = {
   email: Mail,
   website: Globe,
   linkedin: Link,
+  link: ExternalLink,
   location: MapPin,
 };
 

--- a/src/components/editor/resume-preview.ts
+++ b/src/components/editor/resume-preview.ts
@@ -20,6 +20,7 @@ export type ContactKind =
   | "email"
   | "website"
   | "linkedin"
+  | "link"
   | "location";
 
 export interface ContactView {

--- a/src/components/editor/resume-to-preview.ts
+++ b/src/components/editor/resume-to-preview.ts
@@ -88,6 +88,11 @@ function toHeaderView(resume: Resume): HeaderView {
     const url = withHttps(linkedin);
     contacts.push({ kind: "linkedin", value: url, href: url });
   }
+  const link = plain(fields.link);
+  if (link) {
+    const url = withHttps(link);
+    contacts.push({ kind: "link", value: url, href: url });
+  }
   const location = [
     plain(fields.city),
     plain(fields.province),

--- a/src/lib/resume/migrations.ts
+++ b/src/lib/resume/migrations.ts
@@ -606,6 +606,21 @@ const migrateV20toV21: Migration = (doc) => {
 };
 
 /**
+ * v21→v22: the header gains an optional extra `link` field (portfolio, GitHub,
+ * and similar). Absence means empty; existing fields are untouched.
+ */
+const migrateV21toV22: Migration = (doc) => {
+  const next = structuredClone(doc);
+  const header = next.header as
+    | { fields?: Record<string, unknown> }
+    | undefined;
+  if (G.isObject(header?.fields) && !("link" in header.fields)) {
+    header.fields.link = plainField("");
+  }
+  return next;
+};
+
+/**
  * The migration ladder. Each key N is a forward-only step from version N to N+1.
  */
 const LADDER: Record<number, Migration> = {
@@ -629,6 +644,7 @@ const LADDER: Record<number, Migration> = {
   18: migrateV18toV19,
   19: migrateV19toV20,
   20: migrateV20toV21,
+  21: migrateV21toV22,
 };
 
 /** The persisted schemaVersion of a raw document; 0 when absent or malformed. */

--- a/src/lib/resume/schema-registry.ts
+++ b/src/lib/resume/schema-registry.ts
@@ -84,6 +84,12 @@ export const HEADER_SCHEMA: FieldSchema[] = [
     kind: "plain",
     placeholder: "johndoe",
   },
+  {
+    key: "link",
+    label: "Link",
+    kind: "plain",
+    placeholder: "github.com/johndoe",
+  },
   { key: "city", label: "City", kind: "plain", placeholder: "San Francisco" },
   {
     key: "province",

--- a/src/lib/resume/seed.ts
+++ b/src/lib/resume/seed.ts
@@ -65,6 +65,7 @@ export const SEED_RESUME: Resume = {
       phone: plain("+15550101234"),
       website: plain("johndoe.dev"),
       linkedin: plain("linkedin.com/in/johndoe"),
+      link: plain("github.com/johndoe"),
       city: plain("San Francisco"),
       province: plain("California"),
       country: plain("United States"),

--- a/src/lib/resume/types.ts
+++ b/src/lib/resume/types.ts
@@ -5,7 +5,7 @@ import type { JSONContent } from "@tiptap/core";
  * governs object-store/index structure only. Bumped whenever a persisted field
  * shape changes; every bump gets a forward-only step in the migration ladder.
  */
-export const CURRENT_SCHEMA_VERSION = 21;
+export const CURRENT_SCHEMA_VERSION = 22;
 
 /** The language the rendered document's fixed labels (headings, dates) use. */
 export type ResumeLanguage = "en" | "id";


### PR DESCRIPTION
Closes #151. Closes #143 (its visibility half shipped in 0.12.0; this was the remaining ask).

The header gains one optional link slot next to email, website, and LinkedIn, for a portfolio, GitHub, or similar. It is a bare URL field like its siblings, not a labeled pair: a label would replace the URL in the PDF text layer, and an extractable URL is what an ATS parses. The value renders with the same https prefixing as the other links, with an external-link icon in the preview and its vector twin in the PDF.

This is a document shape change, shipped atomically per the migration rules: the new HEADER_SCHEMA field, the CURRENT_SCHEMA_VERSION bump to 22, and a bail-safe v21 to v22 rung that adds an empty field and never touches anything else. Every template, the PDF documents, DOCX, and TXT iterate the contact list generically, so no template needed edits. The interchange schema builds from HEADER_SCHEMA, so JSON and YAML picked the field up automatically. The seed resume now carries a link, and the export validation gate requires it, so the slot cannot silently drop out of an export path later. The PDF importer mapping a second URL into this field stays a follow-up, as scoped in #151.

Testing: a v21 document migrates to v22 with an empty link and untouched sibling fields, and a malformed v21 document bails without gaining fields. The JSON interchange round trip stays identical with the field populated. The export validation pass confirms the link maps through every template PDF, DOCX, and TXT. In the running app, the preview header shows the seed link and the Personal Information form shows the new Link field in both locales. Lint and typecheck pass.