### PR TITLE
feat: add a standalone feedback route with query prefill

### DIFF
--- a/design.md
+++ b/design.md
@@ -21,6 +21,10 @@ editorial
 - App pages (`/platform`, `/platform/template`): **Workbench-minimal**. A page header
   (title + hairline rule) over a toolbar over a grid. Function carries the page; no
   enrichment, no display serif.
+- Utility pages (`/feedback`): **Workbench-minimal**, single column, capped at
+  `max-w-xl`. A kind switch over a heading over the form. Reached from the
+  sidebar dialogs' own surface or opened directly by the desktop app, which
+  passes `kind`, `area`, and `client` as search params.
 - Content pages: none currently.
 
 ## Theme — "evergreen broadsheet"

--- a/messages/en.json
+++ b/messages/en.json
@@ -585,6 +585,14 @@
       "errorInvalidData": "This file isn't a valid resume export."
     }
   },
+  "feedback": {
+    "metaTitle": "Send feedback",
+    "metaDescription": "Report a bug or request a feature. We file the GitHub issue for you, so no account is needed.",
+    "kindLabel": "Choose bug report or feature request",
+    "sentTitle": "Thank you",
+    "sentBody": "We filed the GitHub issue for you. You can close this window.",
+    "sendAnother": "Send another"
+  },
   "editor": {
     "common": {
       "add": "Add"

--- a/messages/id.json
+++ b/messages/id.json
@@ -585,6 +585,14 @@
       "errorInvalidData": "File ini bukan ekspor resume yang valid."
     }
   },
