### PR TITLE
fix: give the release job a token to upload the mac app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,13 @@ name: Release
 on:
   push:
     branches: [main]
+  # Lets the desktop app be built and attached to a tag that already exists,
+  # so a failed upload can be repaired without inventing a release.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing tag to attach the macOS app to
+        required: true
 
 permissions:
   contents: write
@@ -11,11 +18,11 @@ permissions:
 
 jobs:
   release-please:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
-      release_id: ${{ steps.release.outputs.id }}
     steps:
       - id: release
         uses: googleapis/release-please-action@v5
@@ -53,18 +60,25 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
   desktop:
-    # Attaches the macOS app to the release release-please just created. One
-    # build per architecture rather than a universal binary, so nobody downloads
-    # twice the bytes they need. Windows is not built yet.
+    # Attaches the macOS app to the release, one build per architecture rather
+    # than a universal binary, so nobody downloads twice the bytes they need.
+    # Windows is not built yet.
     needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
+    if: >-
+      always() &&
+      (needs.release-please.outputs.release_created == 'true' ||
+       github.event_name == 'workflow_dispatch')
     runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
         target: [aarch64-apple-darwin, x86_64-apple-darwin]
+    env:
+      TAG: ${{ inputs.tag || needs.release-please.outputs.tag_name }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag || needs.release-please.outputs.tag_name }}
 
       - uses: pnpm/action-setup@v6
 
@@ -84,10 +98,19 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # Resolved here rather than taken from the release-please output, so the
+      # manual path and the release path reach the action the same way.
+      - id: release
+        run: echo "id=$(gh release view "$TAG" --json databaseId --jq .databaseId)" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: tauri-apps/tauri-action@v0
         env:
+          # The action uploads the bundle to the release, so it needs a token.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LANJUT_TARGET: desktop
           NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ vars.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
         with:
-          releaseId: ${{ needs.release-please.outputs.release_id }}
+          releaseId: ${{ steps.release.outputs.id }}
           args: --target ${{ matrix.target }}


### PR DESCRIPTION
The 0.16.0 release published with no app attached to it.

Both architectures built successfully and then failed at the upload with `GITHUB_TOKEN is required`. The action that bundles and uploads the app needs a token and was not given one.

The release itself and the site deploy both succeeded, so the outcome is worse than a plain failure: the landing page now carries a live download button pointing at a release with nothing in it.

## The fix

Pass the token.

## Repairing a release rather than replacing it

The job can now also be started by hand against a tag that already exists. That matters here, because the alternative for fixing 0.16.0 would be cutting a throwaway version whose only purpose is to carry a file that should already have been attached to the previous one.

The release id is read from the tag inside the job rather than taken from the release step's output, so the automatic path and the manual path reach the upload in exactly the same way. One code path, two triggers.

## Why this was not caught earlier

The upload step cannot run without a real release to upload to. No pull request produces one, and the desktop build job added earlier proves only that the app compiles, which it did here too.

This was called out as the last unverified step before the release was cut. That did not prevent the failure, but it did mean the failure was expected rather than mysterious, and the damage is limited to one release that can now be repaired in place.

## Testing

A workflow change cannot be fully verified until it runs. This one is unproven until the job is triggered against 0.16.0.
