### PR TITLE
fix: restore the desktop layout and the updater artifacts

### DIFF
--- a/.github/scripts/check-tauri-config.mjs
+++ b/.github/scripts/check-tauri-config.mjs
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+
+const config = JSON.parse(readFileSync("src-tauri/tauri.conf.json", "utf8"));
+const failures = [];
+
+// macOS ships the updater payload as a tarball of the .app bundle. A dmg-only
+// target builds no such artifact, so the release carries no latest.json and
+// every update check reads a 404. Tauri only warns.
+if (
+  config.bundle?.createUpdaterArtifacts &&
+  !config.bundle?.targets?.includes("app")
+) {
+  failures.push(
+    'bundle.targets must include "app" while createUpdaterArtifacts is true, ' +
+      "or the release ships no latest.json and the updater goes quiet.",
+  );
+}
+
+// Tauri appends a hash source to every CSP directive it manages. A style-src
+// that carries a hash makes the browser ignore 'unsafe-inline', and the app
+// drops every style attribute in the exported HTML.
+const csp = config.app?.security?.csp ?? "";
+const styleSrc = csp
+  .split(";")
+  .find((part) => part.trim().startsWith("style-src"));
+const disabled = config.app?.security?.dangerousDisableAssetCspModification;
+const styleSrcExempt =
+  disabled === true ||
+  (Array.isArray(disabled) && disabled.includes("style-src"));
+if (styleSrc?.includes("'unsafe-inline'") && !styleSrcExempt) {
+  failures.push(
+    'security.dangerousDisableAssetCspModification must list "style-src" while ' +
+      "the CSP relies on 'unsafe-inline' for styles. The injected hash voids it, " +
+      "and the layout then loads without its CSS variables.",
+  );
+}
+
+if (failures.length > 0) {
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exit(1);
+}
+console.log("✓ src-tauri/tauri.conf.json holds its load-bearing values");

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,5 +85,10 @@ jobs:
           test -f "${resolved}/splashscreen.html" \
             || { echo "frontendDist ${dist} has no splash screen"; exit 1; }
 
+      # Both of these shipped broken once. Neither fails the build, and neither
+      # is visible until a user installs the app.
+      - name: Confirm the shell config still holds its load-bearing values
+        run: node .github/scripts/check-tauri-config.mjs
+
       - name: Build the desktop shell
         run: cargo build --manifest-path src-tauri/Cargo.toml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,13 @@ The one shipped example of that carve-out is the opt-in header photo: off by def
   either orphans the résumés of everyone who already installed the app.
 - The window opens on `/en/platform/`. Tauri resolves a directory path by falling back
   to `<path>/index.html`, which is why the desktop build sets `trailingSlash`.
+- `dangerousDisableAssetCspModification` lists `style-src` and must keep listing it.
+  Tauri appends a hash source to every directive it manages. A `style-src` that
+  carries a hash makes the browser ignore `'unsafe-inline'`. The app then drops every
+  `style` attribute in the exported HTML, and that includes the `--sidebar-width` that
+  carries the whole platform layout. Next.js cannot nonce those attributes in a static
+  export, so the two cannot both hold. `script-src` keeps its injection, which is the
+  directive that stops script execution.
 - Every file the app hands to a user goes through `triggerDownload` in
   `src/components/editor/download-file.ts`. A new export format that builds its own
   anchor will work on the web and do nothing at all in the desktop app. The function
@@ -78,6 +85,11 @@ The one shipped example of that carve-out is the opt-in header photo: off by def
   private key lives only in the `TAURI_SIGNING_PRIVATE_KEY` repository secret. Tauri
   does not check the public key at build time, so a wrong one fails silently at
   runtime and every update check quietly does nothing.
+- `bundle.targets` must keep `app` beside `dmg`. On macOS the updater ships the `.app`
+  bundle as a signed tarball, and a `dmg` alone builds no such artifact. The release
+  then carries no `latest.json`, every update check reads a 404, and the failure is
+  silent by design. The 0.17.0 release shipped this way. Read the `tauri-action` log
+  for "no updater-enabled targets were built" to catch it.
 - An update check is a network call the user did not ask for. It runs at most once
   every three days, a failure is silent, and nothing installs without a click.
 - Biome ignores `src-tauri`. Rust is formatted by `cargo fmt`, and the JSON config files

