### PR TITLE
fix: lay out the desktop window correctly at startup

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -56,10 +56,11 @@ pub fn run() {
                     let _ = window.set_background_color(Some(paper));
                 }
             }
-            // The main window starts hidden. Showing it on a timer alone put an
-            // empty frame on screen whenever the app took longer than the timer,
-            // so wait for the page itself and keep the timer only as a floor and
-            // a ceiling.
+            // The splash covers the main window rather than replacing it. A
+            // hidden window is not laid out, so anything that measured the
+            // viewport during startup read the wrong size and the layout came
+            // up wrong. The main window is now real from the first frame and
+            // simply sits behind the splash.
             std::thread::spawn(move || {
                 let started = Instant::now();
                 let _ = rx.recv_timeout(Duration::from_millis(SPLASH_MAX_MS));
@@ -70,12 +71,11 @@ pub fn run() {
                     std::thread::sleep(minimum - elapsed);
                 }
 
-                if let Some(main) = handle.get_webview_window("main") {
-                    let _ = main.show();
-                    let _ = main.set_focus();
-                }
                 if let Some(splash) = handle.get_webview_window("splashscreen") {
                     let _ = splash.close();
+                }
+                if let Some(main) = handle.get_webview_window("main") {
+                    let _ = main.set_focus();
                 }
             });
             Ok(())

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -15,13 +15,14 @@
         "label": "splashscreen",
         "url": "/splashscreen.html",
         "title": "Lanjut",
-        "width": 460,
-        "height": 340,
+        "width": 1280,
+        "height": 860,
         "decorations": false,
         "resizable": false,
         "center": true,
         "skipTaskbar": true,
-        "shadow": true
+        "shadow": true,
+        "alwaysOnTop": true
       },
       {
         "label": "main",
@@ -32,8 +33,7 @@
         "minWidth": 960,
         "minHeight": 640,
         "useHttpsScheme": false,
-        "center": true,
-        "visible": false
+        "center": true
       }
     ],
     "security": {

--- a/src/components/tour/tour-autostart-editor.tsx
+++ b/src/components/tour/tour-autostart-editor.tsx
@@ -2,6 +2,7 @@
 
 import { useNextStep } from "nextstepjs";
 import { useEffect } from "react";
+import { useDocumentVisible } from "@/hooks/use-document-visible";
 import { MEDIA_XL } from "@/hooks/use-media-query";
 import { useResumeStore, useTourStore } from "@/lib/store";
 import { EDITOR_SHEET_TOUR, EDITOR_TOUR } from "@/lib/tour";
@@ -12,16 +13,20 @@ const PREVIEW_SETTLE_MS = 700;
 export function TourAutostartEditor() {
   const openStatus = useResumeStore((state) => state.openStatus);
   const { startNextStep } = useNextStep();
+  const visible = useDocumentVisible();
 
   useEffect(() => {
-    if (openStatus !== "ready") return;
+    // The tour drives the sidebar, and which sidebar it drives depends on the
+    // window width. Starting it before the window is on screen picks the wrong
+    // one and leaves the two out of step.
+    if (!visible || openStatus !== "ready") return;
     const tour = window.matchMedia(MEDIA_XL).matches
       ? EDITOR_TOUR
       : EDITOR_SHEET_TOUR;
     if (useTourStore.getState().hasSeen(tour)) return;
     const timer = setTimeout(() => startNextStep(tour), PREVIEW_SETTLE_MS);
     return () => clearTimeout(timer);
-  }, [openStatus, startNextStep]);
+  }, [visible, openStatus, startNextStep]);
 
   return null;
 }

--- a/src/hooks/use-document-visible.ts
+++ b/src/hooks/use-document-visible.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Whether the document is actually on screen.
+ *
+ * The desktop app keeps its window hidden behind the splash until the page has
+ * loaded, and a hidden webview does not report a usable viewport. Anything that
+ * measures the window at startup, such as choosing between the wide and narrow
+ * layouts, reads the wrong value while that is true.
+ */
+export function useDocumentVisible() {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const read = () => setVisible(document.visibilityState === "visible");
+    read();
+    document.addEventListener("visibilitychange", read);
+    return () => document.removeEventListener("visibilitychange", read);
+  }, []);
+
+  return visible;
+}

--- a/src/hooks/use-media-query.ts
+++ b/src/hooks/use-media-query.ts
@@ -7,10 +7,16 @@ export function useMediaQuery(query: string) {
 
   useEffect(() => {
     const mql = window.matchMedia(query);
-    const onChange = () => setMatches(mql.matches);
-    mql.addEventListener("change", onChange);
-    setMatches(mql.matches);
-    return () => mql.removeEventListener("change", onChange);
+    const read = () => setMatches(mql.matches);
+    mql.addEventListener("change", read);
+    // See use-mobile: a hidden window measures wrong and revealing it does not
+    // always fire a change event.
+    document.addEventListener("visibilitychange", read);
+    read();
+    return () => {
+      mql.removeEventListener("change", read);
+      document.removeEventListener("visibilitychange", read);
+    };
   }, [query]);
 
   return matches;

--- a/src/hooks/use-mobile.ts
+++ b/src/hooks/use-mobile.ts
@@ -9,12 +9,17 @@ export function useIsMobile() {
 
   React.useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    const read = () => setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    mql.addEventListener("change", read);
+    // A window that is still hidden reports no usable width, and revealing it
+    // does not always fire a media query change. Re-read when the document
+    // comes on screen, or the first measurement stands for the whole session.
+    document.addEventListener("visibilitychange", read);
+    read();
+    return () => {
+      mql.removeEventListener("change", read);
+      document.removeEventListener("visibilitychange", read);
     };
-    mql.addEventListener("change", onChange);
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-    return () => mql.removeEventListener("change", onChange);
   }, []);
 
   return !!isMobile;


### PR DESCRIPTION
The sidebar came up wrong in the packaged app: it rendered over the page instead of beside it, the collapse button did nothing, and switching language put everything right.

That last detail is what identified the cause. Switching language re-renders the tree, so the wrong state was established once at startup and never corrected.

## What was happening

The main window was created hidden and shown after the page finished loading, so the splash had something to hide. A hidden window is not laid out, and anything that measures the viewport while it is hidden reads the wrong size.

The guided tour starts shortly after a résumé opens, which is inside that window. It chooses between the wide sidebar and the narrow sheet from a width measurement, measured mobile, and opened the sheet. The window then appeared at full width, the wide sidebar rendered, and the sheet was what remained on screen.

From there every symptom follows. The sidebar overlapped the page because a sheet reserves no space. The collapse button did nothing visible because it drives the wide sidebar, which was not the thing being displayed. Closing the tour did not help, because the tour only opened the sheet and never owned it.

## The fix

The splash now covers the main window rather than replacing it. It is the same size, centred, and stays on top. The main window is real and correctly sized from the first frame and simply sits behind it, so every startup measurement is taken against the size the user will actually have. Nothing about what the user sees changes.

This removes the cause rather than compensating for it. Any width-dependent code added later is safe by default, instead of being one more thing that has to remember the window might not be real yet.

## Two guards

Both viewport hooks re-read when the document comes on screen, rather than trusting a single reading taken at mount.

The tour waits for the document to be on screen before starting. It drives the sidebar, and it has no business doing that while off screen.

Either guard alone would probably have masked this bug. They are here because the class of fault is easy to reintroduce, not because the main fix needs them.

## Testing

Both build targets compile. Typecheck and lint pass.

The fault cannot be reproduced outside the packaged app, since it depends on a window being hidden while the page starts. Confirming this needs a run of the built application.