+  "feedback": {
+    "metaTitle": "Kirim masukan",
+    "metaDescription": "Laporkan bug atau ajukan fitur. Kami yang membuatkan issue GitHub-nya, jadi kamu tidak perlu akun.",
+    "kindLabel": "Pilih laporan bug atau permintaan fitur",
+    "sentTitle": "Terima kasih",
+    "sentBody": "Issue GitHub sudah kami buatkan. Jendela ini boleh kamu tutup.",
+    "sendAnother": "Kirim lagi"
+  },
   "editor": {
     "common": {
       "add": "Tambah"

--- a/src/app/[locale]/feedback/page.tsx
+++ b/src/app/[locale]/feedback/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+import { Suspense } from "react";
+import { FeedbackPanel } from "@/components/feedback/feedback-panel";
+
+export async function generateMetadata(props: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await props.params;
+  const t = await getTranslations({ locale, namespace: "feedback" });
+  return { title: t("metaTitle"), description: t("metaDescription") };
+}
+
+export default function FeedbackPage() {
+  return (
+    <Suspense>
+      <FeedbackPanel />
+    </Suspense>
+  );
+}

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -56,7 +56,7 @@ function buildIssue(
         "### Area",
         payload.area,
         "### Browser and OS",
-        browser ?? "_Unknown._",
+        payload.client ?? browser ?? "_Unknown._",
         reportedBy(payload.name),
       ].join("\n\n"),
     };

--- a/src/components/feedback/feedback-bug-report-form.tsx
+++ b/src/components/feedback/feedback-bug-report-form.tsx
@@ -1,11 +1,15 @@
 "use client";
 
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
-import { ExternalLink, SendIcon, XIcon } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { type FormEvent, useMemo, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { toast } from "sonner";
+import {
+  useFeedbackArea,
+  useFeedbackClient,
+} from "@/hooks/use-feedback-params";
 import { useValidationTranslator } from "@/hooks/use-validation-translator";
 import { usePathname } from "@/i18n/navigation";
 import {
@@ -27,10 +31,6 @@ import {
 } from "@/lib/resume/rich-content";
 import { PROSE_FEATURES } from "@/lib/resume/schema-registry";
 import { RichTextEditor } from "../editor/rich-text/rich-text-editor";
-import {
-  ResponsiveDialogClose,
-  ResponsiveDialogFooter,
-} from "../shared/responsive-dialog";
 import { TURNSTILE_SITE_KEY, Turnstile } from "../shared/turnstile";
 import { Button } from "../ui/button";
 import {
@@ -50,26 +50,33 @@ import {
   SelectTrigger,
   SelectValue,
 } from "../ui/select";
-import { Spinner } from "../ui/spinner";
+import { FeedbackFormActions } from "./feedback-form-actions";
+import {
+  FEEDBACK_SURFACE_CLASS,
+  type FeedbackSurface,
+} from "./feedback-surface";
 
-interface PlatformBugReportFormProps {
+interface FeedbackBugReportFormProps {
+  surface: FeedbackSurface;
   onSubmitted: () => void;
 }
 
-export function PlatformBugReportForm(props: PlatformBugReportFormProps) {
+export function FeedbackBugReportForm(props: FeedbackBugReportFormProps) {
   const pathname = usePathname();
+  const prefilledArea = useFeedbackArea();
+  const client = useFeedbackClient();
   const t = useTranslations("forms.bug");
-  const tc = useTranslations("forms.common");
   const td = useTranslations("forms.direct");
   const tv = useValidationTranslator();
   const schema = useMemo(() => createBugReportSchema(tv), [tv]);
   const [turnstileEpoch, setTurnstileEpoch] = useState(0);
   const directEnabled = Boolean(TURNSTILE_SITE_KEY);
+  const surfaceClass = FEEDBACK_SURFACE_CLASS[props.surface];
   const form = useForm<BugReportForm>({
     resolver: standardSchemaResolver(schema),
     defaultValues: {
       name: "",
-      area: areaForPathname(pathname),
+      area: prefilledArea ?? areaForPathname(pathname),
       whatHappened: emptyRichTextValue(),
       turnstileToken: "",
     },
@@ -83,6 +90,7 @@ export function PlatformBugReportForm(props: PlatformBugReportFormProps) {
     const result = await submitFeedback({
       kind: "bug",
       name: values.name,
+      client,
       turnstileToken: values.turnstileToken,
       summary: summary.slice(0, 120),
       whatHappened: richBlocksToMarkdown(whatHappened),
@@ -123,11 +131,8 @@ export function PlatformBugReportForm(props: PlatformBugReportFormProps) {
   }
 
   return (
-    <form
-      onSubmit={handleSubmit}
-      className="md:grid md:min-h-0 md:flex-1 md:grid-rows-[minmax(0,1fr)_auto]"
-    >
-      <ScrollArea className="md:-mr-2 md:min-h-0 md:pr-2">
+    <form onSubmit={handleSubmit} className={surfaceClass.form}>
+      <ScrollArea className={surfaceClass.fields}>
         <FieldGroup className="px-1 py-2">
           {directEnabled && (
             <Controller
@@ -227,7 +232,7 @@ export function PlatformBugReportForm(props: PlatformBugReportFormProps) {
             <Button
               type="button"
               variant="link"
-              className="h-auto self-start p-0"
+              className="h-auto items-start self-start whitespace-normal p-0 text-left"
               disabled={form.formState.isSubmitting}
               onClick={openGitHubIssue}
             >
@@ -237,22 +242,11 @@ export function PlatformBugReportForm(props: PlatformBugReportFormProps) {
         </FieldGroup>
       </ScrollArea>
 
-      <ResponsiveDialogFooter className="mt-4 border-t pt-4 md:shrink-0">
-        <ResponsiveDialogClose type="button" variant="outline">
-          <XIcon /> {tc("cancel")}
-        </ResponsiveDialogClose>
-        {directEnabled ? (
-          <Button type="submit" disabled={form.formState.isSubmitting}>
-            {form.formState.isSubmitting ? <Spinner /> : <SendIcon />}
-            {td("send")}
-          </Button>
-        ) : (
-          <Button type="submit">
-            <ExternalLink />
-            {tc("openIssue")}
-          </Button>
-        )}
-      </ResponsiveDialogFooter>
+      <FeedbackFormActions
+        surface={props.surface}
+        directEnabled={directEnabled}
+        submitting={form.formState.isSubmitting}
+      />
     </form>
   );
 }

--- a/src/components/feedback/feedback-feature-request-form.tsx
+++ b/src/components/feedback/feedback-feature-request-form.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
-import { ExternalLink, SendIcon, XIcon } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { type FormEvent, useMemo, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { toast } from "sonner";
+import { useFeedbackClient } from "@/hooks/use-feedback-params";
 import { useValidationTranslator } from "@/hooks/use-validation-translator";
 import {
   createFeatureRequestSchema,
@@ -25,10 +26,6 @@ import {
 } from "@/lib/resume/rich-content";
 import { PROSE_FEATURES } from "@/lib/resume/schema-registry";
 import { RichTextEditor } from "../editor/rich-text/rich-text-editor";
-import {
-  ResponsiveDialogClose,
-  ResponsiveDialogFooter,
-} from "../shared/responsive-dialog";
 import { TURNSTILE_SITE_KEY, Turnstile } from "../shared/turnstile";
 import { Button } from "../ui/button";
 import {
@@ -48,22 +45,28 @@ import {
   SelectTrigger,
   SelectValue,
 } from "../ui/select";
-import { Spinner } from "../ui/spinner";
+import { FeedbackFormActions } from "./feedback-form-actions";
+import {
+  FEEDBACK_SURFACE_CLASS,
+  type FeedbackSurface,
+} from "./feedback-surface";
 
-interface PlatformFeatureRequestFormProps {
+interface FeedbackFeatureRequestFormProps {
+  surface: FeedbackSurface;
   onSubmitted: () => void;
 }
 
-export function PlatformFeatureRequestForm(
-  props: PlatformFeatureRequestFormProps,
+export function FeedbackFeatureRequestForm(
+  props: FeedbackFeatureRequestFormProps,
 ) {
   const t = useTranslations("forms.feature");
-  const tc = useTranslations("forms.common");
   const td = useTranslations("forms.direct");
+  const client = useFeedbackClient();
   const tv = useValidationTranslator();
   const schema = useMemo(() => createFeatureRequestSchema(tv), [tv]);
   const [turnstileEpoch, setTurnstileEpoch] = useState(0);
   const directEnabled = Boolean(TURNSTILE_SITE_KEY);
+  const surfaceClass = FEEDBACK_SURFACE_CLASS[props.surface];
   const form = useForm<FeatureRequestForm>({
     resolver: standardSchemaResolver(schema),
     defaultValues: {
@@ -82,6 +85,7 @@ export function PlatformFeatureRequestForm(
     const result = await submitFeedback({
       kind: "feature",
       name: values.name,
+      client,
       turnstileToken: values.turnstileToken,
       summary: summary.slice(0, 120),
       problem: richBlocksToMarkdown(problem),
@@ -122,11 +126,8 @@ export function PlatformFeatureRequestForm(
   }
 
   return (
-    <form
-      onSubmit={handleSubmit}
-      className="md:grid md:min-h-0 md:flex-1 md:grid-rows-[minmax(0,1fr)_auto]"
-    >
-      <ScrollArea className="md:-mr-2 md:min-h-0 md:pr-2">
+    <form onSubmit={handleSubmit} className={surfaceClass.form}>
+      <ScrollArea className={surfaceClass.fields}>
         <FieldGroup className="px-1 py-2">
           {directEnabled && (
             <Controller
@@ -224,7 +225,7 @@ export function PlatformFeatureRequestForm(
             <Button
               type="button"
               variant="link"
-              className="h-auto self-start p-0"
+              className="h-auto items-start self-start whitespace-normal p-0 text-left"
               disabled={form.formState.isSubmitting}
               onClick={openGitHubIssue}
             >
@@ -234,22 +235,11 @@ export function PlatformFeatureRequestForm(
         </FieldGroup>
       </ScrollArea>
 
-      <ResponsiveDialogFooter className="mt-4 border-t pt-4 md:shrink-0">
-        <ResponsiveDialogClose type="button" variant="outline">
-          <XIcon /> {tc("cancel")}
-        </ResponsiveDialogClose>
-        {directEnabled ? (
-          <Button type="submit" disabled={form.formState.isSubmitting}>
-            {form.formState.isSubmitting ? <Spinner /> : <SendIcon />}
-            {td("send")}
-          </Button>
-        ) : (
-          <Button type="submit">
-            <ExternalLink />
-            {tc("openIssue")}
-          </Button>
-        )}
-      </ResponsiveDialogFooter>
+      <FeedbackFormActions
+        surface={props.surface}
+        directEnabled={directEnabled}
+        submitting={form.formState.isSubmitting}
+      />
     </form>
   );
 }

--- a/src/components/feedback/feedback-form-actions.tsx
+++ b/src/components/feedback/feedback-form-actions.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { ExternalLink, SendIcon, XIcon } from "lucide-react";
+import { useTranslations } from "next-intl";
+import {
+  ResponsiveDialogClose,
+  ResponsiveDialogFooter,
+} from "../shared/responsive-dialog";
+import { Button } from "../ui/button";
+import { Spinner } from "../ui/spinner";
+import type { FeedbackSurface } from "./feedback-surface";
+
+interface FeedbackFormActionsProps {
+  surface: FeedbackSurface;
+  directEnabled: boolean;
+  submitting: boolean;
+}
+
+export function FeedbackFormActions(props: FeedbackFormActionsProps) {
+  const tc = useTranslations("forms.common");
+  const td = useTranslations("forms.direct");
+
+  const submit = props.directEnabled ? (
+    <Button type="submit" disabled={props.submitting}>
+      {props.submitting ? <Spinner /> : <SendIcon />}
+      {td("send")}
+    </Button>
+  ) : (
+    <Button type="submit">
+      <ExternalLink />
+      {tc("openIssue")}
+    </Button>
+  );
+
+  if (props.surface === "page") {
+    return (
+      <div className="mt-4 flex shrink-0 justify-end border-t pt-4">
+        {submit}
+      </div>
+    );
+  }
+
+  return (
+    <ResponsiveDialogFooter className="mt-4 border-t pt-4 md:shrink-0">
+      <ResponsiveDialogClose type="button" variant="outline">
+        <XIcon /> {tc("cancel")}
+      </ResponsiveDialogClose>
+      {submit}
+    </ResponsiveDialogFooter>
+  );
+}

--- a/src/components/feedback/feedback-panel-switch.tsx
+++ b/src/components/feedback/feedback-panel-switch.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useFeedbackKind } from "@/hooks/use-feedback-params";
+import { SegmentedControl } from "../shared/segmented-control";
+
+/** Chooses between the bug report and the feature request on the page surface. */
+export function FeedbackPanelSwitch() {
+  const [kind, setKind] = useFeedbackKind();
+  const t = useTranslations("feedback");
+  const tb = useTranslations("forms.bug");
+  const tf = useTranslations("forms.feature");
+
+  return (
+    <SegmentedControl
+      aria-label={t("kindLabel")}
+      value={kind}
+      onValueChange={(next) => void setKind(next === "feature" ? next : "bug")}
+      items={[
+        { value: "bug", label: tb("title") },
+        { value: "feature", label: tf("title") },
+      ]}
+    />
+  );
+}

--- a/src/components/feedback/feedback-panel.tsx
+++ b/src/components/feedback/feedback-panel.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { CheckCircle2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { useFeedbackKind } from "@/hooks/use-feedback-params";
+import { TURNSTILE_SITE_KEY } from "../shared/turnstile";
+import { Alert, AlertDescription, AlertTitle } from "../ui/alert";
+import { Button } from "../ui/button";
+import { FeedbackBugReportForm } from "./feedback-bug-report-form";
+import { FeedbackFeatureRequestForm } from "./feedback-feature-request-form";
+import { FeedbackPanelSwitch } from "./feedback-panel-switch";
+
+/**
+ * The standalone feedback surface. The desktop app has no server of its own, so
+ * it opens this page on the hosted site where Turnstile and /api/feedback work,
+ * naming the kind, area, and client build in the query string.
+ */
+export function FeedbackPanel() {
+  const [kind] = useFeedbackKind();
+  const [sent, setSent] = useState(false);
+  const t = useTranslations("feedback");
+  const tk = useTranslations(kind === "bug" ? "forms.bug" : "forms.feature");
+
+  if (sent) {
+    return (
+      <div className="mx-auto flex w-full max-w-xl flex-col gap-4 px-4 py-10">
+        <Alert>
+          <CheckCircle2 />
+          <AlertTitle>{t("sentTitle")}</AlertTitle>
+          <AlertDescription>{t("sentBody")}</AlertDescription>
+        </Alert>
+        <Button
+          variant="outline"
+          className="self-start"
+          onClick={() => setSent(false)}
+        >
+          {t("sendAnother")}
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-xl flex-col gap-6 px-4 py-10">
+      <FeedbackPanelSwitch />
+
+      <div className="flex flex-col gap-1.5">
+        <h1 className="font-semibold text-2xl tracking-tight">{tk("title")}</h1>
+        <p className="text-balance text-muted-foreground text-sm">
+          {tk(TURNSTILE_SITE_KEY ? "description" : "descriptionGitHubOnly")}
+        </p>
+      </div>
+
+      {kind === "bug" ? (
+        <FeedbackBugReportForm
+          surface="page"
+          onSubmitted={() => setSent(true)}
+        />
+      ) : (
+        <FeedbackFeatureRequestForm
+          surface="page"
+          onSubmitted={() => setSent(true)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/feedback/feedback-surface.ts
+++ b/src/components/feedback/feedback-surface.ts
@@ -1,0 +1,17 @@
+/**
+ * Where a feedback form is mounted. The dialog caps its own height and scrolls
+ * the fields inside it; the page has no height to cap, so the same classes
+ * would collapse the form to nothing and it lets the fields flow instead.
+ */
+export type FeedbackSurface = "dialog" | "page";
+
+export const FEEDBACK_SURFACE_CLASS: Record<
+  FeedbackSurface,
+  { form: string; fields: string }
+> = {
+  dialog: {
+    form: "md:grid md:min-h-0 md:flex-1 md:grid-rows-[minmax(0,1fr)_auto]",
+    fields: "md:-mr-2 md:min-h-0 md:pr-2",
+  },
+  page: { form: "", fields: "" },
+};

--- a/src/components/platform/platform-bug-report-dialog.tsx
+++ b/src/components/platform/platform-bug-report-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslations } from "next-intl";
 import { useIssueReportStore } from "@/lib/store";
+import { FeedbackBugReportForm } from "../feedback/feedback-bug-report-form";
 import {
   ResponsiveDialog,
   ResponsiveDialogContent,
@@ -10,7 +11,6 @@ import {
   ResponsiveDialogTitle,
 } from "../shared/responsive-dialog";
 import { TURNSTILE_SITE_KEY } from "../shared/turnstile";
-import { PlatformBugReportForm } from "./platform-bug-report-form";
 
 /**
  * Rendered once at the platform layout level, outside the sidebar: on mobile
@@ -35,7 +35,10 @@ export function PlatformBugReportDialog() {
           </ResponsiveDialogDescription>
         </ResponsiveDialogHeader>
 
-        <PlatformBugReportForm onSubmitted={() => setOpen(null)} />
+        <FeedbackBugReportForm
+          surface="dialog"
+          onSubmitted={() => setOpen(null)}
+        />
       </ResponsiveDialogContent>
     </ResponsiveDialog>
   );

--- a/src/components/platform/platform-feature-request-dialog.tsx
+++ b/src/components/platform/platform-feature-request-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslations } from "next-intl";
 import { useIssueReportStore } from "@/lib/store";
+import { FeedbackFeatureRequestForm } from "../feedback/feedback-feature-request-form";
 import {
   ResponsiveDialog,
   ResponsiveDialogContent,
@@ -10,7 +11,6 @@ import {
   ResponsiveDialogTitle,
 } from "../shared/responsive-dialog";
 import { TURNSTILE_SITE_KEY } from "../shared/turnstile";
-import { PlatformFeatureRequestForm } from "./platform-feature-request-form";
 
 /**
  * Rendered once at the platform layout level, outside the sidebar: on mobile
@@ -35,7 +35,10 @@ export function PlatformFeatureRequestDialog() {
           </ResponsiveDialogDescription>
         </ResponsiveDialogHeader>
 
-        <PlatformFeatureRequestForm onSubmitted={() => setOpen(null)} />
+        <FeedbackFeatureRequestForm
+          surface="dialog"
+          onSubmitted={() => setOpen(null)}
+        />
       </ResponsiveDialogContent>
     </ResponsiveDialog>
   );

--- a/src/hooks/use-feedback-params.ts
+++ b/src/hooks/use-feedback-params.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { parseAsString, parseAsStringLiteral, useQueryState } from "nuqs";
+import { BUG_AREAS } from "@/lib/forms/bug-report";
+
+export const FEEDBACK_KINDS = ["bug", "feature"] as const;
+
+/** Which form the /feedback page opens on. Absent inside the platform dialogs. */
+export function useFeedbackKind() {
+  return useQueryState(
+    "kind",
+    parseAsStringLiteral(FEEDBACK_KINDS).withDefault("bug"),
+  );
+}
+
+/**
+ * Bug area prefilled from the URL. The /feedback page is opened from elsewhere
+ * (the desktop app's feedback window), so the caller names the area it was on
+ * instead of the page guessing from its own pathname.
+ */
+export function useFeedbackArea() {
+  const [area] = useQueryState("area", parseAsStringLiteral(BUG_AREAS));
+  return area;
+}
+
+/**
+ * Which build sent the report, e.g. "desktop 0.15.0 macOS 15". The web app
+ * leaves this unset and the server falls back to the user-agent header.
+ */
+export function useFeedbackClient() {
+  const [client] = useQueryState("client", parseAsString);
+  return client?.trim() ? client.trim().slice(0, 120) : undefined;
+}

--- a/src/lib/forms/feedback.ts
+++ b/src/lib/forms/feedback.ts
@@ -5,12 +5,15 @@ import { FEATURE_LAYERS } from "./feature-request";
 const reporterName = z.string().trim().min(1).max(80);
 const summary = z.string().trim().min(1).max(120);
 const requiredMarkdown = z.string().trim().min(1).max(8000);
+/** Which build sent the report, e.g. "desktop 0.15.0 macOS 15". Absent on the web. */
+const client = z.string().trim().min(1).max(120).optional();
 
 /** Wire format for POST /api/feedback; validated again on the server. */
 export const feedbackPayloadSchema = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("bug"),
     name: reporterName,
+    client,
     turnstileToken: z.string().min(1),
     summary,
     whatHappened: requiredMarkdown,
@@ -19,6 +22,7 @@ export const feedbackPayloadSchema = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("feature"),
     name: reporterName,
+    client,
     turnstileToken: z.string().min(1),
     summary,
     problem: requiredMarkdown,


### PR DESCRIPTION
Adds `/[locale]/feedback`, a plain page around the same bug report and feature request forms the platform sidebar dialogs already use. The dialogs are unchanged and keep working exactly as before; this adds a second surface rather than replacing the first.

The two forms move from `src/components/platform/` into a new `src/components/feedback/` domain folder. They were named for the platform sidebar because that was the only place they appeared. A standalone route makes feedback their real domain.

Each form now takes a `surface` prop, because the two surfaces differ in two ways. The dialog footer reads the responsive dialog's context for its close button, so a page has nothing to close and supplies a plain footer instead. The dialog also caps its own height and scrolls the fields inside it; a page has no height to cap, and those same classes collapse the form to nothing.

The page reads three search params through nuqs. `kind` chooses which form to show, `area` prefills the bug area, and `client` names the build that sent the report. `client` is new on the wire format, is optional, and replaces the user-agent line in the issue body when present.

## Why

Preparation for the Tauri desktop build in #162. The desktop app ships no server of its own, so it cannot host the feedback route. Turnstile only accepts fully qualified domain names, and the desktop origin is `tauri://localhost` or `http://tauri.localhost`, neither of which can be allowlisted. The desktop app therefore opens this page on the hosted site in a second window, where Turnstile and the existing route work unchanged, and names the kind, area, and client build in the query string.

## Testing

Typecheck, lint, and a production build all pass. `/en/feedback` and `/id/feedback` prerender as static pages.

The page was checked at 1440x960 and at 390x844. The form renders at 544x476 on the wide layout and does not collapse. Switching between the bug report and the feature request updates the address and the heading. Opening the page with `area=Editor` prefills the area. Nothing overflows horizontally at the narrow width. The Indonesian locale renders in Indonesian.

That check also found a bug, fixed here: the "open a prefilled issue" link could not wrap, because the button base style sets `whitespace-nowrap`. At 390px the link measured 391px wide, and the scroll area clipped it with no way to reveal the rest of the sentence. It now wraps. This was latent in the mobile drawer as well, so the dialogs get the fix too.