--- a/messages/en.json
+++ b/messages/en.json
@@ -187,6 +187,16 @@
       "latest": "Latest",
       "fullChangelog": "Full changelog on GitHub",
       "entries": {
+        "0_17_1": [
+          {
+            "title": "The Mac app can update itself",
+            "description": "When a new version is out, the Mac app now offers it to you. It looks at most once every few days, and nothing installs until you click."
+          },
+          {
+            "title": "Bug fixes",
+            "description": "In the Mac app the sidebar covered the page when the app opened, and the button that hides it did nothing. Both are fixed."
+          }
+        ],
         "0_16_0": [
           {
             "title": "Lanjut on your Mac",

--- a/messages/id.json
+++ b/messages/id.json
@@ -187,6 +187,16 @@
       "latest": "Terbaru",
       "fullChangelog": "Changelog lengkap di GitHub",
       "entries": {
+        "0_17_1": [
+          {
+            "title": "Aplikasi Mac bisa memperbarui dirinya",
+            "description": "Kalau ada versi baru, aplikasi Mac sekarang menawarkannya ke kamu. Pengecekan paling sering beberapa hari sekali, dan tidak ada yang dipasang sebelum kamu klik."
+          },
+          {
+            "title": "Perbaikan bug",
+            "description": "Di aplikasi Mac, sidebar menutupi halaman saat aplikasi dibuka, dan tombol untuk menyembunyikannya tidak berfungsi. Keduanya sudah diperbaiki."
+          }
+        ],
         "0_16_0": [
           {
             "title": "Lanjut di Mac kamu",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -37,12 +37,13 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self'"
+      "csp": "default-src 'self'; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self'",
+      "dangerousDisableAssetCspModification": ["style-src"]
     }
   },
   "bundle": {
     "active": true,
-    "targets": ["dmg"],
+    "targets": ["app", "dmg"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -9,6 +9,7 @@ export interface ChangelogEntry {
  * with dots replaced by underscores, as a list of { title, description }.
  */
 export const CHANGELOG: ChangelogEntry[] = [
+  { version: "0.17.1", date: "2026-09-12" },
   { version: "0.16.0", date: "2026-09-11" },
   { version: "0.14.0", date: "2026-09-06" },
   { version: "0.13.0", date: "2026-09-06" },


### PR DESCRIPTION
Two faults in the desktop shell, both found while retesting 0.17.0 on a clean install. Both are one line of `tauri.conf.json`.

## The layout

Tauri appends a hash source to every CSP directive it manages. Per the CSP spec a source list that carries a hash makes the browser ignore `'unsafe-inline'`, so `style-src 'self' 'unsafe-inline'` became hash-only and the webview dropped every `style` attribute in the static export. One of those attributes carries `--sidebar-width`:

```html
<div data-slot="sidebar-wrapper" style="--sidebar-width:16rem;--sidebar-width-icon:3rem">
```

With that variable unset, `w-(--sidebar-width)` is invalid. The empty gap div collapsed to zero width while the fixed sidebar fell back to its content width, so the sidebar sat on top of the page. The toggle looked dead for the same reason, because it moves the sidebar with `-left-(--sidebar-width)`.

Switching the language appeared to fix it. React re-created the element through CSSOM, which CSP does not govern, so any re-mount hid the fault and it only ever showed on a cold start.

Next.js cannot nonce inline style attributes in a static export, so the injected hash and the app cannot both hold. `script-src` keeps its injection, which is the directive that stops script execution.

## The updater

On macOS the updater ships the `.app` bundle as a signed tarball. The `dmg`-only target built no such artifact, so `tauri-action` logged a warning and skipped the manifest:

```
Warn  The bundler was configured to create updater artifacts but no
      updater-enabled targets were built. Please enable one of these
      targets: app, appimage, msi, nsis
      Signature not found for the updater JSON. Skipping upload...
```

Neither line fails the job. The 0.17.0 release carries two `.dmg` files and nothing else, so every update check reads a 404 on the missing `latest.json` and fails silently by design. Adding the `app` target restores it.

**Anyone already on 0.17.0 must download the next release by hand.** No in-app update can reach them.

## Guard

Both faults shipped green, so the `desktop` job now checks the two values before it builds the shell. The script fails on the exact config 0.17.0 shipped and passes on this branch.

## Testing

Verified on a release bundle built from this branch, not the debug binary:

- The sidebar opens in its own column, and the toggle collapses it and reflows the content.
- The splash screen renders and hands over to the main window after about two seconds.
- The build ends with `Bundling .../Lanjut.app.tar.gz (updater)`, which is the artifact 0.17.0 never produced. The local build stops at the missing private key, which is correct, because that key lives only in the repository secret.
- The guard was run against the 0.17.0 values and fails on both.
