### PR TITLE
feat: add an opt-in header photo with size, radius, and position controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,8 @@ An ATS Builder. Free, Open-Source, local-first resume builder. Customizable pres
 
 Any feature request that adds structural freedom (tables, columns, floating elements, decorative icons in text runs) is out of scope unless it is presentation-only and degrades gracefully to plain text in export.
 
+The one shipped example of that carve-out is the opt-in header photo: off by default, stored as a downscaled data URL on `header.photo`, rendered by each template's header (never absolutely positioned), embedded in PDF and DOCX, ignored by TXT. `scripts/validate-exports.tsx` enforces that adding a photo never changes the extracted text of any export.
+
 ## Data and Storage
 
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Customization applies to how the resume looks. It does not extend to layouts tha
 - Print-accurate A4 preview with automatic pagination
 - Rich text editing per field, scoped to ATS-safe formatting (bold, italic, lists, links), with undo and redo per field
 - Document-level undo and redo across every edit (typing, reorder, layout, settings), from the editor toolbar or Ctrl/Cmd+Z
+- Optional header photo (off by default): add a portrait in Personal Information and every template places it to match its own layout; exports embed it without affecting how parsers read the text
 - Custom sections alongside the fixed types, all sharing the same restricted schema
 - Drag to reorder sections and toggle any section's visibility (entries within a section sort by date automatically)
 - Document-level presentation controls: font, font size, section spacing, line height, letter spacing, contact-icon visibility, and a one-click style reset

--- a/docs/export-validation.md
+++ b/docs/export-validation.md
@@ -19,6 +19,10 @@ XML, and the serializer output for `.txt`. It then asserts:
 - **Field mapping**: name, headline, email, website, each employer, an employer and a
   school location, education, certificate, a representative skill, and a language are
   all present in the extracted text.
