### PR TITLE
docs: add the 0.13.0 changelog entry for the what's new sheet

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -180,6 +180,12 @@
       "latest": "Latest",
       "fullChangelog": "Full changelog on GitHub",
       "entries": {
+        "0_13_0": [
+          {
+            "title": "One more link in your header",
+            "description": "A new optional Link field sits next to LinkedIn in Personal Information, for your portfolio, GitHub, or anything else. It shows in the preview and every export, and importing a PDF picks it up too."
+          }
+        ],
         "0_12_0": [
           {
             "title": "Undo and redo",

--- a/messages/id.json
+++ b/messages/id.json
@@ -180,6 +180,12 @@
       "latest": "Terbaru",
       "fullChangelog": "Changelog lengkap di GitHub",
       "entries": {
+        "0_13_0": [
+          {
+            "title": "Satu tautan lagi di header",
+            "description": "Ada kolom Tautan opsional baru di samping LinkedIn di Informasi Pribadi, untuk portofolio, GitHub, atau apa pun. Tampil di pratinjau dan semua ekspor, dan ikut terbaca saat impor PDF."
+          }
+        ],
         "0_12_0": [
           {
             "title": "Urungkan dan ulangi",

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -9,6 +9,7 @@ export interface ChangelogEntry {
  * with dots replaced by underscores, as a list of { title, description }.
  */
 export const CHANGELOG: ChangelogEntry[] = [
+  { version: "0.13.0", date: "2026-09-06" },
   { version: "0.12.0", date: "2026-09-02" },
   { version: "0.11.0", date: "2026-08-02" },
   { version: "0.10.0", date: "2026-07-17" },


### PR DESCRIPTION
Adds the 0.13.0 entry to the in-app "What's new" sheet ahead of the release: one feature highlight for the new optional header link, covering the form field, the exports, and the PDF import pickup (#155). English and Indonesian.

Testing: lint and typecheck pass; the sheet reads the new version from the changelog list.