### PR TITLE
docs: add the 0.14.0 changelog entry for the what's new sheet

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -173,6 +173,20 @@
       "latest": "Latest",
       "fullChangelog": "Full changelog on GitHub",
       "entries": {
+        "0_14_0": [
+          {
+            "title": "Add a photo to your header",
+            "description": "You can now put a photo on your resume. It is optional and off by default. Add it in Personal Information, then pick the size, corner roundness, and position. It comes along in PDF and Word exports, and the text of your resume stays fully readable to parsers."
+          },
+          {
+            "title": "A fresh new look",
+            "description": "Lanjut has a new logo and a rebuilt landing page. The previews there are rendered by the real templates, so what you see is exactly what you get."
+          },
+          {
+            "title": "Support Lanjut",
+            "description": "Lanjut is free and always will be. If it helped you, you can now support development through Saweria or SociaBuzz, right from the sidebar or the footer."
+          }
+        ],
         "0_13_0": [
           {
             "title": "One more link in your header",

--- a/messages/id.json
+++ b/messages/id.json
@@ -173,6 +173,20 @@
       "latest": "Terbaru",
       "fullChangelog": "Changelog lengkap di GitHub",
       "entries": {
+        "0_14_0": [
+          {
+            "title": "Pasang foto di header",
+            "description": "Sekarang kamu bisa pasang foto di resume. Sifatnya opsional dan mati secara bawaan. Tambahkan lewat Informasi Pribadi, lalu atur ukuran, kelengkungan sudut, dan posisinya. Foto ikut di ekspor PDF dan Word, dan teks resume kamu tetap terbaca penuh oleh parser."
+          },
+          {
+            "title": "Tampilan baru",
+            "description": "Lanjut punya logo baru dan halaman depan yang dibangun ulang. Pratinjau di sana dirender langsung dari template asli, jadi yang kamu lihat persis yang kamu dapat."
+          },
+          {
+            "title": "Dukung Lanjut",
+            "description": "Lanjut gratis dan akan selalu gratis. Kalau aplikasi ini membantu kamu, sekarang kamu bisa dukung pengembangannya lewat Saweria atau SociaBuzz, langsung dari sidebar atau footer."
+          }
+        ],
         "0_13_0": [
           {
             "title": "Satu tautan lagi di header",

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -9,6 +9,7 @@ export interface ChangelogEntry {
  * with dots replaced by underscores, as a list of { title, description }.
  */
 export const CHANGELOG: ChangelogEntry[] = [
+  { version: "0.14.0", date: "2026-09-06" },
   { version: "0.13.0", date: "2026-09-06" },
   { version: "0.12.0", date: "2026-09-02" },
   { version: "0.11.0", date: "2026-08-02" },


### PR DESCRIPTION
Adds the 0.14.0 entry to the what's new sheet, dated to match the open release PR. Three highlights in both locales: the opt-in header photo with size, corner, and position controls, the new mark and rebuilt landing page, and the Saweria and SociaBuzz support links in the sidebar and footer. The release range has no bug fixes, so there is no bug fixes entry.

Testing: lint and type checks pass. The entry keys follow the existing version-with-underscores convention, so the sheet picks them up by version.
