### PR TITLE
feat: pick up the extra header link when a pdf is imported

### DIFF
--- a/src/lib/import/parse.ts
+++ b/src/lib/import/parse.ts
@@ -129,10 +129,17 @@ function fillHeader(
   const website = (allText.match(URL_G_RE) ?? []).find(
     (url) => !/linkedin\.com/i.test(url),
   );
+  // The extra link only comes from the preamble: anywhere else, a second URL
+  // is far more likely a company or project site from an entry.
+  const link = (preamble.join(" ").match(URL_G_RE) ?? []).find(
+    (url) =>
+      !/linkedin\.com/i.test(url) && url !== website && !url.includes("@"),
+  );
   if (email) fields.email = plain(email);
   if (phone) fields.phone = plain(phone);
   if (linkedin) fields.linkedin = plain(linkedin);
   if (website) fields.website = plain(website);
+  if (link) fields.link = plain(link);
 
   const named = pipe(
     preamble,


### PR DESCRIPTION
The follow-up scoped in #151: the PDF importer now fills the header's extra link field added in #153.

The website heuristic stays as it was (the first non-LinkedIn URL anywhere in the text). The extra link is stricter: it only comes from the preamble, the lines before the first section heading, because a second URL anywhere else is far more likely a company or project site from an entry. It also skips the URL already taken as the website and anything containing an @.

Testing: round-tripped the seed resume through PDF export and import; all five header contacts come back, with the GitHub link in the link field. A resume with no header link but URLs inside experience bullets keeps an empty link field, so entry sites cannot leak into the header. The export validation pass, lint, and typecheck all pass.