### PR TITLE
refactor: route every editor link through one href builder and id hook

### DIFF
--- a/src/components/editor/editor-document-import.tsx
+++ b/src/components/editor/editor-document-import.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { useRouter } from "@/i18n/navigation";
 import type { ParseResult } from "@/lib/import";
 import type { ResumeLanguage } from "@/lib/resume";
+import { editorHref } from "@/lib/routes";
 import { useResumeStore } from "@/lib/store";
 import { isResumePreviewEmpty, resumeToPreview } from "./resume-to-preview";
 
@@ -72,7 +73,7 @@ export function EditorDocumentImport() {
       language: locale as ResumeLanguage,
     });
     reset();
-    router.push(`/platform/editor/${resume.id}`);
+    router.push(editorHref(resume.id));
   };
 
   return (

--- a/src/components/editor/editor-resume-not-found.tsx
+++ b/src/components/editor/editor-resume-not-found.tsx
@@ -1,22 +1,23 @@
 "use client";
 
 import { FileQuestion } from "lucide-react";
-import { useParams } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { useEditorId } from "@/hooks/use-editor-id";
 import { Link } from "@/i18n/navigation";
 import { nearestResumeById } from "@/lib/resume";
+import { editorHref } from "@/lib/routes";
 import { useResumeStore } from "@/lib/store";
 
 /**
- * The editor's missing-résumé state. When the route id doesn't resolve, the
- * library index is searched for the closest id within edit tolerance, a
+ * The editor's missing-résumé state. When the id in the URL doesn't resolve,
+ * the library index is searched for the closest id within edit tolerance, a
  * "did you mean" for mangled or truncated links. Deleted résumés (no near id)
  * fall back to the plain message.
  */
 export function EditorResumeNotFound() {
-  const params = useParams<{ id?: string }>();
+  const id = useEditorId();
   const index = useResumeStore((state) => state.index);
-  const suggestion = nearestResumeById(index, params?.id ?? "");
+  const suggestion = nearestResumeById(index, id ?? "");
   const t = useTranslations("editor.chrome");
 
   return (
@@ -31,7 +32,7 @@ export function EditorResumeNotFound() {
         <p>
           {t("didYouMean")}{" "}
           <Link
-            href={`/platform/editor/${suggestion.id}`}
+            href={editorHref(suggestion.id)}
             className="font-medium text-primary underline-offset-4 hover:underline"
           >
             {suggestion.title}

--- a/src/components/landing/landing-try-it.tsx
+++ b/src/components/landing/landing-try-it.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Field, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { useRouter } from "@/i18n/navigation";
+import { editorHref } from "@/lib/routes";
 import {
   type LandingDraft,
   useLandingDraftStore,
@@ -67,7 +68,7 @@ export function LandingTryIt() {
           templateId: template,
         },
       );
-      router.push(`/platform/editor/${resume.id}`);
+      router.push(editorHref(resume.id));
     } finally {
       setCreating(false);
     }

--- a/src/components/platform/platform-resume-create-dialog.tsx
+++ b/src/components/platform/platform-resume-create-dialog.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/lib/forms/resume";
 import type { ParseResult } from "@/lib/import";
 import type { ResumeLanguage } from "@/lib/resume";
+import { editorHref } from "@/lib/routes";
 import { useResumeStore } from "@/lib/store";
 import { DEFAULT_TEMPLATE_ID, resolveTemplateId } from "@/lib/templates";
 import {
@@ -84,7 +85,7 @@ export function PlatformResumeCreateDialog(
     form.reset({ title: "", source: "sample" });
     setImported(null);
     props.onOpenChange(false);
-    router.push(`/platform/editor/${resume.id}`);
+    router.push(editorHref(resume.id));
   });
 
   const importIncomplete = source === "import" && (!imported || parsing);

--- a/src/components/platform/platform-resume-grid/platform-resume-grid-item.tsx
+++ b/src/components/platform/platform-resume-grid/platform-resume-grid-item.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/tooltip";
 import { Link } from "@/i18n/navigation";
 import type { ResumeIndexEntry } from "@/lib/resume";
+import { editorHref } from "@/lib/routes";
 import { PlatformResumeGridItemMenu } from "./platform-resume-grid-item-menu";
 import { PlatformResumeGridItemThumbnail } from "./platform-resume-grid-item-thumbnail";
 
@@ -26,7 +27,7 @@ export function PlatformResumeGridItem({
   const t = useTranslations("platform.grid");
   const formatter = useFormatter();
   const updatedAt = new Date(resume.updatedAt);
-  const href = `/platform/editor/${resume.id}`;
+  const href = editorHref(resume.id);
 
   return (
     <Card size="sm" className="pt-0">

--- a/src/components/platform/platform-sidebar-resume-item.tsx
+++ b/src/components/platform/platform-sidebar-resume-item.tsx
@@ -1,10 +1,11 @@
 import type { BaseUIEvent } from "@base-ui/react";
 import { Copy, FileText, MoreVertical, Pen, Trash } from "lucide-react";
-import { useParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { type MouseEvent, useState } from "react";
+import { useEditorId } from "@/hooks/use-editor-id";
 import { Link } from "@/i18n/navigation";
 import type { ResumeIndexEntry } from "@/lib/resume";
+import { editorHref } from "@/lib/routes";
 import { useResumeStore } from "@/lib/store";
 import {
   DropdownMenu,
@@ -30,7 +31,7 @@ interface PlatformSidebarResumeItemProps {
 export function PlatformSidebarResumeItem({
   resume,
 }: PlatformSidebarResumeItemProps) {
-  const { id } = useParams<{ id?: string }>();
+  const id = useEditorId();
   const duplicateResume = useResumeStore((state) => state.duplicateResume);
   const [open, setOpen] = useState({ rename: false, remove: false });
   const t = useTranslations("platform.sidebar");
@@ -60,7 +61,7 @@ export function PlatformSidebarResumeItem({
       <SidebarMenuButton
         isActive={id === resume.id}
         className="truncate"
-        render={<Link href={`/platform/editor/${resume.id}`} />}
+        render={<Link href={editorHref(resume.id)} />}
       >
         <FileText />
         <span className="truncate">{resume.title}</span>

--- a/src/hooks/use-editor-id.ts
+++ b/src/hooks/use-editor-id.ts
@@ -1,0 +1,12 @@
+"use client";
+
+import { useParams } from "next/navigation";
+
+/**
+ * Reads the id of the résumé the editor is open on. The counterpart to
+ * `editorHref`: where the id sits in the URL is known here and nowhere else.
+ */
+export function useEditorId() {
+  const params = useParams<{ id?: string }>();
+  return params?.id;
+}

--- a/src/hooks/use-editor-resume.ts
+++ b/src/hooks/use-editor-resume.ts
@@ -1,19 +1,18 @@
 "use client";
 
-import { useParams } from "next/navigation";
 import { useEffect } from "react";
+import { useEditorId } from "@/hooks/use-editor-id";
 import { registerResumeFlushListeners, useResumeStore } from "@/lib/store";
 
 /**
- * Loads the résumé addressed by the route `[id]` into the store and keeps it in
- * sync with navigation: opens on mount / id change (`openResume` flushes the
+ * Loads the résumé addressed by the URL into the store and keeps it in sync
+ * with navigation: opens on mount / id change (`openResume` flushes the
  * previously open document itself), flushes pending writes when leaving the
  * editor, and registers the page-lifecycle flush safety net. Synchronizing the
  * store with the route and IndexedDB is a legitimate external-system effect.
  */
 export function useEditorResume() {
-  const params = useParams<{ id: string }>();
-  const id = params?.id;
+  const id = useEditorId();
   const openResume = useResumeStore((state) => state.openResume);
   const flush = useResumeStore((state) => state.flush);
   const openStatus = useResumeStore((state) => state.openStatus);

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -1,0 +1,9 @@
+/**
+ * Builds the editor address. Every link and redirect into the editor goes
+ * through here so that the id can move between the path and a search param
+ * without touching a call site: a static export cannot emit one file per
+ * user-generated id, so the desktop build addresses the editor differently.
+ */
+export function editorHref(id: string): `/platform/editor/${string}` {
+  return `/platform/editor/${id}`;
+}


### PR DESCRIPTION
Preparation for the desktop build in #162. No user-visible change.

The editor address was written out by hand in nine places: six link builders used a `/platform/editor/${id}` template literal, and three readers pulled the id back out with `useParams`. This adds `editorHref(id)` in `src/lib/routes.ts` and `useEditorId()` in `src/hooks/use-editor-id.ts`, and points all nine at them.

The result is that where the id sits in the URL is known in those two files and nowhere else. A grep across `src/` for the literal path, or for `useParams`, now returns only `src/lib/routes.ts` and `src/hooks/use-editor-id.ts`.

This matters because of the decision recorded on #162. A static export cannot emit one file per user-generated id, so the desktop target has to address the editor with a search param while the web keeps its `[id]` path. Rather than force the ugly search-param URL onto the web app, the two builds keep their own shapes behind these two helpers. Step 3 of that RFC changes these two files and nothing else.

`editorHref` returns the template literal type `` `/platform/editor/${string}` `` so it stays compatible with typed routes.

## Testing

`pnpm typecheck` and `pnpm lint` pass. The web app is untouched: same URLs, same routing, same `[id]` route folder, so opening a résumé from the grid, the sidebar, the create dialog, the import panel, the landing try-it button, and the not-found suggestion all behave exactly as before.

No changelog entry, since nothing changed for a user. README, AGENTS.md, and design.md stay accurate: no new dependency, route, script, or field shape.
