### PR TITLE
feat: offer the mac app on the landing page

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -44,6 +44,13 @@
     "ctaPrimary": "Create your resume",
     "ctaSecondary": "Browse templates"
   },
+  "desktop": {
+    "kicker": "05 · Desktop",
+    "heading": "Or keep it on your Mac",
+    "description": "The same builder as a native app. Your résumés live on your own machine, and it keeps working with the network off.",
+    "cta": "Download for macOS",
+    "gatekeeper": "Beta, and not yet signed by Apple, so macOS asks you to confirm the first time you open it."
+  },
   "footer": {
     "ariaLabel": "Footer",
     "tagline": "Local-first: your resume never leaves your browser.",
@@ -173,6 +180,16 @@
       "latest": "Latest",
       "fullChangelog": "Full changelog on GitHub",
       "entries": {
+        "0_16_0": [
+          {
+            "title": "Lanjut on your Mac",
+            "description": "There is now a Mac app. It is the same builder you already use, running on your own machine, and it keeps working with the network off. Your resumes stay on that machine. Download it from the link on the home page. It is a beta and it is not signed by Apple yet, so macOS will ask you to confirm the first time you open it."
+          },
+          {
+            "title": "A page for feedback",
+            "description": "Bug reports and feature requests now have their own page, so you can send one from anywhere, including from the Mac app. You still do not need a GitHub account."
+          }
+        ],
         "0_14_0": [
           {
             "title": "Add a photo to your header",

--- a/messages/id.json
+++ b/messages/id.json
@@ -44,6 +44,13 @@
     "ctaPrimary": "Buat resume kamu",
     "ctaSecondary": "Intip template"
   },
+  "desktop": {
+    "kicker": "05 · Desktop",
+    "heading": "Atau simpan di Mac kamu",
+    "description": "Builder yang sama sebagai aplikasi native. Résumé kamu tersimpan di perangkat sendiri, dan tetap jalan waktu internet mati.",
+    "cta": "Unduh untuk macOS",
+    "gatekeeper": "Masih beta dan belum ditandatangani Apple, jadi macOS minta konfirmasi saat pertama kali dibuka."
+  },
   "footer": {
     "ariaLabel": "Footer",
     "tagline": "Local-first: resume kamu nggak pernah keluar dari browser.",
@@ -173,6 +180,16 @@
       "latest": "Terbaru",
       "fullChangelog": "Changelog lengkap di GitHub",
       "entries": {
+        "0_16_0": [
+          {
+            "title": "Lanjut di Mac kamu",
+            "description": "Sekarang ada aplikasi Mac. Isinya builder yang sama, jalan di perangkat kamu sendiri, dan tetap bisa dipakai waktu internet mati. Résumé kamu tetap tersimpan di situ. Unduh lewat tautan di halaman depan. Masih beta dan belum ditandatangani Apple, jadi macOS akan minta konfirmasi saat pertama kali dibuka."
+          },
+          {
+            "title": "Halaman khusus masukan",
+            "description": "Laporan bug dan permintaan fitur sekarang punya halamannya sendiri, jadi bisa dikirim dari mana saja, termasuk dari aplikasi Mac. Kamu tetap tidak perlu akun GitHub."
+          }
+        ],
         "0_14_0": [
           {
             "title": "Pasang foto di header",

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { LandingClosure } from "@/components/landing/landing-closure";
+import { LandingDesktop } from "@/components/landing/landing-desktop";
 import { LandingFooter } from "@/components/landing/landing-footer";
 import { LandingHero } from "@/components/landing/landing-hero";
 import { LandingHowItWorks } from "@/components/landing/landing-how-it-works";
@@ -80,6 +81,7 @@ export default async function Home(props: {
         <LandingTryIt />
         <LandingHowItWorks />
         <LandingValues />
+        <LandingDesktop />
         <LandingClosure />
       </main>
       <LandingFooter />

--- a/src/components/landing/landing-desktop.tsx
+++ b/src/components/landing/landing-desktop.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { ArrowUpRight, Download } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { ExternalLink } from "@/components/shared/external-link";
+import { Button } from "@/components/ui/button";
+import { DESKTOP_RELEASE_URL } from "@/lib/site";
+
+/**
+ * Desktop download. The build is unsigned, so macOS blocks it on first open and
+ * calls it damaged. That warning sits next to the button on purpose: a user who
+ * meets it with no explanation concludes the app is broken.
+ */
+export function LandingDesktop() {
+  const t = useTranslations("desktop");
+
+  return (
+    <section className="mx-auto w-11/12 max-w-5xl pb-24 md:pb-32">
+      <div className="flex flex-col gap-6 rounded-2xl border bg-card p-8 md:flex-row md:items-center md:justify-between md:p-10">
+        <div className="max-w-xl">
+          <p className="font-mono text-xs tracking-[0.18em] text-primary uppercase">
+            {t("kicker")}
+          </p>
+          <h2 className="mt-3 font-display text-2xl font-semibold tracking-tight text-balance sm:text-3xl">
+            {t("heading")}
+          </h2>
+          <p className="mt-3 text-foreground/70 text-sm sm:text-base">
+            {t("description")}
+          </p>
+        </div>
+
+        <div className="flex shrink-0 flex-col items-start gap-2 md:items-end">
+          <Button
+            size="lg"
+            className="gap-2"
+            nativeButton={false}
+            render={<ExternalLink href={DESKTOP_RELEASE_URL} />}
+          >
+            <Download />
+            {t("cta")}
+            <ArrowUpRight />
+          </Button>
+          <p className="max-w-72 text-pretty text-muted-foreground text-xs md:text-right">
+            {t("gatekeeper")}
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -9,6 +9,7 @@ export interface ChangelogEntry {
  * with dots replaced by underscores, as a list of { title, description }.
  */
 export const CHANGELOG: ChangelogEntry[] = [
+  { version: "0.16.0", date: "2026-09-11" },
   { version: "0.14.0", date: "2026-09-06" },
   { version: "0.13.0", date: "2026-09-06" },
   { version: "0.12.0", date: "2026-09-02" },

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -12,3 +12,10 @@ export const DONATION_LINKS = {
   saweria: "https://saweria.co/rimzzlabs",
   sociabuzz: "https://sociabuzz.com/rimzzlabs/tribe",
 } as const;
+
+/**
+ * Where the desktop download points. The latest-release page rather than a
+ * pinned asset, so the link does not rot when a new version publishes.
+ */
+export const DESKTOP_RELEASE_URL =
+  "https://github.com/rimzzlabs/lanjut/releases/latest";


### PR DESCRIPTION
Adds a download section to the landing page and a what's new entry for the release that ships the app.

Completes the user-facing half of #162. The previous change made a macOS app exist and publish; this one tells people about it.

## The section

A `05 · Desktop` block sits between the values and the closing statement, rather than as a third button in the hero. The desktop app is a beta for one platform, and a hero-level call to action would overstate it against the web app, which is the thing most visitors actually want.

The link points at the latest release rather than a pinned file, so it does not rot when a new version publishes.

It goes through the external link helper, which means it also works from inside the desktop app. The landing page is still reachable there, and a raw new-tab link would have done nothing.

## The warning is next to the button on purpose

The build is unsigned, so macOS stops the first open and reports the app as damaged. That line sits beside the download button rather than below the fold or on a help page.

Someone who meets Gatekeeper with no warning concludes the app is broken and files a bug about it. Someone who read one sentence first knows what to expect. The cost of the sentence is far lower than the cost of the misunderstanding.

## What's new

Two entries at 0.16.0: the Mac app, and the feedback page. Both written for someone who does not care how the app is built.

The entry is attached to the version that actually ships the app, not the one before it. The announcement and the download therefore become true at the same moment.

Note that 0.15.0 went out without a what's new entry. This does not backfill one. Everything in that release was groundwork: route helpers, a build split, and a desktop app that nobody could download yet. There was nothing in it for a user to see, and writing an entry would have meant inventing value that was not there. The sheet moves from 0.14.0 to 0.16.0.

## Testing

Both build targets compile. Typecheck and lint pass.

The section was checked in the running app at wide and narrow widths, including that the button carries the correct address and opens outside the page.
