### PR TITLE
fix: save exported files from the desktop app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,10 @@ The one shipped example of that carve-out is the opt-in header photo: off by def
   either orphans the résumés of everyone who already installed the app.
 - The window opens on `/en/platform/`. Tauri resolves a directory path by falling back
   to `<path>/index.html`, which is why the desktop build sets `trailingSlash`.
+- Every file the app hands to a user goes through `triggerDownload` in
+  `src/components/editor/download-file.ts`. A new export format that builds its own
+  anchor will work on the web and do nothing at all in the desktop app. The function
+  resolves false when the user cancels the save dialog, which is not an error.
 - Biome ignores `src-tauri`. Rust is formatted by `cargo fmt`, and the JSON config files
   are written by the Tauri CLI.
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "@opennextjs/cloudflare": "^1.20.1",
     "@react-pdf/renderer": "^4.5.1",
     "@shadcn/react": "^0.2.0",
+    "@tauri-apps/plugin-dialog": "^2.7.3",
+    "@tauri-apps/plugin-fs": "^2.5.2",
     "@tauri-apps/plugin-opener": "^2.5.5",
     "@tiptap/core": "^3.27.1",
     "@tiptap/extension-bold": "^3.27.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,12 @@ importers:
       '@shadcn/react':
         specifier: ^0.2.0
         version: 0.2.0(@types/react@19.2.17)(react@19.2.4)
+      '@tauri-apps/plugin-dialog':
+        specifier: ^2.7.3
+        version: 2.7.3
+      '@tauri-apps/plugin-fs':
+        specifier: ^2.5.2
+        version: 2.5.2
       '@tauri-apps/plugin-opener':
         specifier: ^2.5.5
         version: 2.5.5
@@ -2472,6 +2478,12 @@ packages:
     resolution: {integrity: sha512-R8xGtMpwyetawSqm9kYOuMmEqkhUbvcUy8n0aNXIxollKBLESUu5f4Fx+64hgASYm1H+jSWq6jCW6zqTnH6hqQ==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-dialog@2.7.3':
+    resolution: {integrity: sha512-CRgE+7TP4tvq9MjBU6f04NLTFIqVMLKHk3hAqlhil00ngK9ACTrXPH3oHpKMProxILodd3YjBoKbMwSI4IEcfA==}
+
+  '@tauri-apps/plugin-fs@2.5.2':
+    resolution: {integrity: sha512-XXvMSnFiob+G1H+YHCDf+bzWVumseQuEIhzpbOJzevUfL4k0U+sTApZWJHpoLiamggnVPJm5dJ5sDsniRyWxlg==}
 
   '@tauri-apps/plugin-opener@2.5.5':
     resolution: {integrity: sha512-xvzGai5aQds8j8R8RsUK/lW6pGG50YgOYIPLzvkqmkwAj7dfySOD7sGtejRzvVdMmv1EQfKVEFh1MvmDp8QR0g==}
@@ -7619,6 +7631,14 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.4
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.4
       '@tauri-apps/cli-win32-x64-msvc': 2.11.4
+
+  '@tauri-apps/plugin-dialog@2.7.3':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
+
+  '@tauri-apps/plugin-fs@2.5.2':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-opener@2.5.5':
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1935,6 +1935,8 @@ version = "0.0.0"
 dependencies = [
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
+ "tauri-plugin-fs",
  "tauri-plugin-opener",
 ]
 
@@ -2297,6 +2299,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.2",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2826,6 +2829,30 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3521,6 +3548,48 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61854a36651aa48381e5e209f69a01273b77f3f9f91f0c430b1b98d33bd47229"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.20",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de22eef34fd78c0da050e748710edd50bf127e651d02ea1b2bfada1523cc5c51"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.20",
+ "toml 1.1.6+spec-1.1.0",
+ "url",
 ]
 
 [[package]]
@@ -4573,6 +4642,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4604,11 +4682,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4642,6 +4737,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4652,6 +4753,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4666,10 +4773,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4684,6 +4803,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4694,6 +4819,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4708,6 +4839,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4718,6 +4855,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,6 +15,8 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 tauri = { version = "2", features = [] }
+tauri-plugin-dialog = "2"
+tauri-plugin-fs = "2"
 tauri-plugin-opener = "2"
 
 [profile.release]

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -12,6 +12,8 @@
           "url": "https://*"
         }
       ]
-    }
+    },
+    "dialog:allow-save",
+    "fs:allow-write-file"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,7 @@
 pub fn run() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_opener::init())
         .run(tauri::generate_context!())
         .expect("error while running lanjut");