+- **Photo invariance**: rendering with the opt-in header photo must leave the
+  extracted text of every template PDF and the `.docx` byte-identical to the
+  photo-free output. The photo is presentation-only; if it ever shifts, drops, or
+  adds a character of extracted text, the gate fails.
 
 This is the pdftotext-equivalent text-extraction test required by `AGENTS.md`. **Run it
 after any change to an export path** (`pdf/`, `docx/`, `resume-to-text.ts`,

--- a/messages/en.json
+++ b/messages/en.json
@@ -655,7 +655,19 @@
       "province": "Province",
       "provincePlaceholder": "Banten",
       "country": "Country",
-      "countryPlaceholder": "Indonesia"
+      "countryPlaceholder": "Indonesia",
+      "photo": "Photo",
+      "photoAdd": "Add photo",
+      "photoReplace": "Replace",
+      "photoRemove": "Remove",
+      "photoHint": "Optional. Common for applications in Indonesia; many ATS and US employers ignore or discourage photos. The text of your resume always stays fully readable to parsers.",
+      "photoError": "That file could not be read as an image.",
+      "photoSize": "Photo size",
+      "photoRadius": "Corner radius",
+      "photoAlign": "Position",
+      "photoAlignTop": "Top",
+      "photoAlignCenter": "Center",
+      "photoAlignBottom": "Bottom"
     },
     "summary": {
       "accordionTitle": "Professional Summary",

--- a/messages/id.json
+++ b/messages/id.json
@@ -655,7 +655,19 @@
       "province": "Provinsi",
       "provincePlaceholder": "Banten",
       "country": "Negara",
-      "countryPlaceholder": "Indonesia"
+      "countryPlaceholder": "Indonesia",
+      "photo": "Foto",
+      "photoAdd": "Tambah foto",
+      "photoReplace": "Ganti",
+      "photoRemove": "Hapus",
+      "photoHint": "Opsional. Umum untuk lamaran di Indonesia; banyak ATS dan perusahaan luar mengabaikan atau tidak menyarankan foto. Teks resume kamu tetap terbaca penuh oleh parser.",
+      "photoError": "File itu tidak bisa dibaca sebagai gambar.",
+      "photoSize": "Ukuran foto",
+      "photoRadius": "Sudut foto",
+      "photoAlign": "Posisi",
+      "photoAlignTop": "Atas",
+      "photoAlignCenter": "Tengah",
+      "photoAlignBottom": "Bawah"
     },
     "summary": {
       "accordionTitle": "Ringkasan",

--- a/scripts/validate-exports.tsx
+++ b/scripts/validate-exports.tsx
@@ -220,6 +220,16 @@ async function extractDocxText(buffer: Buffer): Promise<string> {
     .replace(/&gt;/g, ">");
 }
 
+/** A tiny valid JPEG, enough for react-pdf and docx to embed. */
+const TEST_PHOTO = `data:image/jpeg;base64,${[
+  "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEB",
+  "AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/2wBDAQEBAQEBAQEBAQEBAQEB",
+  "AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/wAAR",
+  "CAACAAIDASIAAhEBAxEB/8QAFAABAAAAAAAAAAAAAAAAAAAACv/EABQQAQAAAAAAAAAAAAAA",
+  "AAAAAAD/xAAUAQEAAAAAAAAAAAAAAAAAAAAA/8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAwD",
+  "AQACEQMRAD8AfwD/2Q==",
+].join("")}`;
+
 async function main(): Promise<void> {
   registerFonts();
   const preview = resumeToPreview(SEED_RESUME);
@@ -249,6 +259,38 @@ async function main(): Promise<void> {
     console.log(`${label}: extracted ${text.length} chars`);
     errors.push(...checkReadingOrder(text, label), ...checkFields(text, label));
   }
+
+  // The opt-in photo is presentation-only: with a photo present, the extracted
+  // text of every template PDF and the DOCX must be identical to the
+  // photo-free output, or the photo has disturbed parsing.
+  const photoResume = structuredClone(SEED_RESUME);
+  photoResume.header.photo = TEST_PHOTO;
+  const photoPreview = resumeToPreview(photoResume);
+  const docxPlain = await extractDocxText(
+    await Packer.toBuffer(buildAwalDocx(preview)),
+  );
+  const docxPhoto = await extractDocxText(
+    await Packer.toBuffer(buildAwalDocx(photoPreview)),
+  );
+  if (docxPlain !== docxPhoto) {
+    errors.push("DOCX: adding a photo changed the extracted text");
+  }
+  for (const [template, PdfDocument] of Object.entries(
+    TEMPLATE_PDF_DOCUMENTS,
+  )) {
+    const plainText = await extractPdfText(
+      await renderToBuffer(<PdfDocument preview={preview} />),
+    );
+    const withPhoto = await extractPdfText(
+      await renderToBuffer(<PdfDocument preview={photoPreview} />),
+    );
+    if (plainText !== withPhoto) {
+      errors.push(
+        `PDF(${template}): adding a photo changed the extracted text`,
+      );
+    }
+  }
+  console.log("Photo invariance: extracted text identical with a photo");
 
   for (const family of ["Lora", "Merriweather"]) {
     const ligatureErrors = await checkLigatureSafety(family);

--- a/src/components/editor/docx/resume-to-docx.ts
+++ b/src/components/editor/docx/resume-to-docx.ts
@@ -2,6 +2,7 @@ import {
   BorderStyle,
   Document,
   ExternalHyperlink,
+  ImageRun,
   Paragraph,
   TabStopType,
   TextRun,
@@ -108,10 +109,31 @@ function subtitle(text: string, href?: string, suffix = ""): Paragraph {
   });
 }
 
+/**
+ * The photo data URL is a pre-cropped square JPEG from the upload path;
+ * decode the base64 payload for docx's ImageRun.
+ */
+function photoRun(photo: string, size: number): ImageRun | null {
+  const match = photo.match(/^data:image\/(jpeg|png);base64,(.+)$/);
+  if (!match) return null;
+  const bytes = Uint8Array.from(atob(match[2]), (char) => char.charCodeAt(0));
+  return new ImageRun({
+    type: match[1] === "png" ? "png" : "jpg",
+    data: bytes,
+    transformation: { width: size, height: size },
+  });
+}
+
 function headerParagraphs(header: HeaderView): Paragraph[] {
+  // The photo rides inside the name paragraph: no extra paragraph means the
+  // extracted text stays byte-identical with and without a photo.
+  const photo = header.photo ? photoRun(header.photo, header.photoSize) : null;
   const paragraphs: Paragraph[] = [
     new Paragraph({
-      children: [new TextRun({ text: header.fullName, bold: true, size: 36 })],
+      children: [
+        ...(photo ? [photo] : []),
+        new TextRun({ text: header.fullName, bold: true, size: 36 }),
+      ],
     }),
   ];
   if (header.headline) {

--- a/src/components/editor/editor-sections/ed-section-personal/ed-section-personal-form.tsx
+++ b/src/components/editor/editor-sections/ed-section-personal/ed-section-personal-form.tsx
@@ -22,6 +22,7 @@ import {
   type PersonalFormValues,
   toPersonalValues,
 } from "../resume-form-adapter";
+import { EditorSectionPersonalPhoto } from "./ed-section-personal-photo";
 
 export function EditorSectionPersonalForm() {
   const open = useResumeStore((state) => state.open);
@@ -53,6 +54,7 @@ export function EditorSectionPersonalForm() {
             {t("personalInfoDesc")}
           </FieldDescription>
           <FieldGroup>
+            <EditorSectionPersonalPhoto />
             <div className="grid grid-cols-2 gap-2">
               <Controller
                 control={form.control}

--- a/src/components/editor/editor-sections/ed-section-personal/ed-section-personal-photo.tsx
+++ b/src/components/editor/editor-sections/ed-section-personal/ed-section-personal-photo.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { ImagePlus, Trash2 } from "lucide-react";
+import Image from "next/image";
+import { useTranslations } from "next-intl";
+import { useRef } from "react";
+import { toast } from "sonner";
+import { SegmentedControl } from "@/components/shared/segmented-control";
+import { Button } from "@/components/ui/button";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
+import { Slider } from "@/components/ui/slider";
+import { useResumeStore } from "@/lib/store";
+import { processPhotoFile } from "./photo-process";
+
+const PHOTO_SIZE_MIN = 40;
+const PHOTO_SIZE_MAX = 96;
+const PHOTO_SIZE_DEFAULT = 56;
+const PHOTO_RADIUS_MIN = 0;
+const PHOTO_RADIUS_MAX = 50;
+
+function toSingle(value: number | readonly number[]): number {
+  return Array.isArray(value) ? value[0] : (value as number);
+}
+
+/**
+ * Opt-in portrait control. Lives outside react-hook-form on purpose: the photo
+ * is not a text field, so it reads from the store and writes through
+ * updateOpen, which also makes every change undoable.
+ */
+export function EditorSectionPersonalPhoto() {
+  const photo = useResumeStore((state) => state.open?.header.photo);
+  const photoSize = useResumeStore(
+    (state) => state.open?.photoSize ?? PHOTO_SIZE_DEFAULT,
+  );
+  const photoRadius = useResumeStore((state) => state.open?.photoRadius ?? 0);
+  const photoAlign = useResumeStore((state) => state.open?.photoAlign ?? "top");
+  const updateOpen = useResumeStore((state) => state.updateOpen);
+  const t = useTranslations("editor.personal");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  async function onFile(file: File | undefined) {
+    if (!file) return;
+    const processed = await processPhotoFile(file);
+    if (!processed) {
+      toast.error(t("photoError"));
+      return;
+    }
+    updateOpen((draft) => {
+      draft.header.photo = processed;
+    });
+  }
+
+  return (
+    <Field>
+      <FieldLabel htmlFor="header-photo">{t("photo")}</FieldLabel>
+      <div className="flex items-center gap-3">
+        {photo ? (
+          <Image
+            src={photo}
+            alt={t("photo")}
+            width={56}
+            height={56}
+            unoptimized
+            className="size-14 object-cover"
+            style={{ borderRadius: `${photoRadius}%` }}
+          />
+        ) : null}
+        <input
+          ref={inputRef}
+          id="header-photo"
+          type="file"
+          accept="image/*"
+          className="sr-only"
+          onChange={(event) => {
+            void onFile(event.target.files?.[0]);
+            event.target.value = "";
+          }}
+        />
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => inputRef.current?.click()}
+        >
+          <ImagePlus />
+          {photo ? t("photoReplace") : t("photoAdd")}
+        </Button>
+        {photo ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() =>
+              updateOpen((draft) => {
+                draft.header.photo = undefined;
+              })
+            }
+          >
+            <Trash2 />
+            {t("photoRemove")}
+          </Button>
+        ) : null}
+      </div>
+      {photo ? (
+        <div className="mt-2 space-y-2">
+          <div className="flex items-center justify-between gap-3">
+            <span
+              id="photo-size-label"
+              className="shrink-0 text-sm text-muted-foreground"
+            >
+              {t("photoSize")}
+            </span>
+            <Slider
+              aria-labelledby="photo-size-label"
+              className="max-w-36"
+              value={photoSize}
+              onValueChange={(value) =>
+                updateOpen((draft) => {
+                  draft.photoSize = toSingle(value);
+                })
+              }
+              min={PHOTO_SIZE_MIN}
+              max={PHOTO_SIZE_MAX}
+              step={2}
+            />
+          </div>
+          <div className="flex items-center justify-between gap-3">
+            <span
+              id="photo-radius-label"
+              className="shrink-0 text-sm text-muted-foreground"
+            >
+              {t("photoRadius")}
+            </span>
+            <Slider
+              aria-labelledby="photo-radius-label"
+              className="max-w-36"
+              value={photoRadius}
+              onValueChange={(value) =>
+                updateOpen((draft) => {
+                  draft.photoRadius = toSingle(value);
+                })
+              }
+              min={PHOTO_RADIUS_MIN}
+              max={PHOTO_RADIUS_MAX}
+              step={1}
+            />
+          </div>
+          <div className="flex items-center justify-between gap-3">
+            <span
+              id="photo-align-label"
+              className="shrink-0 text-sm text-muted-foreground"
+            >
+              {t("photoAlign")}
+            </span>
+            <SegmentedControl
+              aria-label={t("photoAlign")}
+              value={photoAlign}
+              onValueChange={(value) =>
+                updateOpen((draft) => {
+                  draft.photoAlign = value as "top" | "center" | "bottom";
+                })
+              }
+              items={[
+                { value: "top", label: t("photoAlignTop") },
+                { value: "center", label: t("photoAlignCenter") },
+                { value: "bottom", label: t("photoAlignBottom") },
+              ]}
+            />
+          </div>
+        </div>
+      ) : null}
+      <FieldDescription>{t("photoHint")}</FieldDescription>
+    </Field>
+  );
+}

--- a/src/components/editor/editor-sections/ed-section-personal/photo-process.ts
+++ b/src/components/editor/editor-sections/ed-section-personal/photo-process.ts
@@ -1,0 +1,31 @@
+const PHOTO_SIZE = 256;
+const JPEG_QUALITY = 0.85;
+
+/**
+ * Center-crops the image to a square and downscales it to a 256px JPEG data
+ * URL. The hard downscale is what keeps the stored document small: the data
+ * URL lands in IndexedDB, in every undo snapshot, and in the JSON/YAML
+ * interchange. A white fill first, since JPEG has no alpha and a transparent
+ * PNG would otherwise composite onto black.
+ */
+export async function processPhotoFile(file: File): Promise<string | null> {
+  if (!file.type.startsWith("image/")) return null;
+  try {
+    const bitmap = await createImageBitmap(file);
+    const side = Math.min(bitmap.width, bitmap.height);
+    const sx = (bitmap.width - side) / 2;
+    const sy = (bitmap.height - side) / 2;
+    const canvas = document.createElement("canvas");
+    canvas.width = PHOTO_SIZE;
+    canvas.height = PHOTO_SIZE;
+    const context = canvas.getContext("2d");
+    if (!context) return null;
+    context.fillStyle = "#ffffff";
+    context.fillRect(0, 0, PHOTO_SIZE, PHOTO_SIZE);
+    context.drawImage(bitmap, sx, sy, side, side, 0, 0, PHOTO_SIZE, PHOTO_SIZE);
+    bitmap.close();
+    return canvas.toDataURL("image/jpeg", JPEG_QUALITY);
+  } catch {
+    return null;
+  }
+}

--- a/src/components/editor/pdf/awal-pdf-document.tsx
+++ b/src/components/editor/pdf/awal-pdf-document.tsx
@@ -30,6 +30,7 @@ import {
 } from "./pdf-font";
 import { PDF_COLORS } from "./pdf-fonts";
 import { dateRange, PdfGrid } from "./pdf-grid";
+import { PdfHeaderPhoto } from "./pdf-header-photo";
 import { PdfRichText } from "./pdf-rich-text";
 
 // Font sizes are multiplied by the document's per-group scales (name, title,
@@ -90,11 +91,14 @@ function PdfHeader(props: { header: HeaderView }) {
   const styles = usePdfStyles(baseStyles);
   return (
     <View style={styles.header}>
-      <View style={styles.headerLeft}>
-        <Text style={styles.name}>{props.header.fullName}</Text>
-        {props.header.headline ? (
-          <Text style={styles.headline}>{props.header.headline}</Text>
-        ) : null}
+      <View style={{ flexDirection: "row", alignItems: "flex-start", gap: 10 }}>
+        <PdfHeaderPhoto header={props.header} />
+        <View style={styles.headerLeft}>
+          <Text style={styles.name}>{props.header.fullName}</Text>
+          {props.header.headline ? (
+            <Text style={styles.headline}>{props.header.headline}</Text>
+          ) : null}
+        </View>
       </View>
       <View style={styles.headerRight}>
         {props.header.contacts.map((contact) => (

--- a/src/components/editor/pdf/ketat-pdf-document.tsx
+++ b/src/components/editor/pdf/ketat-pdf-document.tsx
@@ -32,6 +32,7 @@ import {
 } from "./pdf-font";
 import { PDF_COLORS } from "./pdf-fonts";
 import { dateRange, PdfGrid } from "./pdf-grid";
+import { PdfHeaderPhoto } from "./pdf-header-photo";
 import { PdfRichText } from "./pdf-rich-text";
 
 // Font sizes are multiplied by the document's per-group scales (name, title,
@@ -108,15 +109,18 @@ function KetatHeader(props: { header: HeaderView }) {
   const serif = usePdfFontFamily("Lora");
   return (
     <View style={styles.header}>
-      <View style={styles.headerLeft}>
-        <Text style={[styles.name, { fontFamily: serif }]}>
-          {props.header.fullName}
-        </Text>
-        {props.header.headline ? (
-          <Text style={[styles.headline, { fontFamily: serif }]}>
-            {props.header.headline}
+      <View style={{ flexDirection: "row", alignItems: "flex-start", gap: 10 }}>
+        <PdfHeaderPhoto header={props.header} />
+        <View style={styles.headerLeft}>
+          <Text style={[styles.name, { fontFamily: serif }]}>
+            {props.header.fullName}
           </Text>
-        ) : null}
+          {props.header.headline ? (
+            <Text style={[styles.headline, { fontFamily: serif }]}>
+              {props.header.headline}
+            </Text>
+          ) : null}
+        </View>
       </View>
       <View style={styles.headerRight}>
         {props.header.contacts.map((contact) => (

--- a/src/components/editor/pdf/ketik-pdf-document.tsx
+++ b/src/components/editor/pdf/ketik-pdf-document.tsx
@@ -32,6 +32,7 @@ import {
 } from "./pdf-font";
 import { PDF_COLORS } from "./pdf-fonts";
 import { dateRange, PdfGrid } from "./pdf-grid";
+import { PdfHeaderPhoto } from "./pdf-header-photo";
 import { PdfRichText } from "./pdf-rich-text";
 
 // Font sizes are multiplied by the document's per-group scales (name, title,
@@ -124,18 +125,21 @@ function KetikHeader(props: { header: HeaderView }) {
   const styles = usePdfStyles(baseStyles);
   const mono = usePdfFontFamily("GeistMono");
   return (
-    <View>
-      <Text style={[styles.name, { fontFamily: mono }]}>
-        {props.header.fullName}
-      </Text>
-      {props.header.headline ? (
-        <Text style={[styles.headline, { fontFamily: mono }]}>
-          {props.header.headline}
+    <View style={{ flexDirection: "row", alignItems: "flex-start", gap: 12 }}>
+      <PdfHeaderPhoto header={props.header} />
+      <View>
+        <Text style={[styles.name, { fontFamily: mono }]}>
+          {props.header.fullName}
         </Text>
-      ) : null}
-      {props.header.contacts.length > 0 ? (
-        <KetikContactLine contacts={props.header.contacts} />
-      ) : null}
+        {props.header.headline ? (
+          <Text style={[styles.headline, { fontFamily: mono }]}>
+            {props.header.headline}
+          </Text>
+        ) : null}
+        {props.header.contacts.length > 0 ? (
+          <KetikContactLine contacts={props.header.contacts} />
+        ) : null}
+      </View>
     </View>
   );
 }

--- a/src/components/editor/pdf/klasik-pdf-document.tsx
+++ b/src/components/editor/pdf/klasik-pdf-document.tsx
@@ -30,6 +30,7 @@ import {
 } from "./pdf-font";
 import { PDF_COLORS } from "./pdf-fonts";
 import { dateRange, PdfGrid } from "./pdf-grid";
+import { PdfHeaderPhoto } from "./pdf-header-photo";
 import { PdfRichText } from "./pdf-rich-text";
 
 // Font sizes are multiplied by the document's per-group scales (name, title,
@@ -113,6 +114,7 @@ function KlasikHeader(props: { header: HeaderView }) {
   const styles = usePdfStyles(baseStyles);
   return (
     <View style={styles.header}>
+      <PdfHeaderPhoto header={props.header} centered />
       <Text style={styles.name}>{props.header.fullName}</Text>
       {props.header.headline ? (
         <Text style={styles.headline}>{props.header.headline}</Text>

--- a/src/components/editor/pdf/luasa-pdf-document.tsx
+++ b/src/components/editor/pdf/luasa-pdf-document.tsx
@@ -32,6 +32,7 @@ import {
 } from "./pdf-font";
 import { PDF_COLORS } from "./pdf-fonts";
 import { dateRange, PdfGrid } from "./pdf-grid";
+import { PdfHeaderPhoto } from "./pdf-header-photo";
 import { PdfRichText } from "./pdf-rich-text";
 
 // Font sizes are multiplied by the document's per-group scales (name, title,
@@ -127,18 +128,26 @@ function LuasaHeader(props: { header: HeaderView }) {
   const styles = usePdfStyles(baseStyles);
   const serif = usePdfFontFamily("Lora");
   return (
-    <View style={styles.accentBar}>
-      <Text style={[styles.name, { fontFamily: serif }]}>
-        {props.header.fullName}
-      </Text>
-      {props.header.headline ? (
-        <Text style={[styles.headline, { fontFamily: serif }]}>
-          {props.header.headline}
+    <View
+      style={[
+        styles.accentBar,
+        { flexDirection: "row", alignItems: "flex-start", gap: 10 },
+      ]}
+    >
+      <PdfHeaderPhoto header={props.header} />
+      <View>
+        <Text style={[styles.name, { fontFamily: serif }]}>
+          {props.header.fullName}
         </Text>
-      ) : null}
-      {props.header.contacts.length > 0 ? (
-        <LuasaContactLine contacts={props.header.contacts} />
-      ) : null}
+        {props.header.headline ? (
+          <Text style={[styles.headline, { fontFamily: serif }]}>
+            {props.header.headline}
+          </Text>
+        ) : null}
+        {props.header.contacts.length > 0 ? (
+          <LuasaContactLine contacts={props.header.contacts} />
+        ) : null}
+      </View>
     </View>
   );
 }

--- a/src/components/editor/pdf/pdf-header-photo.tsx
+++ b/src/components/editor/pdf/pdf-header-photo.tsx
@@ -1,0 +1,39 @@
+import { Image } from "@react-pdf/renderer";
+import type { HeaderView } from "../resume-preview";
+
+/** Preview px to PDF pt, matching the type scale used across the templates. */
+const PDF_SCALE = 0.75;
+
+/**
+ * The opt-in portrait for PDF headers. Renders nothing without a photo, so
+ * photo-free documents lay out exactly as before. Size and corner radius are
+ * the document's presentation tokens. Drawn as an image, never absolutely
+ * positioned, so it cannot disturb text extraction order.
+ */
+export function PdfHeaderPhoto(props: {
+  header: Pick<
+    HeaderView,
+    "photo" | "photoSize" | "photoRadius" | "photoAlign"
+  >;
+  centered?: boolean;
+}) {
+  const { photo, photoSize, photoRadius, photoAlign } = props.header;
+  if (!photo) return null;
+  const size = photoSize * PDF_SCALE;
+  return (
+    <Image
+      src={photo}
+      style={{
+        width: size,
+        height: size,
+        borderRadius: (size * photoRadius) / 100,
+        alignSelf: (
+          { top: "flex-start", center: "center", bottom: "flex-end" } as const
+        )[photoAlign],
+        ...(props.centered
+          ? { alignSelf: "center", marginBottom: 6 }
+          : undefined),
+      }}
+    />
+  );
+}

--- a/src/components/editor/pdf/tebal-pdf-document.tsx
+++ b/src/components/editor/pdf/tebal-pdf-document.tsx
@@ -30,6 +30,7 @@ import {
 } from "./pdf-font";
 import { PDF_COLORS } from "./pdf-fonts";
 import { dateRange, PdfGrid } from "./pdf-grid";
+import { PdfHeaderPhoto } from "./pdf-header-photo";
 import { PdfRichText } from "./pdf-rich-text";
 
 // Font sizes are multiplied by the document's per-group scales (name, title,
@@ -97,29 +98,32 @@ const baseStyles = makeStyles(NO_SCALE);
 function TebalHeader(props: { header: HeaderView }) {
   const styles = usePdfStyles(baseStyles);
   return (
-    <View>
-      <Text style={styles.name}>{props.header.fullName}</Text>
-      {props.header.headline ? (
-        <Text style={styles.headline}>{props.header.headline}</Text>
-      ) : null}
-      {props.header.contacts.length > 0 ? (
-        <View style={styles.contactRowWrap}>
-          {props.header.contacts.map((contact) => (
-            <View key={contact.kind} style={styles.contactRow}>
-              {props.header.showIcons ? (
-                <PdfContactIcon kind={contact.kind} />
-              ) : null}
-              {contact.href ? (
-                <Link src={contact.href} style={styles.linkPlain}>
-                  {contact.value}
-                </Link>
-              ) : (
-                <Text>{contact.value}</Text>
-              )}
-            </View>
-          ))}
-        </View>
-      ) : null}
+    <View style={{ flexDirection: "row", alignItems: "flex-start", gap: 12 }}>
+      <PdfHeaderPhoto header={props.header} />
+      <View>
+        <Text style={styles.name}>{props.header.fullName}</Text>
+        {props.header.headline ? (
+          <Text style={styles.headline}>{props.header.headline}</Text>
+        ) : null}
+        {props.header.contacts.length > 0 ? (
+          <View style={styles.contactRowWrap}>
+            {props.header.contacts.map((contact) => (
+              <View key={contact.kind} style={styles.contactRow}>
+                {props.header.showIcons ? (
+                  <PdfContactIcon kind={contact.kind} />
+                ) : null}
+                {contact.href ? (
+                  <Link src={contact.href} style={styles.linkPlain}>
+                    {contact.value}
+                  </Link>
+                ) : (
+                  <Text>{contact.value}</Text>
+                )}
+              </View>
+            ))}
+          </View>
+        ) : null}
+      </View>
     </View>
   );
 }

--- a/src/components/editor/resume-header-photo.tsx
+++ b/src/components/editor/resume-header-photo.tsx
@@ -1,0 +1,38 @@
+import Image from "next/image";
+import { cn } from "@/lib/utils";
+import type { HeaderView } from "./resume-preview";
+
+/**
+ * The opt-in portrait, shared by every template header. Renders nothing when
+ * the document has no photo, so photo-free resumes lay out exactly as before.
+ * Size and corner radius are the document's presentation tokens; uploads are
+ * pre-cropped square, so object-cover never has to crop here.
+ */
+export function ResumeHeaderPhoto(props: {
+  header: Pick<
+    HeaderView,
+    "photo" | "photoSize" | "photoRadius" | "photoAlign"
+  >;
+  className?: string;
+}) {
+  const { photo, photoSize, photoRadius, photoAlign } = props.header;
+  if (!photo) return null;
+  return (
+    <Image
+      src={photo}
+      alt=""
+      width={photoSize}
+      height={photoSize}
+      unoptimized
+      className={cn("shrink-0 object-cover", props.className)}
+      style={{
+        width: photoSize,
+        height: photoSize,
+        borderRadius: `${photoRadius}%`,
+        alignSelf: { top: "flex-start", center: "center", bottom: "flex-end" }[
+          photoAlign
+        ],
+      }}
+    />
+  );
+}

--- a/src/components/editor/resume-header.tsx
+++ b/src/components/editor/resume-header.tsx
@@ -1,16 +1,20 @@
 import { ResumeHeaderContact } from "./resume-header-contact";
+import { ResumeHeaderPhoto } from "./resume-header-photo";
 import type { HeaderView } from "./resume-preview";
 
 export function ResumeHeader(props: HeaderView) {
   return (
     <header className="flex flex-wrap items-start justify-between gap-4">
-      <div>
-        <h1 className="resume-name-xl font-bold tracking-tight">
-          {props.fullName}
-        </h1>
-        <p className="mt-1 text-muted-foreground resume-name-sm">
-          {props.headline}
-        </p>
+      <div className="flex items-start gap-4">
+        <ResumeHeaderPhoto header={props} />
+        <div>
+          <h1 className="resume-name-xl font-bold tracking-tight">
+            {props.fullName}
+          </h1>
+          <p className="mt-1 text-muted-foreground resume-name-sm">
+            {props.headline}
+          </p>
+        </div>
       </div>
 
       <ul className="space-y-1 resume-body-xs">

--- a/src/components/editor/resume-preview.ts
+++ b/src/components/editor/resume-preview.ts
@@ -34,6 +34,14 @@ export interface ContactView {
 export interface HeaderView {
   fullName: string;
   headline: string;
+  /** Opt-in portrait as a data URL; absent when the user has not added one. */
+  photo?: string;
+  /** Resolved photo size in preview px (default 56). */
+  photoSize: number;
+  /** Resolved photo corner radius, percent of size: 0 square, 50 circle. */
+  photoRadius: number;
+  /** Resolved vertical anchor of the photo within the header strip. */
+  photoAlign: "top" | "center" | "bottom";
   contacts: ContactView[];
   /** Presentation-only: whether contact icon glyphs are drawn; defaults to true. */
   showIcons: boolean;

--- a/src/components/editor/resume-to-preview.ts
+++ b/src/components/editor/resume-to-preview.ts
@@ -105,6 +105,10 @@ function toHeaderView(resume: Resume): HeaderView {
   return {
     fullName,
     headline: plain(fields.jobTitle),
+    photo: resume.header.photo,
+    photoSize: resume.photoSize ?? 56,
+    photoRadius: resume.photoRadius ?? 0,
+    photoAlign: resume.photoAlign ?? "top",
     contacts,
     showIcons: resume.showIcons ?? true,
   };

--- a/src/components/editor/templates/ketat/ketat-header.tsx
+++ b/src/components/editor/templates/ketat/ketat-header.tsx
@@ -1,4 +1,5 @@
 import { ResumeContactIcon } from "../../resume-contact-icon";
+import { ResumeHeaderPhoto } from "../../resume-header-photo";
 import type { ContactView, HeaderView } from "../../resume-preview";
 
 function KetatHeaderContact(props: ContactView & { showIcons: boolean }) {
@@ -19,13 +20,16 @@ function KetatHeaderContact(props: ContactView & { showIcons: boolean }) {
 export function KetatHeader(props: HeaderView) {
   return (
     <header className="flex flex-wrap items-start justify-between gap-6">
-      <div className="min-w-0">
-        <h1 className="font-serif resume-name-2xl uppercase tracking-wide">
-          {props.fullName}
-        </h1>
-        <p className="mt-1 font-serif resume-name-base text-muted-foreground">
-          {props.headline}
-        </p>
+      <div className="flex min-w-0 items-start gap-4">
+        <ResumeHeaderPhoto header={props} />
+        <div className="min-w-0">
+          <h1 className="font-serif resume-name-2xl uppercase tracking-wide">
+            {props.fullName}
+          </h1>
+          <p className="mt-1 font-serif resume-name-base text-muted-foreground">
+            {props.headline}
+          </p>
+        </div>
       </div>
 
       <ul className="space-y-1.5 resume-body-xs">

--- a/src/components/editor/templates/ketik/ketik-header.tsx
+++ b/src/components/editor/templates/ketik/ketik-header.tsx
@@ -1,31 +1,35 @@
 import { Fragment } from "react";
+import { ResumeHeaderPhoto } from "../../resume-header-photo";
 import type { HeaderView } from "../../resume-preview";
 
 export function KetikHeader(props: HeaderView) {
   return (
-    <header className="font-mono">
-      <h1 className="resume-name-xl font-bold">{props.fullName}</h1>
-      {props.headline && (
-        <p className="mt-0.5 resume-name-sm text-muted-foreground">
-          {props.headline}
-        </p>
-      )}
-      {props.contacts.length > 0 && (
-        <p className="mt-1.5 resume-body-xs text-muted-foreground">
-          {props.contacts.map((contact, index) => (
-            <Fragment key={contact.kind}>
-              {index > 0 && <span aria-hidden> | </span>}
-              {contact.href ? (
-                <a href={contact.href} className="underline">
-                  {contact.value}
-                </a>
-              ) : (
-                <span>{contact.value}</span>
-              )}
-            </Fragment>
-          ))}
-        </p>
-      )}
+    <header className="flex items-start gap-4 font-mono">
+      <ResumeHeaderPhoto header={props} />
+      <div>
+        <h1 className="resume-name-xl font-bold">{props.fullName}</h1>
+        {props.headline && (
+          <p className="mt-0.5 resume-name-sm text-muted-foreground">
+            {props.headline}
+          </p>
+        )}
+        {props.contacts.length > 0 && (
+          <p className="mt-1.5 resume-body-xs text-muted-foreground">
+            {props.contacts.map((contact, index) => (
+              <Fragment key={contact.kind}>
+                {index > 0 && <span aria-hidden> | </span>}
+                {contact.href ? (
+                  <a href={contact.href} className="underline">
+                    {contact.value}
+                  </a>
+                ) : (
+                  <span>{contact.value}</span>
+                )}
+              </Fragment>
+            ))}
+          </p>
+        )}
+      </div>
     </header>
   );
 }

--- a/src/components/editor/templates/klasik/klasik-header.tsx
+++ b/src/components/editor/templates/klasik/klasik-header.tsx
@@ -1,9 +1,11 @@
 import { Fragment } from "react";
+import { ResumeHeaderPhoto } from "../../resume-header-photo";
 import type { HeaderView } from "../../resume-preview";
 
 export function KlasikHeader(props: HeaderView) {
   return (
     <header className="text-center font-serif">
+      <ResumeHeaderPhoto header={props} className="mx-auto mb-2" />
       <h1 className="resume-name-2xl">{props.fullName}</h1>
       {props.headline && (
         <p className="mt-0.5 resume-name-sm italic text-muted-foreground">

--- a/src/components/editor/templates/luasa/luasa-header.tsx
+++ b/src/components/editor/templates/luasa/luasa-header.tsx
@@ -1,33 +1,37 @@
 import { Fragment } from "react";
+import { ResumeHeaderPhoto } from "../../resume-header-photo";
 import type { HeaderView } from "../../resume-preview";
 
 export function LuasaHeader(props: HeaderView) {
   return (
-    <header className="border-l-2 border-foreground/80 pl-4">
-      <h1 className="font-serif resume-name-2xl uppercase tracking-[0.08em]">
-        {props.fullName}
-      </h1>
-      {props.headline && (
-        <p className="mt-0.5 font-serif resume-name-sm text-muted-foreground">
-          {props.headline}
-        </p>
-      )}
-      {props.contacts.length > 0 && (
-        <p className="mt-1 resume-body-xs text-muted-foreground">
-          {props.contacts.map((contact, index) => (
-            <Fragment key={contact.kind}>
-              {index > 0 && <span aria-hidden> • </span>}
-              {contact.href ? (
-                <a href={contact.href} className="underline">
-                  {contact.value}
-                </a>
-              ) : (
-                <span>{contact.value}</span>
-              )}
-            </Fragment>
-          ))}
-        </p>
-      )}
+    <header className="flex items-start gap-4 border-l-2 border-foreground/80 pl-4">
+      <ResumeHeaderPhoto header={props} />
+      <div>
+        <h1 className="font-serif resume-name-2xl uppercase tracking-[0.08em]">
+          {props.fullName}
+        </h1>
+        {props.headline && (
+          <p className="mt-0.5 font-serif resume-name-sm text-muted-foreground">
+            {props.headline}
+          </p>
+        )}
+        {props.contacts.length > 0 && (
+          <p className="mt-1 resume-body-xs text-muted-foreground">
+            {props.contacts.map((contact, index) => (
+              <Fragment key={contact.kind}>
+                {index > 0 && <span aria-hidden> • </span>}
+                {contact.href ? (
+                  <a href={contact.href} className="underline">
+                    {contact.value}
+                  </a>
+                ) : (
+                  <span>{contact.value}</span>
+                )}
+              </Fragment>
+            ))}
+          </p>
+        )}
+      </div>
     </header>
   );
 }

--- a/src/components/editor/templates/tebal/tebal-header.tsx
+++ b/src/components/editor/templates/tebal/tebal-header.tsx
@@ -1,28 +1,32 @@
 import { ResumeHeaderContact } from "../../resume-header-contact";
+import { ResumeHeaderPhoto } from "../../resume-header-photo";
 import type { HeaderView } from "../../resume-preview";
 
 export function TebalHeader(props: HeaderView) {
   return (
-    <header>
-      <h1 className="resume-name-3xl font-extrabold tracking-tight">
-        {props.fullName}
-      </h1>
-      {props.headline && (
-        <p className="mt-1 resume-name-sm font-medium text-muted-foreground">
-          {props.headline}
-        </p>
-      )}
-      {props.contacts.length > 0 && (
-        <ul className="mt-2 flex flex-wrap gap-x-4 gap-y-1 resume-body-xs">
-          {props.contacts.map((contact) => (
-            <ResumeHeaderContact
-              key={contact.kind}
-              showIcons={props.showIcons}
-              {...contact}
-            />
-          ))}
-        </ul>
-      )}
+    <header className="flex items-start gap-4">
+      <ResumeHeaderPhoto header={props} />
+      <div>
+        <h1 className="resume-name-3xl font-extrabold tracking-tight">
+          {props.fullName}
+        </h1>
+        {props.headline && (
+          <p className="mt-1 resume-name-sm font-medium text-muted-foreground">
+            {props.headline}
+          </p>
+        )}
+        {props.contacts.length > 0 && (
+          <ul className="mt-2 flex flex-wrap gap-x-4 gap-y-1 resume-body-xs">
+            {props.contacts.map((contact) => (
+              <ResumeHeaderContact
+                key={contact.kind}
+                showIcons={props.showIcons}
+                {...contact}
+              />
+            ))}
+          </ul>
+        )}
+      </div>
     </header>
   );
 }

--- a/src/lib/interchange/codec.ts
+++ b/src/lib/interchange/codec.ts
@@ -37,6 +37,9 @@ export interface ResumeContent {
   nameScale?: number;
   titleScale?: number;
   bodyScale?: number;
+  photoSize?: number;
+  photoRadius?: number;
+  photoAlign?: "top" | "center" | "bottom";
   header: Header;
   sections: Section[];
 }
@@ -128,6 +131,10 @@ export function resumeToInterchange(resume: Resume): InterchangeResume {
     titleScale: resume.titleScale,
     bodyScale: resume.bodyScale,
     header,
+    photo: resume.header.photo,
+    photoSize: resume.photoSize,
+    photoRadius: resume.photoRadius,
+    photoAlign: resume.photoAlign,
     sections: resume.sections.map(sectionToInterchange),
   };
 }
@@ -207,6 +214,8 @@ export function interchangeToContent(data: InterchangeResume): ResumeContent {
     }
   }
 
+  if (data.photo) header.photo = data.photo;
+
   const provided = (data.sections ?? []).map(interchangeToSection);
   // Summary is pinned first; core sections the document omits are appended
   // empty so the editor always has its full fixed set.
@@ -235,6 +244,9 @@ export function interchangeToContent(data: InterchangeResume): ResumeContent {
     nameScale: data.nameScale,
     titleScale: data.titleScale,
     bodyScale: data.bodyScale,
+    photoSize: data.photoSize,
+    photoRadius: data.photoRadius,
+    photoAlign: data.photoAlign,
     header,
     sections,
   };

--- a/src/lib/interchange/import-file.ts
+++ b/src/lib/interchange/import-file.ts
@@ -39,6 +39,15 @@ function buildImportedResume(
   if (parsed.content.bodyScale !== undefined) {
     resume.bodyScale = parsed.content.bodyScale;
   }
+  if (parsed.content.photoSize !== undefined) {
+    resume.photoSize = parsed.content.photoSize;
+  }
+  if (parsed.content.photoRadius !== undefined) {
+    resume.photoRadius = parsed.content.photoRadius;
+  }
+  if (parsed.content.photoAlign !== undefined) {
+    resume.photoAlign = parsed.content.photoAlign;
+  }
   if (parsed.content.title) resume.title = parsed.content.title;
   return { ok: true, resume, leftovers: [] };
 }

--- a/src/lib/interchange/schema.ts
+++ b/src/lib/interchange/schema.ts
@@ -97,6 +97,14 @@ export const interchangeSchema = z
     titleScale: z.number().min(0.8).max(1.2).optional(),
     bodyScale: z.number().min(0.8).max(1.2).optional(),
     header: entryShape(HEADER_SCHEMA).optional(),
+    /** Opt-in portrait as a data URL; kept out of the header field map since it is not text. */
+    photo: z
+      .string()
+      .regex(/^data:image\/(?:jpeg|png);base64,[A-Za-z0-9+/=]+$/)
+      .optional(),
+    photoSize: z.number().min(40).max(96).optional(),
+    photoRadius: z.number().min(0).max(50).optional(),
+    photoAlign: z.enum(["top", "center", "bottom"]).optional(),
     sections: z.array(sectionSchema).optional(),
   })
   .superRefine((value, ctx) => {

--- a/src/lib/resume/migrations.ts
+++ b/src/lib/resume/migrations.ts
@@ -621,6 +621,15 @@ const migrateV21toV22: Migration = (doc) => {
 };
 
 /**
+ * v22→v23: the header gains an optional opt-in `photo` (a data URL) and the
+ * document gains its presentation tokens `photoSize`, `photoRadius`, and
+ * `photoAlign`.
+ * Absence means no photo and the defaults, so nothing is reshaped; the step
+ * exists to stamp the version and keep the ladder gap-free.
+ */
+const migrateV22toV23: Migration = (doc) => structuredClone(doc);
+
+/**
  * The migration ladder. Each key N is a forward-only step from version N to N+1.
  */
 const LADDER: Record<number, Migration> = {
@@ -645,6 +654,7 @@ const LADDER: Record<number, Migration> = {
   19: migrateV19toV20,
   20: migrateV20toV21,
   21: migrateV21toV22,
+  22: migrateV22toV23,
 };
 
 /** The persisted schemaVersion of a raw document; 0 when absent or malformed. */

--- a/src/lib/resume/types.ts
+++ b/src/lib/resume/types.ts
@@ -5,7 +5,7 @@ import type { JSONContent } from "@tiptap/core";
  * governs object-store/index structure only. Bumped whenever a persisted field
  * shape changes; every bump gets a forward-only step in the migration ladder.
  */
-export const CURRENT_SCHEMA_VERSION = 22;
+export const CURRENT_SCHEMA_VERSION = 23;
 
 /** The language the rendered document's fixed labels (headings, dates) use. */
 export type ResumeLanguage = "en" | "id";
@@ -105,6 +105,12 @@ export interface Section {
  */
 export interface Header {
   fields: Record<FieldKey, Field>;
+  /**
+   * Opt-in portrait as a data URL, downscaled at upload. Absence means no
+   * photo. Presentation-only: it carries no text and every export ignores it
+   * for extraction purposes.
+   */
+  photo?: string;
 }
 
 /**
@@ -135,6 +141,23 @@ export interface Resume {
    * value as `true`; templates that never draw icons ignore it.
    */
   showIcons?: boolean;
+  /**
+   * Presentation-only size of the opt-in header photo, in rendering units (px
+   * on screen, scaled for PDF). Unset means the 56-unit default. Bounded to
+   * 40..96 by the editor slider and the interchange schema.
+   */
+  photoSize?: number;
+  /**
+   * Presentation-only corner radius of the header photo as a percentage of its
+   * size: 0 (unset) is a square, 50 a full circle. Bounded to 0..50.
+   */
+  photoRadius?: number;
+  /**
+   * Presentation-only vertical anchor of the header photo within the header
+   * strip, for the side-by-side templates. Unset means "top", which reads
+   * correctly at every header height. Centered templates (Klasik) ignore it.
+   */
+  photoAlign?: "top" | "center" | "bottom";
   /**
    * Presentation-only vertical space adjustment above each section heading, in
    * rendering units (px on screen, pt in PDF), applied on top of the


### PR DESCRIPTION
Closes #152.

Resumes stay photo-free by default. A new Photo control in Personal Information adds a portrait: uploads are center-cropped square and downscaled to a 256px JPEG data URL on the client, so the stored document, the undo snapshots, and the JSON/YAML interchange stay small. Add, replace, remove, and every adjustment go through the store, so they are all undoable. A caption states the tradeoff plainly: common for applications in Indonesia, ignored or discouraged by many ATS and US employers, and the resume text always stays fully readable to parsers.

Three presentation tokens control the rendering, all interchange-bound and undoable. Size runs 40 to 96 with a hard clamp at both ends. Corner radius runs 0 to 50 percent; the default is 0, a square. Position is a Top, Center, Bottom segmented control (arrow keys walk the options) anchoring the photo within the header strip; Top is the default because it reads correctly at every header height, where centering floats the photo away from the name once contacts make the block tall.

Each template places the photo to match its own composition: Klasik stacks it centered above the name; the five side-by-side templates lead their text block with it, grouped so split headers (Awal, Ketat) keep their contacts right-aligned. The PDF mirrors every placement with plain flexbox, never absolute positioning. DOCX embeds the image inside the name paragraph; TXT ignores it. This is the one shipped exception to the structural-freedom non-goal, and AGENTS.md documents the carve-out.

The document shape change ships atomically: header photo plus the three tokens, the CURRENT_SCHEMA_VERSION bump to 23, and a gap-free ladder rung. The export gate gains a photo-invariance check: the extracted text of every template PDF and the DOCX must stay byte-identical with and without a photo, which turns the presentation-only claim into a tested invariant (it caught two real regressions during development).

Testing: drove the full flow in the browser against the dev server. Uploaded a canvas-generated portrait through the real control, confirmed it renders in the preview header and in all six templates via the layout switcher, and that undo removes it and redo restores it. Measured the controls on a tall header: default top anchor at 0, center at the exact midpoint, bottom at exactly header height minus photo, size clamping at both 40 and 96, radius applying from square to rounded. Confirmed each template PDF embeds exactly one image, and that JSON and YAML round trips stay identical with the photo and all three tokens. The full export validation pass, lint, and typecheck all pass.