### PR TITLE
ci: build and publish the macos desktop app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,45 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm exec opennextjs-cloudflare build
+
+  desktop:
+    # The desktop app is not covered by the checks job, and a broken Rust shell or
+    # a misplaced static export is invisible to lint and typecheck. This builds
+    # both halves on a clean checkout, which is the only place a stale local
+    # artifact cannot hide a fault.
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build the static export
+        run: pnpm build
+        env:
+          LANJUT_TARGET: desktop
+
+      - name: Confirm the export is where the app loads it from
+        run: |
+          set -euo pipefail
+          dist=$(node -p "require('./src-tauri/tauri.conf.json').build.frontendDist")
+          resolved="src-tauri/${dist}"
+          test -f "${resolved}/en/platform/index.html" \
+            || { echo "frontendDist ${dist} has no exported page"; exit 1; }
+          test -f "${resolved}/splashscreen.html" \
+            || { echo "frontendDist ${dist} has no splash screen"; exit 1; }
+
+      - name: Build the desktop shell
+        run: cargo build --manifest-path src-tauri/Cargo.toml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+      release_id: ${{ steps.release.outputs.id }}
     steps:
       - id: release
         uses: googleapis/release-please-action@v5
@@ -50,3 +51,43 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+  desktop:
+    # Attaches the macOS app to the release release-please just created. One
+    # build per architecture rather than a universal binary, so nobody downloads
+    # twice the bytes they need. Windows is not built yet.
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [aarch64-apple-darwin, x86_64-apple-darwin]
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          key: ${{ matrix.target }}
+
+      - run: pnpm install --frozen-lockfile
+
+      - uses: tauri-apps/tauri-action@v0
+        env:
+          LANJUT_TARGET: desktop
+          NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ vars.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
+        with:
+          releaseId: ${{ needs.release-please.outputs.release_id }}
+          args: --target ${{ matrix.target }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ An ATS Builder. Free, Open-Source, local-first resume builder. Customizable pres
 - Next.js (App Router)
 - open-next on Cloudflare (hosting only; the sole server surface is the `/api/feedback` route, which relays bug reports and feature requests and never receives resume content)
 - Static desktop export selected by `LANJUT_TARGET=desktop`; no desktop runtime packages are part of the web application
-- Tauri 2 (desktop shell for Windows and macOS; `src-tauri/`, system webview, loads the static export from disk)
+- Tauri 2 (desktop shell for macOS; `src-tauri/`, system webview, loads the static export from disk)
 - next-intl (internationalization; `[locale]` routing for English and Indonesian, `messages/*.json`, edge middleware on web and explicit locale prefixes on desktop)
 - shadcn (base-ui variant)
 - Tailwind CSS
@@ -69,6 +69,11 @@ The one shipped example of that carve-out is the opt-in header photo: off by def
   `src/components/editor/download-file.ts`. A new export format that builds its own
   anchor will work on the web and do nothing at all in the desktop app. The function
   resolves false when the user cancels the save dialog, which is not an error.
+- macOS is the only desktop target. The shell has never been built or run on Windows,
+  so do not describe it as supported until it has been.
+- A tagged release publishes one `.dmg` per architecture. The build is unsigned, so
+  macOS refuses to open it until the quarantine attribute is cleared. That is a paid
+  Apple membership away from being fixed, not a code change.
 - Biome ignores `src-tauri`. Rust is formatted by `cargo fmt`, and the JSON config files
   are written by the Tauri CLI.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Every template renders the same linear block sequence, so switching templates ne
 |---|---|
 | Framework | Next.js (App Router) |
 | Build targets | open-next on Cloudflare (default), static export (`LANJUT_TARGET=desktop`) |
-| Desktop shell | Tauri 2 (Windows, macOS) |
+| Desktop shell | Tauri 2 (macOS) |
 | Internationalization | next-intl (English, Indonesian) |
 | UI components | shadcn (base-ui) |
 | Styling | Tailwind CSS |

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -42,7 +42,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["nsis", "dmg"],
+    "targets": ["dmg"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
Makes a real macOS app exist. Until now the desktop shell only ever ran from a working directory; nothing published it and nothing verified it.

Groundwork for #162.

## Publishing

A tagged release now attaches the macOS app to the release that release-please creates, one build per architecture rather than a universal binary. A universal binary roughly doubles the download so that nobody picks the wrong file. Two clearly labelled files cost a moment of attention instead, and cost every user half the bytes.

## Building on every pull request

This is the more important half.

Nothing in the existing checks compiles the Rust shell or produces the static export. Lint and typecheck pass happily while the desktop app is broken, so a broken desktop build can reach the default branch with every check green.

That is not hypothetical. It already happened: an earlier change gave each build target its own cache directory, which also moved the static export, and the application kept pointing at the old location. Several merges shipped that way. The reason it went unnoticed is worth stating plainly: the local check looked for the export at the old path, and a stale directory from before the change was still sitting there and satisfied it.

So the new job does not only build. It reads the frontend path out of the application's own configuration and asserts that the export actually exists there. That assertion was tested by putting the old broken value back and confirming it fails, rather than only confirming it passes today.

It runs on a clean checkout, which is the one place a leftover local artifact cannot hide a fault.

## macOS only

The Windows bundle target is removed. The shell has never been built or run on Windows, and leaving the target in place implies a level of support that has never been tested. It can return when someone has actually run it there.

## The build is unsigned

macOS will refuse to open the downloaded app and report it as damaged until the quarantine attribute is cleared by hand. That is a paid Apple Developer membership away from being fixed, not a code change.

Anyone publishing a download link needs to say this next to the link. A user who hits Gatekeeper with no warning concludes the app is broken, not that it is unsigned.

## Testing

Both build targets compile. Typecheck and lint pass.

The export assertion passes against a real export and fails against the old broken path.

The release job itself cannot be proven until a tag is cut. It is the one part of this change that stays unverified until then.