--- a/src/components/editor/docx/download-resume-docx.ts
+++ b/src/components/editor/docx/download-resume-docx.ts
@@ -11,7 +11,7 @@ import { buildAwalDocx } from "./resume-to-docx";
 export async function downloadResumeDocx(
   preview: ResumePreview,
   fileName: string,
-): Promise<void> {
+): Promise<boolean> {
   const blob = await Packer.toBlob(buildAwalDocx(preview));
-  triggerDownload(blob, `${safeFileName(fileName)}.docx`);
+  return triggerDownload(blob, `${safeFileName(fileName)}.docx`);
 }

--- a/src/components/editor/download-file.ts
+++ b/src/components/editor/download-file.ts
@@ -1,3 +1,5 @@
+import { IS_DESKTOP } from "@/lib/build-target";
+
 /**
  * Sanitizes a user-typed file name: strips characters illegal in file names and
  * a redundant trailing extension, preserving spaces and case. Falls back to
@@ -11,12 +13,58 @@ export function safeFileName(name: string): string {
   return cleaned || "resume";
 }
 
-/** Triggers a browser download of `blob` as `fileName`, revoking the object URL. */
-export function triggerDownload(blob: Blob, fileName: string): void {
+const EXTENSION_LABEL: Record<string, string> = {
+  pdf: "PDF document",
+  docx: "Word document",
+  txt: "Plain text",
+  json: "JSON",
+  yaml: "YAML",
+};
+
+async function saveThroughDialog(blob: Blob, fileName: string) {
+  const [{ save }, { writeFile }] = await Promise.all([
+    import("@tauri-apps/plugin-dialog"),
+    import("@tauri-apps/plugin-fs"),
+  ]);
+
+  const extension = fileName.split(".").pop() ?? "";
+  const path = await save({
+    defaultPath: fileName,
+    filters: extension
+      ? [
+          {
+            name: EXTENSION_LABEL[extension] ?? extension,
+            extensions: [extension],
+          },
+        ]
+      : [],
+  });
+  if (!path) return false;
+
+  await writeFile(path, new Uint8Array(await blob.arrayBuffer()));
+  return true;
+}
+
+/**
+ * Writes `blob` out as `fileName`. Resolves false when the user backs out.
+ *
+ * The browser takes an anchor click and drops the file in its download
+ * directory. The system webview ignores that click entirely, so the desktop
+ * build asks for a destination and writes the bytes itself. The save dialog
+ * grants filesystem access to the chosen file alone, which is why this needs no
+ * broad write permission.
+ */
+export async function triggerDownload(
+  blob: Blob,
+  fileName: string,
+): Promise<boolean> {
+  if (IS_DESKTOP) return saveThroughDialog(blob, fileName);
+
   const url = URL.createObjectURL(blob);
   const anchor = document.createElement("a");
   anchor.href = url;
   anchor.download = fileName;
   anchor.click();
   URL.revokeObjectURL(url);
+  return true;
 }

--- a/src/components/editor/download-resume-json.ts
+++ b/src/components/editor/download-resume-json.ts
@@ -6,9 +6,12 @@ import { safeFileName, triggerDownload } from "./download-file";
  * Serializes the full document (not the preview projection) to interchange
  * JSON and downloads it as `<fileName>.json`, so the file re-imports losslessly.
  */
-export function downloadResumeJson(resume: Resume, fileName: string): void {
+export async function downloadResumeJson(
+  resume: Resume,
+  fileName: string,
+): Promise<boolean> {
   const blob = new Blob([resumeToJson(resume)], {
     type: "application/json;charset=utf-8",
   });
-  triggerDownload(blob, `${safeFileName(fileName)}.json`);
+  return triggerDownload(blob, `${safeFileName(fileName)}.json`);
 }

--- a/src/components/editor/download-resume-text.ts
+++ b/src/components/editor/download-resume-text.ts
@@ -3,12 +3,12 @@ import type { ResumePreview } from "./resume-preview";
 import { resumeToText } from "./resume-to-text";
 
 /** Serializes `preview` to plain text and downloads it as `<fileName>.txt`. */
-export function downloadResumeText(
+export async function downloadResumeText(
   preview: ResumePreview,
   fileName: string,
-): void {
+): Promise<boolean> {
   const blob = new Blob([resumeToText(preview)], {
     type: "text/plain;charset=utf-8",
   });
-  triggerDownload(blob, `${safeFileName(fileName)}.txt`);
+  return triggerDownload(blob, `${safeFileName(fileName)}.txt`);
 }

--- a/src/components/editor/download-resume-yaml.ts
+++ b/src/components/editor/download-resume-yaml.ts
@@ -6,9 +6,12 @@ import { safeFileName, triggerDownload } from "./download-file";
  * Serializes the full document (not the preview projection) to interchange
  * YAML and downloads it as `<fileName>.yaml`, so the file re-imports losslessly.
  */
-export function downloadResumeYaml(resume: Resume, fileName: string): void {
+export async function downloadResumeYaml(
+  resume: Resume,
+  fileName: string,
+): Promise<boolean> {
   const blob = new Blob([resumeToYaml(resume)], {
     type: "text/yaml;charset=utf-8",
   });
-  triggerDownload(blob, `${safeFileName(fileName)}.yaml`);
+  return triggerDownload(blob, `${safeFileName(fileName)}.yaml`);
 }

--- a/src/components/editor/download-resume.ts
+++ b/src/components/editor/download-resume.ts
@@ -13,37 +13,33 @@ export async function downloadResume(
   resume: Resume,
   format: ExportFormat,
   fileName: string,
-): Promise<void> {
+): Promise<boolean> {
   if (format === "json") {
     const { downloadResumeJson } = await import("./download-resume-json");
-    downloadResumeJson(resume, fileName);
-    return;
+    return downloadResumeJson(resume, fileName);
   }
 
   if (format === "yaml") {
     const { downloadResumeYaml } = await import("./download-resume-yaml");
-    downloadResumeYaml(resume, fileName);
-    return;
+    return downloadResumeYaml(resume, fileName);
   }
 
   const preview = resumeToPreview(resume);
 
   if (format === "pdf") {
     const { downloadResumePdf } = await import("./pdf/download-resume-pdf");
-    await downloadResumePdf(
+    return downloadResumePdf(
       preview,
       fileName,
       resolveTemplateId(resume.templateId),
     );
-    return;
   }
 
   if (format === "docx") {
     const { downloadResumeDocx } = await import("./docx/download-resume-docx");
-    await downloadResumeDocx(preview, fileName);
-    return;
+    return downloadResumeDocx(preview, fileName);
   }
 
   const { downloadResumeText } = await import("./download-resume-text");
-  downloadResumeText(preview, fileName);
+  return downloadResumeText(preview, fileName);
 }

--- a/src/components/editor/pdf/download-resume-pdf.tsx
+++ b/src/components/editor/pdf/download-resume-pdf.tsx
@@ -15,9 +15,9 @@ export async function downloadResumePdf(
   preview: ResumePreview,
   fileName: string,
   template: TemplateId,
-): Promise<void> {
+): Promise<boolean> {
   registerPdfFonts();
   const PdfDocument = TEMPLATE_PDF_DOCUMENTS[template];
   const blob = await pdf(<PdfDocument preview={preview} />).toBlob();
-  triggerDownload(blob, `${safeFileName(fileName)}.pdf`);
+  return triggerDownload(blob, `${safeFileName(fileName)}.pdf`);
 }

--- a/src/components/editor/resume-exporter.tsx
+++ b/src/components/editor/resume-exporter.tsx
@@ -29,7 +29,7 @@ export function ResumeExporter({ request, onSettled }: ResumeExporterProps) {
     if (startedFor.current === request) return;
     startedFor.current = request;
     downloadResume(request.resume, request.format, request.fileName)
-      .then(() => onSettled(true))
+      .then((saved) => onSettled(saved))
       .catch(() => onSettled(false));
   }, [request, onSettled]);
 


### PR DESCRIPTION
Every export was silently doing nothing in the desktop app. The browser takes an anchor click and drops the file in its download directory. The system webview ignores that click entirely, so PDF, DOCX, TXT, JSON, and YAML all appeared to succeed and produced no file.

Silent is the worst part. Nothing failed, nothing was reported, and the only symptom was an absent file.

Groundwork for #162.

## The fix

The desktop build now asks for a destination and writes the bytes itself.

All five formats already funnelled through `triggerDownload`, so that one function is the only place this had to change. The per-format modules keep their own logic and simply return what it resolves.

## Filesystem permission

The save dialog grants access to the file the user picked, and nothing else. The capability therefore declares no write scope of its own.

This is worth stating plainly, because the obvious alternative is worse. A wildcard over the home directory would hand the app permanent write access to everything the user owns, in order to support a feature that writes a single chosen file. The dialog already scopes itself at the moment of choosing, so the broad grant buys nothing and risks a lot.

## Cancelling

Backing out of the save dialog is not a failure, and it is a state the export flow never had before. `triggerDownload` now resolves false rather than true, which the flow already treated as "did not complete": the download dialog stays open and nothing is reported to the user.

That required no new state. The five format functions and the dispatcher thread the result through to the existing flag.

## Documentation

AGENTS.md gains the rule that every file handed to a user goes through `triggerDownload`. A future export format that builds its own anchor would work on the web and do nothing in the desktop app, which is exactly this bug waiting to happen again.

## Testing

Both build targets compile. Typecheck and lint pass. The Tauri packages do not appear in the web bundle.

The export validation suite still passes, so reading order and field mapping are unchanged across every template PDF, DOCX, and TXT.

Saving a file and cancelling the dialog have not yet been exercised in the running desktop app.
